### PR TITLE
feat(proxy): add OpenClaw hooks client, WS handler, session routing

### DIFF
--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -1,31 +1,17 @@
 import Fastify from 'fastify';
 import websocket from '@fastify/websocket';
 
-import { DEFAULT_WS_PATH } from '@webagent/shared/constants';
-
 import { loadConfig } from './config.js';
-import { registerHealthRoutes } from './routes/health.js';
+import { handleConnection } from './ws/handler.js';
 import { registerWidgetRoutes } from './routes/widget.js';
-import { handleConnection, registerAgentToken } from './ws/handler.js';
+import { registerHealthRoutes } from './routes/health.js';
+import { DEFAULT_WS_PATH } from '@webagent/shared/constants';
 
 const config = loadConfig();
 const app = Fastify({ logger: true });
 
-const tokenAgentMapValue = process.env.AGENT_TOKEN_MAP?.trim();
-if (tokenAgentMapValue) {
-  for (const entry of tokenAgentMapValue.split(',').map((part) => part.trim())) {
-    if (!entry) {
-      continue;
-    }
-
-    const [token, agentId] = entry.split(':').map((part) => part.trim());
-    if (token && agentId) {
-      registerAgentToken(token, agentId);
-    }
-  }
-}
-
 await app.register(websocket);
+
 registerHealthRoutes(app);
 registerWidgetRoutes(app);
 
@@ -37,10 +23,7 @@ const start = async (): Promise<void> => {
   try {
     await app.listen({ host: '0.0.0.0', port: config.port });
     app.log.info(
-      {
-        port: config.port,
-        openClawHooksUrl: config.openClawHooksUrl
-      },
+      { port: config.port, openClawHooksUrl: config.openClawHooksUrl },
       'proxy server started'
     );
   } catch (error) {

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -1,97 +1,36 @@
 import Fastify from 'fastify';
 import websocket from '@fastify/websocket';
-import { randomUUID } from 'node:crypto';
 
 import { DEFAULT_WS_PATH } from '@webagent/shared/constants';
-import type { ClientMessage, ServerMessage } from '@webagent/shared/protocol';
-import type { HealthResponse } from '@webagent/shared/types';
 
 import { loadConfig } from './config.js';
+import { registerHealthRoutes } from './routes/health.js';
+import { registerWidgetRoutes } from './routes/widget.js';
+import { handleConnection, registerAgentToken } from './ws/handler.js';
 
 const config = loadConfig();
 const app = Fastify({ logger: true });
 
+const tokenAgentMapValue = process.env.AGENT_TOKEN_MAP?.trim();
+if (tokenAgentMapValue) {
+  for (const entry of tokenAgentMapValue.split(',').map((part) => part.trim())) {
+    if (!entry) {
+      continue;
+    }
+
+    const [token, agentId] = entry.split(':').map((part) => part.trim());
+    if (token && agentId) {
+      registerAgentToken(token, agentId);
+    }
+  }
+}
+
 await app.register(websocket);
-
-app.get('/health', async () => {
-  const payload: HealthResponse = {
-    status: 'ok',
-    uptime: process.uptime(),
-    timestamp: new Date().toISOString()
-  };
-
-  return payload;
-});
+registerHealthRoutes(app);
+registerWidgetRoutes(app);
 
 app.get(DEFAULT_WS_PATH, { websocket: true }, (connection) => {
-  connection.socket.on('message', (raw: unknown) => {
-    const serialized =
-      typeof raw === 'string'
-        ? raw
-        : Buffer.isBuffer(raw)
-          ? raw.toString('utf8')
-          : String(raw);
-
-    let incoming: ClientMessage;
-
-    try {
-      incoming = JSON.parse(serialized) as ClientMessage;
-    } catch {
-      const invalidJson: ServerMessage = { type: 'error', message: 'Invalid JSON payload' };
-      connection.socket.send(JSON.stringify(invalidJson));
-      return;
-    }
-
-    switch (incoming.type) {
-      case 'auth': {
-        if (!incoming.agentToken || !incoming.userId) {
-          const authError: ServerMessage = {
-            type: 'auth_error',
-            reason: 'Missing agentToken or userId'
-          };
-          connection.socket.send(JSON.stringify(authError));
-          return;
-        }
-
-        const authOk: ServerMessage = { type: 'auth_ok', sessionId: randomUUID() };
-        connection.socket.send(JSON.stringify(authOk));
-        return;
-      }
-
-      case 'message': {
-        if (!incoming.content || typeof incoming.content !== 'string') {
-          const invalidMessage: ServerMessage = {
-            type: 'error',
-            message: 'Missing message content'
-          };
-          connection.socket.send(JSON.stringify(invalidMessage));
-          return;
-        }
-
-        const message: ServerMessage = {
-          type: 'message',
-          content: incoming.content,
-          done: true
-        };
-        connection.socket.send(JSON.stringify(message));
-        return;
-      }
-
-      case 'ping': {
-        const pong: ServerMessage = { type: 'pong' };
-        connection.socket.send(JSON.stringify(pong));
-        return;
-      }
-
-      default: {
-        const unsupported: ServerMessage = {
-          type: 'error',
-          message: 'Unsupported message type'
-        };
-        connection.socket.send(JSON.stringify(unsupported));
-      }
-    }
-  });
+  handleConnection(connection.socket);
 });
 
 const start = async (): Promise<void> => {

--- a/packages/proxy/src/openclaw/client.ts
+++ b/packages/proxy/src/openclaw/client.ts
@@ -1,140 +1,77 @@
 import { loadConfig } from '../config.js';
 
-export interface AgentResponse {
-  content: string;
-  done: boolean;
-}
-
-interface RequestOptions {
-  expectJson?: boolean;
-}
-
-/**
- * Join a base URL with an endpoint path, deduplicating any overlapping
- * path suffix/prefix so that both of these produce the same result:
- *   base "http://host:port/hooks" + endpoint "/hooks/agent" → "http://host:port/hooks/agent"
- *   base "http://host:port"       + endpoint "/hooks/agent" → "http://host:port/hooks/agent"
- */
-function joinUrl(base: string, endpoint: string): string {
-  const cleanBase = base.replace(/\/+$/, '');
-  const cleanEndpoint = endpoint.replace(/^\/+/, '');
-
-  const baseParts = cleanBase.split('/');
-  const endpointParts = cleanEndpoint.split('/');
-
-  // Find the longest overlapping suffix of baseParts that matches a prefix of endpointParts.
-  let overlap = 0;
-  for (let len = 1; len <= Math.min(baseParts.length, endpointParts.length); len++) {
-    const baseSuffix = baseParts.slice(-len).join('/');
-    const endpointPrefix = endpointParts.slice(0, len).join('/');
-    if (baseSuffix === endpointPrefix) {
-      overlap = len;
-    }
-  }
-
-  return `${cleanBase}/${endpointParts.slice(overlap).join('/')}`.replace(/\/+$/, '');
+interface AgentResponse {
+  success: boolean;
+  response?: string;
+  error?: string;
 }
 
 export class OpenClawClient {
-  private readonly baseUrl: string;
-  private readonly token: string;
+  private baseUrl: string;
+  private token: string;
 
-  constructor(config = loadConfig()) {
-    this.baseUrl = config.openClawHooksUrl.replace(/\/$/, '');
-    this.token = config.openClawHooksToken;
+  constructor(baseUrl?: string, token?: string) {
+    const config = loadConfig();
+    this.baseUrl = baseUrl || config.openClawHooksUrl;
+    this.token = token || config.openClawHooksToken;
   }
 
-  async sendMessage(agentId: string, sessionKey: string, content: string): Promise<AgentResponse> {
-    const payload = await this.request<unknown>(
-      '/hooks/agent',
-      {
-        method: 'POST',
-        body: JSON.stringify({ agentId, sessionKey, content })
+  // Send message to an agent via hooks API
+  async sendMessage(opts: {
+    message: string;
+    agentId: string;
+    sessionKey?: string;
+    name?: string;
+  }): Promise<AgentResponse> {
+    const res = await fetch(`${this.baseUrl}/hooks/agent`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${this.token}`,
+        'Content-Type': 'application/json',
       },
-      { expectJson: true }
-    );
+      body: JSON.stringify({
+        message: opts.message,
+        agentId: opts.agentId,
+        name: opts.name || 'widget-chat',
+        wakeMode: 'now',
+      }),
+    });
 
-    return this.normalizeAgentResponse(payload);
+    if (!res.ok) {
+      return { success: false, error: `OpenClaw API error: ${res.status} ${res.statusText}` };
+    }
+
+    const data = await res.json() as Record<string, unknown>;
+    return { success: true, response: data.response as string || data.text as string || JSON.stringify(data) };
   }
 
-  async wake(agentId: string): Promise<void> {
-    await this.request(
-      '/hooks/wake',
-      {
-        method: 'POST',
-        body: JSON.stringify({ agentId })
+  // Wake the main session (for system events)
+  async wake(text: string, mode: 'now' | 'next-heartbeat' = 'now'): Promise<boolean> {
+    const res = await fetch(`${this.baseUrl}/hooks/wake`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${this.token}`,
+        'Content-Type': 'application/json',
       },
-      { expectJson: false }
-    );
+      body: JSON.stringify({ text, mode }),
+    });
+    return res.ok;
   }
 
+  // Health check
   async ping(): Promise<boolean> {
     try {
-      await this.request('/hooks/wake', { method: 'POST', body: JSON.stringify({}) }, { expectJson: false });
-      return true;
+      const res = await fetch(`${this.baseUrl}/hooks/wake`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${this.token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ text: 'health-check', mode: 'next-heartbeat' }),
+      });
+      return res.ok;
     } catch {
       return false;
     }
-  }
-
-  private async request<T>(
-    endpoint: string,
-    init: RequestInit,
-    options: RequestOptions = {}
-  ): Promise<T | undefined> {
-    const url = joinUrl(this.baseUrl, endpoint);
-
-    let response: Response;
-
-    try {
-      response = await fetch(url, {
-        ...init,
-        headers: {
-          authorization: `Bearer ${this.token}`,
-          'content-type': 'application/json',
-          accept: 'application/json',
-          ...(init.headers ?? {})
-        }
-      });
-    } catch (error) {
-      const reason = error instanceof Error ? error.message : 'Unknown network failure';
-      throw new Error(`OpenClaw request failed (${endpoint}): ${reason}`);
-    }
-
-    if (!response.ok) {
-      const body = await response.text().catch(() => '');
-      const detail = body ? ` - ${body.slice(0, 500)}` : '';
-      throw new Error(`OpenClaw request failed (${endpoint}): HTTP ${response.status}${detail}`);
-    }
-
-    if (!options.expectJson) {
-      return undefined;
-    }
-
-    try {
-      return (await response.json()) as T;
-    } catch {
-      throw new Error(`OpenClaw request failed (${endpoint}): invalid JSON response`);
-    }
-  }
-
-  private normalizeAgentResponse(payload: unknown): AgentResponse {
-    if (!payload || typeof payload !== 'object') {
-      return { content: '', done: true };
-    }
-
-    const maybe = payload as { content?: unknown; done?: unknown; message?: unknown; output?: unknown };
-    const content =
-      typeof maybe.content === 'string'
-        ? maybe.content
-        : typeof maybe.message === 'string'
-          ? maybe.message
-          : typeof maybe.output === 'string'
-            ? maybe.output
-            : '';
-
-    const done = typeof maybe.done === 'boolean' ? maybe.done : true;
-
-    return { content, done };
   }
 }

--- a/packages/proxy/src/openclaw/client.ts
+++ b/packages/proxy/src/openclaw/client.ts
@@ -1,0 +1,140 @@
+import { loadConfig } from '../config.js';
+
+export interface AgentResponse {
+  content: string;
+  done: boolean;
+}
+
+interface RequestOptions {
+  expectJson?: boolean;
+}
+
+/**
+ * Join a base URL with an endpoint path, deduplicating any overlapping
+ * path suffix/prefix so that both of these produce the same result:
+ *   base "http://host:port/hooks" + endpoint "/hooks/agent" → "http://host:port/hooks/agent"
+ *   base "http://host:port"       + endpoint "/hooks/agent" → "http://host:port/hooks/agent"
+ */
+function joinUrl(base: string, endpoint: string): string {
+  const cleanBase = base.replace(/\/+$/, '');
+  const cleanEndpoint = endpoint.replace(/^\/+/, '');
+
+  const baseParts = cleanBase.split('/');
+  const endpointParts = cleanEndpoint.split('/');
+
+  // Find the longest overlapping suffix of baseParts that matches a prefix of endpointParts.
+  let overlap = 0;
+  for (let len = 1; len <= Math.min(baseParts.length, endpointParts.length); len++) {
+    const baseSuffix = baseParts.slice(-len).join('/');
+    const endpointPrefix = endpointParts.slice(0, len).join('/');
+    if (baseSuffix === endpointPrefix) {
+      overlap = len;
+    }
+  }
+
+  return `${cleanBase}/${endpointParts.slice(overlap).join('/')}`.replace(/\/+$/, '');
+}
+
+export class OpenClawClient {
+  private readonly baseUrl: string;
+  private readonly token: string;
+
+  constructor(config = loadConfig()) {
+    this.baseUrl = config.openClawHooksUrl.replace(/\/$/, '');
+    this.token = config.openClawHooksToken;
+  }
+
+  async sendMessage(agentId: string, sessionKey: string, content: string): Promise<AgentResponse> {
+    const payload = await this.request<unknown>(
+      '/hooks/agent',
+      {
+        method: 'POST',
+        body: JSON.stringify({ agentId, sessionKey, content })
+      },
+      { expectJson: true }
+    );
+
+    return this.normalizeAgentResponse(payload);
+  }
+
+  async wake(agentId: string): Promise<void> {
+    await this.request(
+      '/hooks/wake',
+      {
+        method: 'POST',
+        body: JSON.stringify({ agentId })
+      },
+      { expectJson: false }
+    );
+  }
+
+  async ping(): Promise<boolean> {
+    try {
+      await this.request('/hooks/wake', { method: 'POST', body: JSON.stringify({}) }, { expectJson: false });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async request<T>(
+    endpoint: string,
+    init: RequestInit,
+    options: RequestOptions = {}
+  ): Promise<T | undefined> {
+    const url = joinUrl(this.baseUrl, endpoint);
+
+    let response: Response;
+
+    try {
+      response = await fetch(url, {
+        ...init,
+        headers: {
+          authorization: `Bearer ${this.token}`,
+          'content-type': 'application/json',
+          accept: 'application/json',
+          ...(init.headers ?? {})
+        }
+      });
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : 'Unknown network failure';
+      throw new Error(`OpenClaw request failed (${endpoint}): ${reason}`);
+    }
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      const detail = body ? ` - ${body.slice(0, 500)}` : '';
+      throw new Error(`OpenClaw request failed (${endpoint}): HTTP ${response.status}${detail}`);
+    }
+
+    if (!options.expectJson) {
+      return undefined;
+    }
+
+    try {
+      return (await response.json()) as T;
+    } catch {
+      throw new Error(`OpenClaw request failed (${endpoint}): invalid JSON response`);
+    }
+  }
+
+  private normalizeAgentResponse(payload: unknown): AgentResponse {
+    if (!payload || typeof payload !== 'object') {
+      return { content: '', done: true };
+    }
+
+    const maybe = payload as { content?: unknown; done?: unknown; message?: unknown; output?: unknown };
+    const content =
+      typeof maybe.content === 'string'
+        ? maybe.content
+        : typeof maybe.message === 'string'
+          ? maybe.message
+          : typeof maybe.output === 'string'
+            ? maybe.output
+            : '';
+
+    const done = typeof maybe.done === 'boolean' ? maybe.done : true;
+
+    return { content, done };
+  }
+}

--- a/packages/proxy/src/openclaw/sessions.ts
+++ b/packages/proxy/src/openclaw/sessions.ts
@@ -1,0 +1,26 @@
+const sessions = new Map<string, string>();
+
+export function sessionKey(agentId: string, userId: string): string {
+  return `widget:${agentId}:${userId}`;
+}
+
+export function getOrCreateSession(agentId: string, userId: string): string {
+  const key = sessionKey(agentId, userId);
+  const existing = sessions.get(key);
+
+  if (existing) {
+    return existing;
+  }
+
+  const created = key;
+  sessions.set(key, created);
+  return created;
+}
+
+export function getSession(agentId: string, userId: string): string | undefined {
+  return sessions.get(sessionKey(agentId, userId));
+}
+
+export function removeSession(agentId: string, userId: string): boolean {
+  return sessions.delete(sessionKey(agentId, userId));
+}

--- a/packages/proxy/src/openclaw/sessions.ts
+++ b/packages/proxy/src/openclaw/sessions.ts
@@ -1,26 +1,24 @@
-const sessions = new Map<string, string>();
+// In-memory session map (will later use DB)
+const sessionMap = new Map<string, string>();
 
-export function sessionKey(agentId: string, userId: string): string {
+function sessionKey(agentId: string, userId: string): string {
   return `widget:${agentId}:${userId}`;
 }
 
 export function getOrCreateSession(agentId: string, userId: string): string {
-  const key = sessionKey(agentId, userId);
-  const existing = sessions.get(key);
-
-  if (existing) {
-    return existing;
+  const key = `${agentId}::${userId}`;
+  let session = sessionMap.get(key);
+  if (!session) {
+    session = sessionKey(agentId, userId);
+    sessionMap.set(key, session);
   }
-
-  const created = key;
-  sessions.set(key, created);
-  return created;
+  return session;
 }
 
 export function getSession(agentId: string, userId: string): string | undefined {
-  return sessions.get(sessionKey(agentId, userId));
+  return sessionMap.get(`${agentId}::${userId}`);
 }
 
 export function removeSession(agentId: string, userId: string): boolean {
-  return sessions.delete(sessionKey(agentId, userId));
+  return sessionMap.delete(`${agentId}::${userId}`);
 }

--- a/packages/proxy/src/routes/health.ts
+++ b/packages/proxy/src/routes/health.ts
@@ -1,37 +1,21 @@
 import type { FastifyInstance } from 'fastify';
-
 import type { HealthResponse } from '@webagent/shared/types';
-
 import { OpenClawClient } from '../openclaw/client.js';
 
-interface OpenClawHealthResponse extends HealthResponse {
-  openclaw: 'ok' | 'unreachable';
-}
+export function registerHealthRoutes(app: FastifyInstance) {
+  const openclaw = new OpenClawClient();
 
-function healthPayload(): HealthResponse {
-  return {
-    status: 'ok',
-    uptime: process.uptime(),
-    timestamp: new Date().toISOString()
-  };
-}
-
-export function registerHealthRoutes(app: FastifyInstance, openClaw = new OpenClawClient()): void {
   app.get('/health', async () => {
-    return healthPayload();
+    const payload: HealthResponse = {
+      status: 'ok',
+      uptime: process.uptime(),
+      timestamp: new Date().toISOString(),
+    };
+    return payload;
   });
 
-  app.get('/health/openclaw', async (_request, reply) => {
-    const ok = await openClaw.ping();
-    const payload: OpenClawHealthResponse = {
-      ...healthPayload(),
-      openclaw: ok ? 'ok' : 'unreachable'
-    };
-
-    if (!ok) {
-      return reply.code(503).send(payload);
-    }
-
-    return payload;
+  app.get('/health/openclaw', async () => {
+    const ok = await openclaw.ping();
+    return { status: ok ? 'ok' : 'unreachable', timestamp: new Date().toISOString() };
   });
 }

--- a/packages/proxy/src/routes/health.ts
+++ b/packages/proxy/src/routes/health.ts
@@ -1,0 +1,37 @@
+import type { FastifyInstance } from 'fastify';
+
+import type { HealthResponse } from '@webagent/shared/types';
+
+import { OpenClawClient } from '../openclaw/client.js';
+
+interface OpenClawHealthResponse extends HealthResponse {
+  openclaw: 'ok' | 'unreachable';
+}
+
+function healthPayload(): HealthResponse {
+  return {
+    status: 'ok',
+    uptime: process.uptime(),
+    timestamp: new Date().toISOString()
+  };
+}
+
+export function registerHealthRoutes(app: FastifyInstance, openClaw = new OpenClawClient()): void {
+  app.get('/health', async () => {
+    return healthPayload();
+  });
+
+  app.get('/health/openclaw', async (_request, reply) => {
+    const ok = await openClaw.ping();
+    const payload: OpenClawHealthResponse = {
+      ...healthPayload(),
+      openclaw: ok ? 'ok' : 'unreachable'
+    };
+
+    if (!ok) {
+      return reply.code(503).send(payload);
+    }
+
+    return payload;
+  });
+}

--- a/packages/proxy/src/routes/widget.ts
+++ b/packages/proxy/src/routes/widget.ts
@@ -1,46 +1,31 @@
-import { readFile } from 'node:fs/promises';
-
 import type { FastifyInstance } from 'fastify';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
 
-const FALLBACK_WIDGET_BUNDLE = `console.warn('[WebAgent] widget bundle unavailable. Build @webagent/widget to enable embed script.');`;
+let widgetJs: string | null = null;
 
-let cachedWidgetBundle: string | null = null;
-let attemptedLoad = false;
-
-async function loadWidgetBundle(): Promise<string> {
-  if (cachedWidgetBundle) {
-    return cachedWidgetBundle;
-  }
-
-  if (attemptedLoad) {
-    return FALLBACK_WIDGET_BUNDLE;
-  }
-
-  attemptedLoad = true;
-
-  const candidates = [
-    new URL('../../../widget/dist/widget.js', import.meta.url),
-    new URL('../../../../widget/dist/widget.js', import.meta.url)
+function loadWidgetJs(): string {
+  if (widgetJs) return widgetJs;
+  
+  // Try built widget first, then fallback
+  const paths = [
+    resolve(import.meta.dirname, '../../../widget/dist/widget.js'),
+    resolve(import.meta.dirname, '../../node_modules/@webagent/widget/dist/widget.js'),
   ];
-
-  for (const candidate of candidates) {
-    try {
-      cachedWidgetBundle = await readFile(candidate, 'utf8');
-      return cachedWidgetBundle;
-    } catch {
-      // Try next candidate path.
+  
+  for (const p of paths) {
+    if (existsSync(p)) {
+      widgetJs = readFileSync(p, 'utf8');
+      return widgetJs;
     }
   }
-
-  return FALLBACK_WIDGET_BUNDLE;
+  
+  return '// WebAgent widget not built yet. Run: pnpm --filter @webagent/widget build';
 }
 
-export function registerWidgetRoutes(app: FastifyInstance): void {
-  app.get('/widget.js', async (_request, reply) => {
-    const bundle = await loadWidgetBundle();
-    return reply
-      .type('application/javascript; charset=utf-8')
-      .header('cache-control', 'public, max-age=300')
-      .send(bundle);
+export function registerWidgetRoutes(app: FastifyInstance) {
+  app.get('/widget.js', async (_req, reply) => {
+    const js = loadWidgetJs();
+    reply.type('application/javascript').send(js);
   });
 }

--- a/packages/proxy/src/routes/widget.ts
+++ b/packages/proxy/src/routes/widget.ts
@@ -1,0 +1,46 @@
+import { readFile } from 'node:fs/promises';
+
+import type { FastifyInstance } from 'fastify';
+
+const FALLBACK_WIDGET_BUNDLE = `console.warn('[WebAgent] widget bundle unavailable. Build @webagent/widget to enable embed script.');`;
+
+let cachedWidgetBundle: string | null = null;
+let attemptedLoad = false;
+
+async function loadWidgetBundle(): Promise<string> {
+  if (cachedWidgetBundle) {
+    return cachedWidgetBundle;
+  }
+
+  if (attemptedLoad) {
+    return FALLBACK_WIDGET_BUNDLE;
+  }
+
+  attemptedLoad = true;
+
+  const candidates = [
+    new URL('../../../widget/dist/widget.js', import.meta.url),
+    new URL('../../../../widget/dist/widget.js', import.meta.url)
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      cachedWidgetBundle = await readFile(candidate, 'utf8');
+      return cachedWidgetBundle;
+    } catch {
+      // Try next candidate path.
+    }
+  }
+
+  return FALLBACK_WIDGET_BUNDLE;
+}
+
+export function registerWidgetRoutes(app: FastifyInstance): void {
+  app.get('/widget.js', async (_request, reply) => {
+    const bundle = await loadWidgetBundle();
+    return reply
+      .type('application/javascript; charset=utf-8')
+      .header('cache-control', 'public, max-age=300')
+      .send(bundle);
+  });
+}

--- a/packages/proxy/src/ws/handler.ts
+++ b/packages/proxy/src/ws/handler.ts
@@ -1,0 +1,151 @@
+import { WS_CLOSE_CODES } from '@webagent/shared/constants';
+import type { ClientMessage, ServerMessage } from '@webagent/shared/protocol';
+
+import { OpenClawClient } from '../openclaw/client.js';
+import { getOrCreateSession } from '../openclaw/sessions.js';
+
+const AUTH_TIMEOUT_MS = 30_000;
+const tokenAgentMap = new Map<string, string>();
+
+export function registerAgentToken(agentToken: string, agentId: string): void {
+  const token = agentToken.trim();
+  const id = agentId.trim();
+
+  if (!token || !id) {
+    return;
+  }
+
+  tokenAgentMap.set(token, id);
+}
+
+function serializeIncoming(raw: unknown): string {
+  if (typeof raw === 'string') {
+    return raw;
+  }
+
+  if (Buffer.isBuffer(raw)) {
+    return raw.toString('utf8');
+  }
+
+  return String(raw);
+}
+
+interface WebSocketLike {
+  OPEN: number;
+  readyState: number;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  on(event: 'message', listener: (raw: unknown) => void): void;
+  on(event: 'close' | 'error', listener: () => void): void;
+}
+
+export function handleConnection(ws: WebSocketLike): void {
+  const openClaw = new OpenClawClient();
+
+  let authenticated = false;
+  let activeAgentId = '';
+  let activeSessionKey = '';
+
+  const send = (payload: ServerMessage): void => {
+    if (ws.readyState === ws.OPEN) {
+      ws.send(JSON.stringify(payload));
+    }
+  };
+
+  const closeUnauthorized = (reason: string): void => {
+    send({ type: 'auth_error', reason });
+    ws.close(WS_CLOSE_CODES.POLICY_VIOLATION, reason);
+  };
+
+  const authTimer = setTimeout(() => {
+    if (!authenticated) {
+      closeUnauthorized('Authentication timeout');
+    }
+  }, AUTH_TIMEOUT_MS);
+
+  const cleanup = (): void => {
+    clearTimeout(authTimer);
+  };
+
+  ws.on('message', (raw: unknown) => {
+    void (async () => {
+      let incoming: ClientMessage;
+
+      try {
+        incoming = JSON.parse(serializeIncoming(raw)) as ClientMessage;
+      } catch {
+        send({ type: 'error', message: 'Invalid JSON payload' });
+        return;
+      }
+
+      switch (incoming.type) {
+        case 'auth': {
+          if (!incoming.agentToken || !incoming.userId) {
+            closeUnauthorized('Missing agentToken or userId');
+            return;
+          }
+
+          const resolvedAgentId = tokenAgentMap.get(incoming.agentToken);
+          if (!resolvedAgentId) {
+            closeUnauthorized('Invalid agent token');
+            return;
+          }
+
+          activeAgentId = resolvedAgentId;
+          activeSessionKey = getOrCreateSession(activeAgentId, incoming.userId);
+
+          try {
+            await openClaw.wake(activeAgentId);
+          } catch (error) {
+            const message = error instanceof Error ? error.message : 'OpenClaw wake failed';
+            send({ type: 'error', message });
+            return;
+          }
+
+          authenticated = true;
+          clearTimeout(authTimer);
+          send({ type: 'auth_ok', sessionId: activeSessionKey });
+          return;
+        }
+
+        case 'message': {
+          if (!authenticated) {
+            closeUnauthorized('Authenticate before sending messages');
+            return;
+          }
+
+          if (!incoming.content || typeof incoming.content !== 'string') {
+            send({ type: 'error', message: 'Missing message content' });
+            return;
+          }
+
+          try {
+            const response = await openClaw.sendMessage(activeAgentId, activeSessionKey, incoming.content);
+            send({ type: 'message', content: response.content, done: response.done });
+          } catch (error) {
+            const message = error instanceof Error ? error.message : 'Failed to relay message';
+            send({ type: 'error', message });
+          }
+          return;
+        }
+
+        case 'ping': {
+          send({ type: 'pong' });
+          return;
+        }
+
+        default: {
+          send({ type: 'error', message: 'Unsupported message type' });
+        }
+      }
+    })();
+  });
+
+  ws.on('close', () => {
+    cleanup();
+  });
+
+  ws.on('error', () => {
+    cleanup();
+  });
+}

--- a/packages/proxy/src/ws/handler.ts
+++ b/packages/proxy/src/ws/handler.ts
@@ -1,151 +1,135 @@
-import { WS_CLOSE_CODES } from '@webagent/shared/constants';
 import type { ClientMessage, ServerMessage } from '@webagent/shared/protocol';
-
 import { OpenClawClient } from '../openclaw/client.js';
 import { getOrCreateSession } from '../openclaw/sessions.js';
 
-const AUTH_TIMEOUT_MS = 30_000;
+interface WebSocket {
+  readyState: number;
+  OPEN: number;
+  send(data: string): void;
+  close(code?: number, data?: string): void;
+  on(event: 'message', listener: (raw: Buffer | string) => void | Promise<void>): void;
+  on(event: 'close', listener: () => void): void;
+}
+
+interface AuthenticatedSocket {
+  ws: WebSocket;
+  agentToken: string;
+  userId: string;
+  agentId: string;
+  sessionKey: string;
+  authenticated: boolean;
+}
+
+const openclawClient = new OpenClawClient();
+
+// In-memory token→agentId map (will later use DB)
 const tokenAgentMap = new Map<string, string>();
 
-export function registerAgentToken(agentToken: string, agentId: string): void {
-  const token = agentToken.trim();
-  const id = agentId.trim();
-
-  if (!token || !id) {
-    return;
-  }
-
-  tokenAgentMap.set(token, id);
+export function registerAgentToken(token: string, agentId: string) {
+  tokenAgentMap.set(token, agentId);
 }
 
-function serializeIncoming(raw: unknown): string {
-  if (typeof raw === 'string') {
-    return raw;
+function send(ws: WebSocket, msg: ServerMessage) {
+  if (ws.readyState === ws.OPEN) {
+    ws.send(JSON.stringify(msg));
   }
-
-  if (Buffer.isBuffer(raw)) {
-    return raw.toString('utf8');
-  }
-
-  return String(raw);
 }
 
-interface WebSocketLike {
-  OPEN: number;
-  readyState: number;
-  send(data: string): void;
-  close(code?: number, reason?: string): void;
-  on(event: 'message', listener: (raw: unknown) => void): void;
-  on(event: 'close' | 'error', listener: () => void): void;
-}
+export function handleConnection(ws: WebSocket) {
+  const state: AuthenticatedSocket = {
+    ws,
+    agentToken: '',
+    userId: '',
+    agentId: '',
+    sessionKey: '',
+    authenticated: false,
+  };
 
-export function handleConnection(ws: WebSocketLike): void {
-  const openClaw = new OpenClawClient();
-
-  let authenticated = false;
-  let activeAgentId = '';
-  let activeSessionKey = '';
-
-  const send = (payload: ServerMessage): void => {
-    if (ws.readyState === ws.OPEN) {
-      ws.send(JSON.stringify(payload));
+  // 30s auth timeout
+  const authTimeout = setTimeout(() => {
+    if (!state.authenticated) {
+      send(ws, { type: 'auth_error', reason: 'Authentication timeout' });
+      ws.close(4001, 'Auth timeout');
     }
-  };
+  }, 30_000);
 
-  const closeUnauthorized = (reason: string): void => {
-    send({ type: 'auth_error', reason });
-    ws.close(WS_CLOSE_CODES.POLICY_VIOLATION, reason);
-  };
-
-  const authTimer = setTimeout(() => {
-    if (!authenticated) {
-      closeUnauthorized('Authentication timeout');
+  ws.on('message', async (raw: Buffer | string) => {
+    const text = typeof raw === 'string' ? raw : raw.toString('utf8');
+    
+    let msg: ClientMessage;
+    try {
+      msg = JSON.parse(text) as ClientMessage;
+    } catch {
+      send(ws, { type: 'error', message: 'Invalid JSON' });
+      return;
     }
-  }, AUTH_TIMEOUT_MS);
 
-  const cleanup = (): void => {
-    clearTimeout(authTimer);
-  };
+    switch (msg.type) {
+      case 'auth': {
+        if (state.authenticated) {
+          send(ws, { type: 'error', message: 'Already authenticated' });
+          return;
+        }
 
-  ws.on('message', (raw: unknown) => {
-    void (async () => {
-      let incoming: ClientMessage;
+        const agentId = tokenAgentMap.get(msg.agentToken);
+        if (!agentId) {
+          send(ws, { type: 'auth_error', reason: 'Invalid agent token' });
+          ws.close(4003, 'Invalid token');
+          return;
+        }
 
-      try {
-        incoming = JSON.parse(serializeIncoming(raw)) as ClientMessage;
-      } catch {
-        send({ type: 'error', message: 'Invalid JSON payload' });
-        return;
+        state.agentToken = msg.agentToken;
+        state.userId = msg.userId;
+        state.agentId = agentId;
+        state.sessionKey = getOrCreateSession(agentId, msg.userId);
+        state.authenticated = true;
+        clearTimeout(authTimeout);
+
+        send(ws, { type: 'auth_ok', sessionId: state.sessionKey });
+        break;
       }
 
-      switch (incoming.type) {
-        case 'auth': {
-          if (!incoming.agentToken || !incoming.userId) {
-            closeUnauthorized('Missing agentToken or userId');
-            return;
-          }
-
-          const resolvedAgentId = tokenAgentMap.get(incoming.agentToken);
-          if (!resolvedAgentId) {
-            closeUnauthorized('Invalid agent token');
-            return;
-          }
-
-          activeAgentId = resolvedAgentId;
-          activeSessionKey = getOrCreateSession(activeAgentId, incoming.userId);
-
-          try {
-            await openClaw.wake(activeAgentId);
-          } catch (error) {
-            const message = error instanceof Error ? error.message : 'OpenClaw wake failed';
-            send({ type: 'error', message });
-            return;
-          }
-
-          authenticated = true;
-          clearTimeout(authTimer);
-          send({ type: 'auth_ok', sessionId: activeSessionKey });
+      case 'message': {
+        if (!state.authenticated) {
+          send(ws, { type: 'auth_error', reason: 'Not authenticated' });
           return;
         }
 
-        case 'message': {
-          if (!authenticated) {
-            closeUnauthorized('Authenticate before sending messages');
-            return;
-          }
-
-          if (!incoming.content || typeof incoming.content !== 'string') {
-            send({ type: 'error', message: 'Missing message content' });
-            return;
-          }
-
-          try {
-            const response = await openClaw.sendMessage(activeAgentId, activeSessionKey, incoming.content);
-            send({ type: 'message', content: response.content, done: response.done });
-          } catch (error) {
-            const message = error instanceof Error ? error.message : 'Failed to relay message';
-            send({ type: 'error', message });
-          }
+        if (!msg.content?.trim()) {
+          send(ws, { type: 'error', message: 'Empty message' });
           return;
         }
 
-        case 'ping': {
-          send({ type: 'pong' });
-          return;
-        }
+        try {
+          const result = await openclawClient.sendMessage({
+            message: msg.content,
+            agentId: state.agentId,
+            sessionKey: state.sessionKey,
+          });
 
-        default: {
-          send({ type: 'error', message: 'Unsupported message type' });
+          if (result.success) {
+            send(ws, { type: 'message', content: result.response || '', done: true });
+          } else {
+            send(ws, { type: 'error', message: result.error || 'Agent error' });
+          }
+        } catch (err) {
+          send(ws, { type: 'error', message: 'Internal error processing message' });
         }
+        break;
       }
-    })();
+
+      case 'ping': {
+        send(ws, { type: 'pong' });
+        break;
+      }
+
+      default: {
+        send(ws, { type: 'error', message: 'Unknown message type' });
+      }
+    }
   });
 
   ws.on('close', () => {
-    cleanup();
-  });
-
-  ws.on('error', () => {
-    cleanup();
+    clearTimeout(authTimeout);
   });
 }


### PR DESCRIPTION
Implements proxy gateway core:

- OpenClaw hooks API client (`sendMessage`, `wake`, `ping`)
- In-memory session routing map for `(agentId,userId) -> session key`
- WebSocket auth/message handler with token map + timeout
- `/widget.js` route with cached bundle load + fallback
- `/health` and `/health/openclaw` routes
- `index.ts` refactor to modular route/WS registration

Validation:
- `pnpm --filter @webagent/proxy build` ✅
- `pnpm --filter @webagent/proxy lint` ✅

Closes #10