### PR TITLE
Fix meta-agent create-agent skill to avoid exec and shell usage

### DIFF
--- a/openclaw/config/openclaw.json5
+++ b/openclaw/config/openclaw.json5
@@ -24,6 +24,12 @@
         name: "Agent Builder",
         workspace: "~/openclaw/workspaces/meta",
         sandbox: { mode: "off" },
+        tools: {
+          profile: "coding",
+          // Meta-agent needs: read, write, edit (file ops) + web/fetch (HTTP calls)
+          // It does NOT need exec, process, browser
+          deny: ["browser", "canvas"]
+        },
         skills: ["create-agent"],
         heartbeat: { every: "0m" }
       }

--- a/openclaw/templates/AGENTS.md
+++ b/openclaw/templates/AGENTS.md
@@ -19,6 +19,12 @@ You help website visitors with questions about {{WEBSITE_NAME}}. You can:
 ## About the Product
 {{API_DESCRIPTION}}
 
+## API Details
+- **Type:** {{API_TYPE}}
+- **Base URL:** {{API_BASE_URL}}
+- **Authentication:** {{API_AUTH}}
+- **Endpoints/operations:** {{API_ENDPOINTS_SUMMARY}}
+
 ## Session Startup
 - Read AGENTS.md and SOUL.md for personality and instructions
 - Each session is one website visitor — treat them as a new person

--- a/openclaw/templates/SOUL.md
+++ b/openclaw/templates/SOUL.md
@@ -4,7 +4,8 @@
 You are a helpful, knowledgeable assistant representing **{{WEBSITE_NAME}}**.
 
 ## Tone & Voice
-{{BRAND_VOICE}}
+- **Tone:** {{PERSONALITY_TONE}}
+- **Voice guidance:** {{BRAND_VOICE}}
 
 ## Default Behavior
 - Be warm but professional

--- a/openclaw/templates/USER.md
+++ b/openclaw/templates/USER.md
@@ -1,5 +1,6 @@
 # Visitor Context
 
 - **Source:** {{WEBSITE_NAME}} chat widget
+- **Website URL:** {{WEBSITE_URL}}
 - **Visitor ID:** (set per session from external_user_id)
-- **Notes:** This is a website visitor. They may be a first-time user or a returning customer. Treat them respectfully and help them accomplish their goal.
+- **Notes:** This visitor is asking about {{WEBSITE_NAME}}. Product context: {{PRODUCT_SUMMARY}}. They may be a first-time user or a returning customer.

--- a/openclaw/workspaces/meta/AGENTS.md
+++ b/openclaw/workspaces/meta/AGENTS.md
@@ -25,7 +25,7 @@ Ask the customer:
 - Are there any rate limits or restrictions?
 
 ### Phase 3: Agent Creation
-Use the `create-agent` skill to:
+Use the `create-agent` skill (`openclaw/workspaces/meta/skills/create-agent/SKILL.md`) to:
 1. Generate workspace files (AGENTS.md, SOUL.md, IDENTITY.md, USER.md) from templates
 2. Generate a website-api skill with the customer's API details
 3. Register the agent in the OpenClaw configuration
@@ -34,7 +34,7 @@ Use the `create-agent` skill to:
 ### Phase 4: Delivery
 - Show the customer their widget embed code
 - Explain how to install it (paste before </body>)
-- Save the widget code to the workspace as `widget-embed.html`
+- Save the widget code to the workspace as `embed-snippet.html`
 - Offer to help customize the agent further
 
 ## Important Rules
@@ -43,8 +43,11 @@ Use the `create-agent` skill to:
 - If the customer doesn't have an API, create a knowledge-base-only agent
 - Always confirm the details before generating
 - The generated agent should be ready to use immediately
+- Use `write`/`edit` for all file operations
+- Use built-in `web`/`fetch` for HTTP requests
+- **NEVER** use `exec` or shell commands for this workflow
 
 ## Tools
-- `create-agent` skill: orchestrates the full agent creation process
-- File tools: create workspace directories and files
-- The exec tool: run `openclaw agents add` to register new agents
+- `create-agent` skill: orchestrates the full agent-creation process end to end
+- File tools (`read`, `write`, `edit`): create and update workspace/config files
+- Built-in HTTP tool (`web`/`fetch`): register agents via proxy internal API

--- a/openclaw/workspaces/meta/skills/create-agent/SKILL.md
+++ b/openclaw/workspaces/meta/skills/create-agent/SKILL.md
@@ -7,125 +7,83 @@ metadata: {"openclaw": {"always": true}}
 
 # create-agent
 
-This skill creates a fully configured customer agent for the WebAgent platform.
+This skill creates a fully configured customer agent for the WebAgent platform with a strict no-shell workflow.
 
-## Prerequisites
-- Customer must have provided: website name, URL, and description
-- API details are optional (agent can work as knowledge-base only)
+## Hard rules
+- **Never use `exec`, shell commands, or CLI process spawning** during this flow.
+- Use only built-in file tools (`read`, `write`, `edit`) and built-in HTTP tools (`web`/`fetch`).
+- For file creation, prefer `write` directly: **`write` creates missing parent directories automatically**.
 
-## Execution Steps
+## 5-Step Flow
 
-### Step 1: Validate Input
-Ensure we have at minimum:
-- `websiteName` — human-readable name
-- `websiteUrl` — full URL (https://...)
-- `description` — what the product/service does
+### Step 1 — Gather info conversationally and confirm understanding
+Collect and confirm:
+- Website/product: `websiteName`, `websiteUrl`, and product summary.
+- API details: API style (`REST`/`GraphQL`), base URL, authentication method, and key endpoints/actions.
+- Personality/tone: how the assistant should sound and behave.
 
-Optional:
-- `apiBaseUrl` — API base URL
-- `apiEndpoints` — list of endpoints (method, path, description)
-- `apiAuth` — authentication method and details
-- `brandVoice` — desired tone (default: "Professional, helpful, and concise")
-- `agentName` — custom name (default: derived from website name)
-- `agentEmoji` — emoji (default: 🤖)
+Before generating anything, send a compact confirmation summary and get explicit customer confirmation that details are correct.
 
-### Step 2: Generate Agent ID
-Create a URL-safe agent ID: `customer_<slugified-website-name>`
+### Step 2 — Generate workspace files via `write`
+Derive:
+- `agentSlug` = website name lowercased, non-alphanumeric collapsed to hyphens, trim edge hyphens.
+- `workspacePath` = `~/openclaw/workspaces/<agentSlug>/`
 
-### Step 3: Create Workspace Directory
-```bash
-AGENT_ID="customer_<slug>"
-WORKSPACE_DIR="$HOME/.openclaw/workspace-${AGENT_ID}"
-mkdir -p "${WORKSPACE_DIR}/skills/website-api"
-mkdir -p "${WORKSPACE_DIR}/memory"
-```
+Using templates in `openclaw/templates/` as the starting point, render and `write`:
+- `<workspacePath>/AGENTS.md`
+- `<workspacePath>/SOUL.md`
+- `<workspacePath>/IDENTITY.md`
+- `<workspacePath>/USER.md`
+- `<workspacePath>/skills/website-api/SKILL.md`
 
-### Step 4: Generate Workspace Files
-Read templates from `{baseDir}/../../templates/` and render with customer values:
+All files must be filled with customer-provided values (website/product, API details, tone/personality).
 
-**AGENTS.md** — Replace:
-- `{{WEBSITE_NAME}}` → websiteName
-- `{{WEBSITE_URL}}` → websiteUrl
-- `{{API_DESCRIPTION}}` → description
+### Step 3 — Register agent in OpenClaw config via `read` + `edit`
+1. `read` `~/openclaw/config/openclaw.json5`
+2. `edit` `agents.list` to add:
+   - `id`: `<agentSlug>`
+   - `name`: `<agentName>`
+   - `workspace`: `<workspacePath>`
+   - `skills`: `["website-api"]`
+   - `heartbeat`: `{ every: "30m" }`
 
-**SOUL.md** — Replace:
-- `{{WEBSITE_NAME}}` → websiteName
-- `{{BRAND_VOICE}}` → brandVoice or default
+Mention to the customer/operator that OpenClaw uses **hybrid hot-reload**, so `agents.*` config updates are picked up without full restart.
 
-**IDENTITY.md** — Replace:
-- `{{WEBSITE_NAME}}` → websiteName
-- `{{AGENT_NAME}}` → agentName or "<websiteName> Assistant"
-- `{{AGENT_VIBE}}` → "Helpful and knowledgeable"
-- `{{AGENT_EMOJI}}` → agentEmoji or "🤖"
+### Step 4 — Register in proxy DB via HTTP POST (no curl/exec)
+Use built-in `web`/`fetch` tool to call:
+- `POST http://localhost:3001/api/internal/agents`
 
-**USER.md** — Replace:
-- `{{WEBSITE_NAME}}` → websiteName
-
-### Step 5: Generate API Skill (if API provided)
-Create `skills/website-api/SKILL.md`:
-
-```markdown
----
-name: website-api
-description: Call the {{websiteName}} API to perform actions for visitors
-metadata: {"openclaw": {"requires": {"env": ["WEBSITE_API_KEY"]}}}
----
-
-# {{websiteName}} API
-
-Base URL: `{{apiBaseUrl}}`
-Authentication: {{apiAuth}}
-
-## Available Endpoints
-
-{{#each apiEndpoints}}
-### {{method}} {{path}}
-{{description}}
-{{/each}}
-
-## Usage
-Use the `exec` tool with `curl` to call these endpoints. Always include proper authentication headers.
-
-## Error Handling
-- If an API call fails, tell the visitor you're having trouble and suggest they try again or contact support.
-- Never expose raw error messages or stack traces to visitors.
-```
-
-### Step 6: Register Agent in OpenClaw
-Run:
-```bash
-openclaw agents add "${AGENT_ID}" \
-  --workspace "${WORKSPACE_DIR}" \
-  --name "${websiteName} Agent"
-```
-
-Or programmatically update `openclaw.json` to add to `agents.list[]`:
+JSON body:
 ```json
 {
-  "id": "${AGENT_ID}",
-  "name": "${websiteName} Agent",
-  "workspace": "${WORKSPACE_DIR}"
+  "customerId": "<from session context>",
+  "openclawAgentId": "<agentSlug>",
+  "name": "<agentName>",
+  "websiteUrl": "<websiteUrl>",
+  "apiDescription": "<apiDescription>"
 }
 ```
 
-### Step 7: Generate Widget Embed Code
-Create `${WORKSPACE_DIR}/widget-embed.html`:
+Expect response shape:
+```json
+{ "agent": { ... }, "embedToken": "..." }
+```
 
+### Step 5 — Generate embed snippet and deliver usage
+Use returned `embedToken` to create:
+- `<workspacePath>/embed-snippet.html`
+
+Snippet format:
 ```html
-<!-- WebAgent Chat Widget for {{websiteName}} -->
-<!-- Paste this before </body> on your website -->
 <script
-  src="https://{{PLATFORM_DOMAIN}}/widget.js"
-  data-agent-token="{{EMBED_TOKEN}}"
-  data-user-id="REPLACE_WITH_YOUR_USER_ID"
+  src="https://{{DOMAIN}}/widget.js"
+  data-agent-token="{{embedToken}}"
+  data-user-id=""
 ></script>
 ```
 
-The `EMBED_TOKEN` is generated by the proxy and stored in the database.
-
-### Step 8: Confirm to Customer
-Display:
-1. Agent name and ID
-2. The embed code to copy
-3. Instructions on how to replace `data-user-id` with their user identification
-4. A reminder that they can come back to update the agent anytime
+Then present:
+1. Agent ID and name
+2. The embed snippet
+3. Where to paste it (`before </body>`)
+4. Reminder that they can return to update behavior or API actions


### PR DESCRIPTION
## Summary
- rewrote `openclaw/workspaces/meta/skills/create-agent/SKILL.md` to a 5-step flow using only `read`/`write`/`edit` plus built-in `web`/`fetch` HTTP calls
- updated meta workspace `AGENTS.md` to explicitly require file tools + built-in HTTP and ban `exec`/shell commands
- updated meta agent entry in `openclaw/config/openclaw.json5` with explicit tools policy (`profile: coding`, `deny: ["browser", "canvas"]`)
- verified and improved template placeholders in `openclaw/templates/AGENTS.md`, `SOUL.md`, and `USER.md` (IDENTITY already valid)

## Validation
- `pnpm lint` ❌ fails pre-existing: Turbo cannot resolve workspaces because root `package.json` is missing `packageManager`
- `pnpm build` ❌ same pre-existing failure
- `pnpm typecheck` ❌ same pre-existing failure
- `git diff --check` ✅ clean

## Notes
- Left unrelated working tree changes in `packages/admin/*` untouched and out of this PR.