### PR TITLE
feat(proxy): wire Drizzle runtime and complete proxy agent API

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "webagent",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@9.0.0",
   "scripts": {
     "dev": "turbo run dev",
     "build": "turbo run build",

--- a/packages/proxy/src/db/auth-schema.ts
+++ b/packages/proxy/src/db/auth-schema.ts
@@ -1,0 +1,55 @@
+import { integer, pgTable, primaryKey, text, timestamp } from 'drizzle-orm/pg-core';
+
+export const users = pgTable('users', {
+  id: text('id').primaryKey(),
+  name: text('name'),
+  email: text('email').notNull(),
+  emailVerified: timestamp('emailVerified', { mode: 'date' }),
+  image: text('image'),
+});
+
+export const accounts = pgTable(
+  'accounts',
+  {
+    userId: text('userId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    type: text('type').notNull(),
+    provider: text('provider').notNull(),
+    providerAccountId: text('providerAccountId').notNull(),
+    refresh_token: text('refresh_token'),
+    access_token: text('access_token'),
+    expires_at: integer('expires_at'),
+    token_type: text('token_type'),
+    scope: text('scope'),
+    id_token: text('id_token'),
+    session_state: text('session_state'),
+  },
+  (account) => ({
+    compoundKey: primaryKey({
+      columns: [account.provider, account.providerAccountId],
+    }),
+  }),
+);
+
+export const sessions = pgTable('sessions', {
+  sessionToken: text('sessionToken').primaryKey(),
+  userId: text('userId')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  expires: timestamp('expires', { mode: 'date' }).notNull(),
+});
+
+export const verificationTokens = pgTable(
+  'verification_tokens',
+  {
+    identifier: text('identifier').notNull(),
+    token: text('token').notNull(),
+    expires: timestamp('expires', { mode: 'date' }).notNull(),
+  },
+  (verificationToken) => ({
+    compositePk: primaryKey({
+      columns: [verificationToken.identifier, verificationToken.token],
+    }),
+  }),
+);

--- a/packages/proxy/src/db/plugin.ts
+++ b/packages/proxy/src/db/plugin.ts
@@ -1,0 +1,14 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { loadConfig } from '../config.js';
+import { createDb, type Database } from './client.js';
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    db: Database;
+  }
+}
+
+export const dbPlugin: FastifyPluginAsync = async (fastify) => {
+  const config = loadConfig();
+  fastify.decorate('db', createDb(config.databaseUrl));
+};

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -2,21 +2,67 @@ import Fastify from 'fastify';
 import websocket from '@fastify/websocket';
 
 import { loadConfig } from './config.js';
-import { handleConnection } from './ws/handler.js';
-import { registerWidgetRoutes } from './routes/widget.js';
+import { dbPlugin } from './db/plugin.js';
+import { registerApiRoutes } from './routes/api.js';
 import { registerHealthRoutes } from './routes/health.js';
+import { registerWidgetRoutes } from './routes/widget.js';
+import { handleConnection } from './ws/handler.js';
 import { DEFAULT_WS_PATH } from '@webagent/shared/constants';
+
+interface ManagedSocket {
+  close(code?: number, data?: string): void;
+  on(event: 'close', listener: () => void): void;
+}
 
 const config = loadConfig();
 const app = Fastify({ logger: true });
+const activeSockets = new Set<ManagedSocket>();
 
 await app.register(websocket);
+await app.register(dbPlugin);
 
 registerHealthRoutes(app);
 registerWidgetRoutes(app);
+registerApiRoutes(app);
 
-app.get(DEFAULT_WS_PATH, { websocket: true }, (connection) => {
-  handleConnection(connection.socket);
+app.get(DEFAULT_WS_PATH, { websocket: true }, (connection, request) => {
+  const socket = connection.socket as ManagedSocket;
+  activeSockets.add(socket);
+  socket.on('close', () => {
+    activeSockets.delete(socket);
+  });
+
+  const origin = typeof request.headers.origin === 'string' ? request.headers.origin : undefined;
+  handleConnection(connection.socket, { db: app.db, origin });
+});
+
+let shuttingDown = false;
+
+const shutdown = async (signal: 'SIGTERM' | 'SIGINT'): Promise<void> => {
+  if (shuttingDown) {
+    return;
+  }
+
+  shuttingDown = true;
+  app.log.info({ signal, sockets: activeSockets.size }, 'shutting down proxy server');
+
+  for (const socket of activeSockets) {
+    try {
+      socket.close(1001, 'Going Away');
+    } catch (error) {
+      app.log.warn({ error }, 'failed to close websocket during shutdown');
+    }
+  }
+
+  await app.close();
+};
+
+process.once('SIGTERM', () => {
+  void shutdown('SIGTERM');
+});
+
+process.once('SIGINT', () => {
+  void shutdown('SIGINT');
 });
 
 const start = async (): Promise<void> => {
@@ -24,7 +70,7 @@ const start = async (): Promise<void> => {
     await app.listen({ host: '0.0.0.0', port: config.port });
     app.log.info(
       { port: config.port, openClawHooksUrl: config.openClawHooksUrl },
-      'proxy server started'
+      'proxy server started',
     );
   } catch (error) {
     app.log.error(error, 'failed to start proxy server');

--- a/packages/proxy/src/openclaw/client.ts
+++ b/packages/proxy/src/openclaw/client.ts
@@ -32,6 +32,7 @@ export class OpenClawClient {
       body: JSON.stringify({
         message: opts.message,
         agentId: opts.agentId,
+        sessionKey: opts.sessionKey,
         name: opts.name || 'widget-chat',
         wakeMode: 'now',
       }),

--- a/packages/proxy/src/openclaw/sessions.ts
+++ b/packages/proxy/src/openclaw/sessions.ts
@@ -1,24 +1,44 @@
-// In-memory session map (will later use DB)
-const sessionMap = new Map<string, string>();
+import { and, eq } from 'drizzle-orm';
+import type { Database } from '../db/client.js';
+import { widgetSessions } from '../db/schema.js';
 
 function sessionKey(agentId: string, userId: string): string {
   return `widget:${agentId}:${userId}`;
 }
 
-export function getOrCreateSession(agentId: string, userId: string): string {
-  const key = `${agentId}::${userId}`;
-  let session = sessionMap.get(key);
-  if (!session) {
-    session = sessionKey(agentId, userId);
-    sessionMap.set(key, session);
-  }
-  return session;
+export async function getOrCreateSession(
+  db: Database,
+  agentId: string,
+  userId: string,
+): Promise<string> {
+  const openclawSessionKey = sessionKey(agentId, userId);
+
+  await db
+    .insert(widgetSessions)
+    .values({
+      agentId,
+      externalUserId: userId,
+      openclawSessionKey,
+      lastActiveAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: [widgetSessions.agentId, widgetSessions.externalUserId],
+      set: {
+        openclawSessionKey,
+        lastActiveAt: new Date(),
+      },
+    });
+
+  return openclawSessionKey;
 }
 
-export function getSession(agentId: string, userId: string): string | undefined {
-  return sessionMap.get(`${agentId}::${userId}`);
-}
-
-export function removeSession(agentId: string, userId: string): boolean {
-  return sessionMap.delete(`${agentId}::${userId}`);
+export async function touchSessionLastActiveAt(
+  db: Database,
+  agentId: string,
+  userId: string,
+): Promise<void> {
+  await db
+    .update(widgetSessions)
+    .set({ lastActiveAt: new Date() })
+    .where(and(eq(widgetSessions.agentId, agentId), eq(widgetSessions.externalUserId, userId)));
 }

--- a/packages/proxy/src/routes/api.ts
+++ b/packages/proxy/src/routes/api.ts
@@ -1,0 +1,431 @@
+import { randomUUID } from 'node:crypto';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { and, count, eq, ne } from 'drizzle-orm';
+import { z } from 'zod';
+import { agents, widgetEmbeds, widgetSessions } from '../db/schema.js';
+import { invalidateEmbedTokenCache } from '../ws/handler.js';
+
+const localhostIps = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+
+const createInternalAgentBodySchema = z.object({
+  customerId: z.string().uuid(),
+  openclawAgentId: z.string().min(1),
+  name: z.string().min(1),
+  websiteUrl: z.string().url().optional(),
+  description: z.string().optional(),
+  apiDescription: z.string().optional(),
+  widgetConfig: z.record(z.string(), z.unknown()).optional(),
+  allowedOrigins: z.array(z.string().min(1)).optional(),
+});
+
+const agentsQuerySchema = z.object({
+  customerId: z.string().uuid(),
+});
+
+const idParamsSchema = z.object({
+  id: z.string().uuid(),
+});
+
+const updateAgentBodySchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    websiteUrl: z.string().url().nullable().optional(),
+    description: z.string().nullable().optional(),
+    status: z.string().min(1).optional(),
+    widgetConfig: z.record(z.string(), z.unknown()).optional(),
+    apiDescription: z.string().nullable().optional(),
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: 'At least one field is required',
+  });
+
+const createEmbedBodySchema = z.object({
+  allowedOrigins: z.array(z.string().min(1)).optional(),
+});
+
+function sendError(
+  reply: FastifyReply,
+  statusCode: number,
+  code: string,
+  message: string,
+  details?: unknown,
+) {
+  return reply.status(statusCode).send({
+    error: {
+      code,
+      message,
+      details,
+    },
+  });
+}
+
+function parseOrError<T>(
+  schema: z.ZodSchema<T>,
+  input: unknown,
+  reply: FastifyReply,
+  code: string,
+): T | null {
+  const parsed = schema.safeParse(input);
+  if (parsed.success) {
+    return parsed.data;
+  }
+
+  sendError(reply, 400, code, 'Validation failed', parsed.error.flatten());
+  return null;
+}
+
+function isLocalhost(request: FastifyRequest): boolean {
+  if (localhostIps.has(request.ip)) return true;
+
+  const remoteAddress = request.raw.socket.remoteAddress;
+  if (!remoteAddress) return false;
+  return localhostIps.has(remoteAddress);
+}
+
+function readBearerToken(request: FastifyRequest): string | null {
+  const value = request.headers.authorization;
+  if (!value) return null;
+
+  const [scheme, token] = value.split(' ');
+  if (scheme?.toLowerCase() !== 'bearer' || !token) {
+    return null;
+  }
+
+  return token;
+}
+
+function getCustomerApiToken(): string | null {
+  return (
+    process.env.PROXY_CUSTOMER_API_TOKEN?.trim()
+    || process.env.PROXY_API_TOKEN?.trim()
+    || process.env.OPENCLAW_HOOKS_TOKEN?.trim()
+    || null
+  );
+}
+
+function requireCustomerAuth(request: FastifyRequest, reply: FastifyReply): boolean {
+  const expected = getCustomerApiToken();
+  if (!expected) {
+    sendError(reply, 500, 'missing_api_token', 'Server API token is not configured');
+    return false;
+  }
+
+  const token = readBearerToken(request);
+  if (!token || token !== expected) {
+    sendError(reply, 401, 'unauthorized', 'Invalid or missing bearer token');
+    return false;
+  }
+
+  return true;
+}
+
+export function registerApiRoutes(app: FastifyInstance) {
+  app.post('/api/internal/agents', async (request, reply) => {
+    if (!isLocalhost(request)) {
+      return sendError(reply, 403, 'forbidden', 'Route is restricted to localhost requests');
+    }
+
+    const body = parseOrError(
+      createInternalAgentBodySchema,
+      request.body,
+      reply,
+      'invalid_internal_agent_payload',
+    );
+    if (!body) return;
+
+    try {
+      const createdAgentRows = await app.db
+        .insert(agents)
+        .values({
+          customerId: body.customerId,
+          openclawAgentId: body.openclawAgentId,
+          name: body.name,
+          websiteUrl: body.websiteUrl,
+          description: body.description,
+          status: 'active',
+          widgetConfig: body.widgetConfig ?? {},
+          apiDescription: body.apiDescription,
+          updatedAt: new Date(),
+        })
+        .returning();
+
+      const createdAgent = createdAgentRows[0];
+      if (!createdAgent) {
+        return sendError(reply, 500, 'agent_create_failed', 'Failed to create agent');
+      }
+
+      const embedToken = randomUUID();
+      const createdEmbedRows = await app.db
+        .insert(widgetEmbeds)
+        .values({
+          agentId: createdAgent.id,
+          embedToken,
+          allowedOrigins: body.allowedOrigins,
+        })
+        .returning();
+
+      return reply.status(201).send({
+        agent: createdAgent,
+        embedToken,
+      });
+    } catch (error) {
+      request.log.error({ error }, 'failed to create internal agent');
+      return sendError(reply, 500, 'internal_error', 'Failed to create internal agent');
+    }
+  });
+
+  app.get('/api/agents', async (request, reply) => {
+    if (!requireCustomerAuth(request, reply)) return;
+
+    const query = parseOrError(agentsQuerySchema, request.query, reply, 'invalid_agents_query');
+    if (!query) return;
+
+    try {
+      const rows = await app.db
+        .select()
+        .from(agents)
+        .where(and(eq(agents.customerId, query.customerId), ne(agents.status, 'deleted')));
+
+      const sessionCountRows = await app.db
+        .select({
+          agentId: widgetSessions.agentId,
+          sessionCount: count(widgetSessions.id),
+        })
+        .from(widgetSessions)
+        .innerJoin(agents, eq(widgetSessions.agentId, agents.id))
+        .where(and(eq(agents.customerId, query.customerId), ne(agents.status, 'deleted')))
+        .groupBy(widgetSessions.agentId);
+
+      const sessionCountByAgentId = new Map(
+        sessionCountRows.map((row) => [row.agentId, Number(row.sessionCount) || 0]),
+      );
+
+      return reply.send({
+        data: rows.map((row) => ({
+          ...row,
+          sessionCount: sessionCountByAgentId.get(row.id) ?? 0,
+        })),
+      });
+    } catch (error) {
+      request.log.error({ error }, 'failed to list agents');
+      return sendError(reply, 500, 'internal_error', 'Failed to list agents');
+    }
+  });
+
+  app.get('/api/agents/:id', async (request, reply) => {
+    if (!requireCustomerAuth(request, reply)) return;
+
+    const params = parseOrError(idParamsSchema, request.params, reply, 'invalid_agent_id');
+    if (!params) return;
+    const query = parseOrError(agentsQuerySchema, request.query, reply, 'invalid_agents_query');
+    if (!query) return;
+
+    try {
+      const rows = await app.db
+        .select()
+        .from(agents)
+        .where(
+          and(
+            eq(agents.id, params.id),
+            eq(agents.customerId, query.customerId),
+            ne(agents.status, 'deleted'),
+          ),
+        )
+        .limit(1);
+      const agent = rows[0];
+      if (!agent) {
+        return sendError(reply, 404, 'not_found', 'Agent not found');
+      }
+
+      const embedRows = await app.db
+        .select()
+        .from(widgetEmbeds)
+        .where(eq(widgetEmbeds.agentId, params.id))
+        .limit(1);
+      const embed = embedRows[0] ?? null;
+
+      return reply.send({
+        data: {
+          ...agent,
+          embed,
+          embedToken: embed?.embedToken ?? null,
+          allowedOrigins: embed?.allowedOrigins ?? null,
+        },
+      });
+    } catch (error) {
+      request.log.error({ error }, 'failed to fetch agent');
+      return sendError(reply, 500, 'internal_error', 'Failed to fetch agent');
+    }
+  });
+
+  app.patch('/api/agents/:id', async (request, reply) => {
+    if (!requireCustomerAuth(request, reply)) return;
+
+    const params = parseOrError(idParamsSchema, request.params, reply, 'invalid_agent_id');
+    if (!params) return;
+
+    const query = parseOrError(agentsQuerySchema, request.query, reply, 'invalid_agents_query');
+    if (!query) return;
+
+    const body = parseOrError(updateAgentBodySchema, request.body, reply, 'invalid_agent_patch');
+    if (!body) return;
+
+    try {
+      const existingAgentRows = await app.db
+        .select()
+        .from(agents)
+        .where(
+          and(
+            eq(agents.id, params.id),
+            eq(agents.customerId, query.customerId),
+            ne(agents.status, 'deleted'),
+          ),
+        )
+        .limit(1);
+      const existingAgent = existingAgentRows[0];
+      if (!existingAgent) {
+        return sendError(reply, 404, 'not_found', 'Agent not found');
+      }
+
+      const updatedRows = await app.db
+        .update(agents)
+        .set({
+          ...body,
+          updatedAt: new Date(),
+        })
+        .where(and(eq(agents.id, params.id), eq(agents.customerId, query.customerId)))
+        .returning();
+
+      const updated = updatedRows[0];
+      if (!updated) {
+        return sendError(reply, 404, 'not_found', 'Agent not found');
+      }
+
+      if (body.status && body.status !== existingAgent.status) {
+        const embedRows = await app.db
+          .select({ embedToken: widgetEmbeds.embedToken })
+          .from(widgetEmbeds)
+          .where(eq(widgetEmbeds.agentId, params.id));
+        for (const embedRow of embedRows) {
+          invalidateEmbedTokenCache(embedRow.embedToken);
+        }
+      }
+
+      return reply.send({ data: updated });
+    } catch (error) {
+      request.log.error({ error }, 'failed to update agent');
+      return sendError(reply, 500, 'internal_error', 'Failed to update agent');
+    }
+  });
+
+  app.delete('/api/agents/:id', async (request, reply) => {
+    if (!requireCustomerAuth(request, reply)) return;
+
+    const params = parseOrError(idParamsSchema, request.params, reply, 'invalid_agent_id');
+    if (!params) return;
+
+    const query = parseOrError(agentsQuerySchema, request.query, reply, 'invalid_agents_query');
+    if (!query) return;
+
+    try {
+      const embedRows = await app.db
+        .select({ embedToken: widgetEmbeds.embedToken })
+        .from(widgetEmbeds)
+        .innerJoin(agents, eq(widgetEmbeds.agentId, agents.id))
+        .where(and(eq(agents.id, params.id), eq(agents.customerId, query.customerId)));
+
+      const updatedRows = await app.db
+        .update(agents)
+        .set({
+          status: 'deleted',
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(agents.id, params.id),
+            eq(agents.customerId, query.customerId),
+            ne(agents.status, 'deleted'),
+          ),
+        )
+        .returning();
+
+      const updated = updatedRows[0];
+      if (!updated) {
+        return sendError(reply, 404, 'not_found', 'Agent not found');
+      }
+
+      for (const embedRow of embedRows) {
+        invalidateEmbedTokenCache(embedRow.embedToken);
+      }
+
+      return reply.send({ data: updated });
+    } catch (error) {
+      request.log.error({ error }, 'failed to soft delete agent');
+      return sendError(reply, 500, 'internal_error', 'Failed to soft delete agent');
+    }
+  });
+
+  app.post('/api/agents/:id/embed-token', async (request, reply) => {
+    if (!requireCustomerAuth(request, reply)) return;
+
+    const params = parseOrError(idParamsSchema, request.params, reply, 'invalid_agent_id');
+    if (!params) return;
+
+    const query = parseOrError(agentsQuerySchema, request.query, reply, 'invalid_agents_query');
+    if (!query) return;
+
+    const body = parseOrError(createEmbedBodySchema, request.body ?? {}, reply, 'invalid_embed_payload');
+    if (!body) return;
+
+    try {
+      const existingRows = await app.db
+        .select({ id: agents.id })
+        .from(agents)
+        .where(
+          and(
+            eq(agents.id, params.id),
+            eq(agents.customerId, query.customerId),
+            ne(agents.status, 'deleted'),
+          ),
+        )
+        .limit(1);
+
+      if (!existingRows[0]) {
+        return sendError(reply, 404, 'not_found', 'Agent not found');
+      }
+
+      const embedRows = await app.db
+        .select()
+        .from(widgetEmbeds)
+        .where(eq(widgetEmbeds.agentId, params.id))
+        .limit(1);
+
+      const existingEmbed = embedRows[0];
+      const embedToken = randomUUID();
+
+      if (existingEmbed) {
+        await app.db
+          .update(widgetEmbeds)
+          .set({
+            embedToken,
+            allowedOrigins: body.allowedOrigins ?? existingEmbed.allowedOrigins,
+          })
+          .where(eq(widgetEmbeds.id, existingEmbed.id));
+        invalidateEmbedTokenCache(existingEmbed.embedToken);
+      } else {
+        await app.db.insert(widgetEmbeds).values({
+          agentId: params.id,
+          embedToken,
+          allowedOrigins: body.allowedOrigins,
+        });
+      }
+
+      invalidateEmbedTokenCache(embedToken);
+
+      return reply.send({ embedToken });
+    } catch (error) {
+      request.log.error({ error }, 'failed to create embed token');
+      return sendError(reply, 500, 'internal_error', 'Failed to create embed token');
+    }
+  });
+}

--- a/packages/proxy/src/ws/handler.ts
+++ b/packages/proxy/src/ws/handler.ts
@@ -1,6 +1,9 @@
 import type { ClientMessage, ServerMessage } from '@webagent/shared/protocol';
+import { and, eq } from 'drizzle-orm';
+import type { Database } from '../db/client.js';
+import { agents, widgetEmbeds } from '../db/schema.js';
 import { OpenClawClient } from '../openclaw/client.js';
-import { getOrCreateSession } from '../openclaw/sessions.js';
+import { getOrCreateSession, touchSessionLastActiveAt } from '../openclaw/sessions.js';
 
 interface WebSocket {
   readyState: number;
@@ -16,17 +19,33 @@ interface AuthenticatedSocket {
   agentToken: string;
   userId: string;
   agentId: string;
+  openclawAgentId: string;
   sessionKey: string;
   authenticated: boolean;
 }
 
+interface TokenLookup {
+  agentId: string;
+  openclawAgentId: string;
+  allowedOrigins: string[] | null;
+}
+
+interface TokenCacheEntry {
+  value: TokenLookup;
+  expiresAt: number;
+}
+
 const openclawClient = new OpenClawClient();
+const TOKEN_CACHE_TTL_MS = 60_000;
+const tokenCache = new Map<string, TokenCacheEntry>();
 
-// In-memory token→agentId map (will later use DB)
-const tokenAgentMap = new Map<string, string>();
+export function invalidateEmbedTokenCache(token?: string): void {
+  if (token) {
+    tokenCache.delete(token);
+    return;
+  }
 
-export function registerAgentToken(token: string, agentId: string) {
-  tokenAgentMap.set(token, agentId);
+  tokenCache.clear();
 }
 
 function send(ws: WebSocket, msg: ServerMessage) {
@@ -35,12 +54,85 @@ function send(ws: WebSocket, msg: ServerMessage) {
   }
 }
 
-export function handleConnection(ws: WebSocket) {
+function isOriginAllowed(origin: string | undefined, allowedOrigins: string[] | null): boolean {
+  if (!allowedOrigins || allowedOrigins.length === 0) {
+    return true;
+  }
+
+  if (!origin) {
+    return false;
+  }
+
+  return allowedOrigins.includes(origin);
+}
+
+function getCachedTokenLookup(embedToken: string): TokenLookup | null {
+  const cached = tokenCache.get(embedToken);
+  if (!cached) {
+    return null;
+  }
+
+  if (cached.expiresAt <= Date.now()) {
+    tokenCache.delete(embedToken);
+    return null;
+  }
+
+  return cached.value;
+}
+
+function setCachedTokenLookup(embedToken: string, value: TokenLookup): void {
+  tokenCache.set(embedToken, { value, expiresAt: Date.now() + TOKEN_CACHE_TTL_MS });
+}
+
+function extractAuthToken(msg: unknown): string {
+  if (!msg || typeof msg !== 'object') {
+    return '';
+  }
+
+  const authMsg = msg as { agentToken?: unknown; token?: unknown };
+  const token = typeof authMsg.agentToken === 'string' ? authMsg.agentToken : authMsg.token;
+  return typeof token === 'string' ? token : '';
+}
+
+async function lookupEmbedToken(db: Database, embedToken: string): Promise<TokenLookup | null> {
+  const cached = getCachedTokenLookup(embedToken);
+  if (cached) {
+    return cached;
+  }
+
+  const rows = await db
+    .select({
+      agentId: agents.id,
+      openclawAgentId: agents.openclawAgentId,
+      allowedOrigins: widgetEmbeds.allowedOrigins,
+    })
+    .from(widgetEmbeds)
+    .innerJoin(agents, eq(widgetEmbeds.agentId, agents.id))
+    .where(and(eq(widgetEmbeds.embedToken, embedToken), eq(agents.status, 'active')))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) {
+    return null;
+  }
+
+  const value = {
+    agentId: row.agentId,
+    openclawAgentId: row.openclawAgentId,
+    allowedOrigins: row.allowedOrigins,
+  };
+
+  setCachedTokenLookup(embedToken, value);
+  return value;
+}
+
+export function handleConnection(ws: WebSocket, ctx: { db: Database; origin?: string }) {
   const state: AuthenticatedSocket = {
     ws,
     agentToken: '',
     userId: '',
     agentId: '',
+    openclawAgentId: '',
     sessionKey: '',
     authenticated: false,
   };
@@ -55,7 +147,7 @@ export function handleConnection(ws: WebSocket) {
 
   ws.on('message', async (raw: Buffer | string) => {
     const text = typeof raw === 'string' ? raw : raw.toString('utf8');
-    
+
     let msg: ClientMessage;
     try {
       msg = JSON.parse(text) as ClientMessage;
@@ -64,68 +156,110 @@ export function handleConnection(ws: WebSocket) {
       return;
     }
 
-    switch (msg.type) {
-      case 'auth': {
-        if (state.authenticated) {
-          send(ws, { type: 'error', message: 'Already authenticated' });
-          return;
-        }
-
-        const agentId = tokenAgentMap.get(msg.agentToken);
-        if (!agentId) {
-          send(ws, { type: 'auth_error', reason: 'Invalid agent token' });
-          ws.close(4003, 'Invalid token');
-          return;
-        }
-
-        state.agentToken = msg.agentToken;
-        state.userId = msg.userId;
-        state.agentId = agentId;
-        state.sessionKey = getOrCreateSession(agentId, msg.userId);
-        state.authenticated = true;
-        clearTimeout(authTimeout);
-
-        send(ws, { type: 'auth_ok', sessionId: state.sessionKey });
-        break;
+    try {
+      if (state.authenticated && msg.type !== 'auth') {
+        await touchSessionLastActiveAt(ctx.db, state.agentId, state.userId);
       }
 
-      case 'message': {
-        if (!state.authenticated) {
-          send(ws, { type: 'auth_error', reason: 'Not authenticated' });
-          return;
-        }
-
-        if (!msg.content?.trim()) {
-          send(ws, { type: 'error', message: 'Empty message' });
-          return;
-        }
-
-        try {
-          const result = await openclawClient.sendMessage({
-            message: msg.content,
-            agentId: state.agentId,
-            sessionKey: state.sessionKey,
-          });
-
-          if (result.success) {
-            send(ws, { type: 'message', content: result.response || '', done: true });
-          } else {
-            send(ws, { type: 'error', message: result.error || 'Agent error' });
+      switch (msg.type) {
+        case 'auth': {
+          if (state.authenticated) {
+            send(ws, { type: 'error', message: 'Already authenticated' });
+            return;
           }
-        } catch (err) {
-          send(ws, { type: 'error', message: 'Internal error processing message' });
+
+          const authToken = extractAuthToken(msg);
+          if (!authToken) {
+            send(ws, { type: 'auth_error', reason: 'Invalid agent token' });
+            ws.close(4003, 'Invalid token');
+            return;
+          }
+
+          let tokenData: TokenLookup | null;
+          try {
+            tokenData = await lookupEmbedToken(ctx.db, authToken);
+          } catch {
+            send(ws, { type: 'auth_error', reason: 'Internal server error' });
+            ws.close(1011, 'Internal error');
+            return;
+          }
+
+          if (!tokenData) {
+            send(ws, { type: 'auth_error', reason: 'Invalid agent token' });
+            ws.close(4003, 'Invalid token');
+            return;
+          }
+
+          if (!isOriginAllowed(ctx.origin, tokenData.allowedOrigins)) {
+            send(ws, { type: 'auth_error', reason: 'Origin not allowed' });
+            ws.close(4003, 'Origin not allowed');
+            return;
+          }
+
+          state.agentToken = authToken;
+          state.userId = msg.userId;
+          state.agentId = tokenData.agentId;
+          state.openclawAgentId = tokenData.openclawAgentId;
+          try {
+            state.sessionKey = await getOrCreateSession(ctx.db, tokenData.agentId, msg.userId);
+          } catch {
+            send(ws, { type: 'auth_error', reason: 'Internal server error' });
+            ws.close(1011, 'Internal error');
+            return;
+          }
+          state.authenticated = true;
+          clearTimeout(authTimeout);
+
+          send(ws, { type: 'auth_ok', sessionId: state.sessionKey });
+          break;
         }
-        break;
+
+        case 'message': {
+          if (!state.authenticated) {
+            send(ws, { type: 'auth_error', reason: 'Not authenticated' });
+            return;
+          }
+
+          if (!msg.content?.trim()) {
+            send(ws, { type: 'error', message: 'Empty message' });
+            return;
+          }
+
+          try {
+            const result = await openclawClient.sendMessage({
+              message: msg.content,
+              agentId: state.openclawAgentId,
+              sessionKey: state.sessionKey,
+            });
+
+            if (result.success) {
+              send(ws, { type: 'message', content: result.response || '', done: true });
+            } else {
+              send(ws, { type: 'error', message: result.error || 'Agent error' });
+            }
+          } catch {
+            send(ws, { type: 'error', message: 'Internal error processing message' });
+          }
+          break;
+        }
+
+        case 'ping': {
+          send(ws, { type: 'pong' });
+          break;
+        }
+
+        default: {
+          send(ws, { type: 'error', message: 'Unknown message type' });
+        }
+      }
+    } catch {
+      if (msg.type === 'auth' && !state.authenticated) {
+        send(ws, { type: 'auth_error', reason: 'Internal server error' });
+        ws.close(1011, 'Internal error');
+        return;
       }
 
-      case 'ping': {
-        send(ws, { type: 'pong' });
-        break;
-      }
-
-      default: {
-        send(ws, { type: 'error', message: 'Unknown message type' });
-      }
+      send(ws, { type: 'error', message: 'Internal error processing message' });
     }
   });
 


### PR DESCRIPTION
## Summary
- wire Drizzle into proxy runtime via Fastify DB plugin (`fastify.db`)
- replace WS token map/session map with DB-backed lookups + widget session persistence
- add embed-token TTL cache + invalidation hooks
- enforce WS origin checks against `widget_embeds.allowed_origins`
- implement proxy agent REST API (`/api/internal/agents`, `/api/agents*`) with Zod validation and structured errors
- add graceful shutdown for websocket drain and Fastify close
- add NextAuth Drizzle auth tables in `db/auth-schema.ts`
- pass `sessionKey` through OpenClaw hooks client

## Validation
- `pnpm build` ✅

Closes #27