### PR TITLE
feat(admin): build dashboard and agent creation pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "webagent",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@9.0.0",
   "scripts": {
     "dev": "turbo run dev",
     "build": "turbo run build",

--- a/packages/admin/next.config.ts
+++ b/packages/admin/next.config.ts
@@ -1,5 +1,18 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: "/api/agents/create-via-meta",
+        destination: "http://localhost:3001/api/agents/create-via-meta",
+      },
+      {
+        source: "/api/agents/:path*",
+        destination: "http://localhost:3001/api/agents/:path*",
+      },
+    ];
+  },
+};
 
 export default nextConfig;

--- a/packages/admin/src/app/create/page.tsx
+++ b/packages/admin/src/app/create/page.tsx
@@ -1,0 +1,23 @@
+import { CreateAgentChat } from "@/components/create-agent-chat";
+import { auth } from "@/lib/auth";
+import { redirect } from "next/navigation";
+
+export default async function CreatePage() {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect("/login");
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mx-auto mb-6 max-w-3xl">
+        <h1 className="text-2xl font-semibold text-gray-900">Create Agent</h1>
+        <p className="mt-2 text-sm text-gray-600">
+          Follow each stage to configure your agent and get embed code.
+        </p>
+      </div>
+      <CreateAgentChat />
+    </main>
+  );
+}

--- a/packages/admin/src/app/dashboard/agents/[id]/page.tsx
+++ b/packages/admin/src/app/dashboard/agents/[id]/page.tsx
@@ -1,0 +1,111 @@
+import { auth } from "@/lib/auth";
+import { getAgent } from "@/lib/api";
+import { normalizeCustomerIdToUuid } from "@/lib/customer-id";
+import { redirect } from "next/navigation";
+import { AgentDetailActions } from "@/components/agent-detail-actions";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+const statusColors: Record<string, string> = {
+  active: "bg-green-100 text-green-800",
+  paused: "bg-yellow-100 text-yellow-800",
+  deleted: "bg-red-100 text-red-800",
+};
+
+export default async function AgentDetailPage({ params }: Props) {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+
+  const { id } = await params;
+  const customerId = normalizeCustomerIdToUuid(session.user.id, session.user.email);
+  const agent = await getAgent(id, customerId);
+
+  if (!agent) {
+    return (
+      <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <p className="text-gray-500">Agent not found.</p>
+      </div>
+    );
+  }
+
+  const embedCode =
+    agent.embedCode ??
+    (agent.embedToken
+      ? `<script src="https://cdn.webagent.ai/widget.js" data-token="${agent.embedToken}"></script>`
+      : "");
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-semibold text-gray-900">{agent.name ?? "Unnamed Agent"}</h1>
+            {agent.websiteUrl && (
+              <a
+                href={agent.websiteUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-1 text-sm text-indigo-600 hover:underline"
+              >
+                {agent.websiteUrl}
+              </a>
+            )}
+          </div>
+          <span
+            className={`rounded-full px-3 py-1 text-sm font-medium capitalize ${
+              statusColors[agent.status ?? ""] ?? "bg-gray-100 text-gray-600"
+            }`}
+          >
+            {agent.status ?? "unknown"}
+          </span>
+        </div>
+        {agent.createdAt && (
+          <p className="mt-2 text-xs text-gray-400">
+            Created: {new Date(agent.createdAt).toLocaleString()}
+          </p>
+        )}
+      </div>
+
+      {/* Embed code */}
+      <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-gray-900">Embed Code</h2>
+        <p className="mt-1 text-sm text-gray-500">Add this snippet to your website.</p>
+        <AgentDetailActions agentId={agent.id} embedCode={embedCode} customerId={customerId} />
+      </div>
+
+      {/* Widget preview */}
+      {agent.widgetPreviewUrl && (
+        <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-gray-900">Widget Preview</h2>
+          <iframe
+            src={agent.widgetPreviewUrl}
+            className="mt-4 h-96 w-full rounded-lg border border-gray-200"
+            title="Widget Preview"
+          />
+        </div>
+      )}
+
+      {/* Recent sessions */}
+      {agent.recentSessions && agent.recentSessions.length > 0 && (
+        <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-gray-900">Recent Sessions</h2>
+          <div className="mt-4 divide-y divide-gray-100">
+            {agent.recentSessions.map((session) => (
+              <div key={session.id} className="flex items-center justify-between py-3">
+                <span className="text-sm text-gray-700">{session.visitorId ?? session.id}</span>
+                {session.lastActive && (
+                  <span className="text-xs text-gray-400">
+                    {new Date(session.lastActive).toLocaleString()}
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/admin/src/app/dashboard/layout.tsx
+++ b/packages/admin/src/app/dashboard/layout.tsx
@@ -1,0 +1,27 @@
+import { auth } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import { DashboardNav } from "@/components/dashboard-nav";
+import { DashboardTopbar } from "@/components/dashboard-topbar";
+
+export default async function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+
+  const userEmail = session.user.email ?? "";
+
+  return (
+    <div className="flex min-h-screen">
+      <DashboardNav userEmail={userEmail} />
+      <div className="flex flex-1 flex-col lg:pl-64">
+        <DashboardTopbar userEmail={userEmail} />
+        <main className="flex-1 bg-gray-50 px-4 py-8 sm:px-6 lg:px-8">
+          <div className="mx-auto max-w-6xl">{children}</div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/app/dashboard/page.tsx
+++ b/packages/admin/src/app/dashboard/page.tsx
@@ -1,36 +1,36 @@
-import { auth } from '@/lib/auth';
-import { redirect } from 'next/navigation';
+import Link from "next/link";
+import { AgentCards } from "@/components/agent-cards";
+import { auth } from "@/lib/auth";
+import { getAgents } from "@/lib/api";
+import { normalizeCustomerIdToUuid } from "@/lib/customer-id";
+import { redirect } from "next/navigation";
 
 export default async function DashboardPage() {
   const session = await auth();
-  
-  if (!session?.user) {
-    redirect('/login');
-  }
+  if (!session?.user) redirect("/login");
+
+  const customerId = normalizeCustomerIdToUuid(session.user.id, session.user.email);
+  const agents = customerId ? await getAgents(customerId) : [];
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <header className="bg-white shadow-sm">
-        <div className="max-w-7xl mx-auto px-4 py-4 sm:px-6 lg:px-8 flex justify-between items-center">
-          <h1 className="text-xl font-semibold text-gray-900">Web Agent Dashboard</h1>
-          <div className="flex items-center gap-4">
-            <span className="text-sm text-gray-600">{session.user.email}</span>
-          </div>
+    <div className="space-y-8">
+      <div className="flex flex-col gap-4 rounded-xl border border-gray-200 bg-white p-6 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Dashboard</h1>
+          <p className="mt-1 text-sm text-gray-600">Manage and launch your web agents.</p>
         </div>
-      </header>
-      
-      <main className="max-w-7xl mx-auto px-4 py-8 sm:px-6 lg:px-8">
-        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-8 text-center">
-          <h2 className="text-2xl font-bold text-gray-900 mb-2">Welcome to Web Agent</h2>
-          <p className="text-gray-600 mb-6">Create AI chat agents for your website in minutes.</p>
-          <a
-            href="/create"
-            className="inline-flex items-center px-6 py-3 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700"
-          >
-            + Create Your First Agent
-          </a>
-        </div>
-      </main>
+        <Link
+          href="/create"
+          className="inline-flex items-center justify-center rounded-lg bg-indigo-600 px-5 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700"
+        >
+          Create New Agent
+        </Link>
+      </div>
+
+      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-gray-900">Your Agents</h2>
+        <AgentCards agents={agents} customerId={customerId} />
+      </section>
     </div>
   );
 }

--- a/packages/admin/src/app/dashboard/settings/page.tsx
+++ b/packages/admin/src/app/dashboard/settings/page.tsx
@@ -1,0 +1,8 @@
+export default function SettingsPage() {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+      <h1 className="text-2xl font-semibold text-gray-900">Settings</h1>
+      <p className="mt-2 text-sm text-gray-600">Settings coming soon.</p>
+    </div>
+  );
+}

--- a/packages/admin/src/app/layout.tsx
+++ b/packages/admin/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { ToastProvider } from "@/components/toast";
 
 export const metadata: Metadata = {
   title: "WebAgent Admin",
@@ -13,7 +14,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <ToastProvider>{children}</ToastProvider>
+      </body>
     </html>
   );
 }

--- a/packages/admin/src/components/agent-cards.tsx
+++ b/packages/admin/src/components/agent-cards.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import type { Agent } from "@/lib/api";
+import { updateAgent, deleteAgent } from "@/lib/api";
+import { useToast } from "@/components/toast";
+
+interface AgentCardsProps {
+  agents: Agent[];
+  customerId?: string;
+}
+
+const statusColors: Record<string, string> = {
+  active: "bg-green-100 text-green-800",
+  paused: "bg-yellow-100 text-yellow-800",
+  deleted: "bg-red-100 text-red-800",
+};
+
+export function AgentCards({ agents: initialAgents, customerId }: AgentCardsProps) {
+  const [agents, setAgents] = useState<Agent[]>(initialAgents);
+  const [loadingId, setLoadingId] = useState<string | null>(null);
+  const { toast } = useToast();
+
+  if (agents.length === 0) {
+    return (
+      <p className="mt-4 text-sm text-gray-500">
+        No agents yet. Create your first agent to get started!
+      </p>
+    );
+  }
+
+  const handleTogglePause = async (agent: Agent) => {
+    const newStatus = agent.status === "paused" ? "active" : "paused";
+    setLoadingId(`pause-${agent.id}`);
+    try {
+      const updated = await updateAgent(agent.id, { status: newStatus }, customerId);
+      if (updated) {
+        setAgents((prev) => prev.map((a) => (a.id === agent.id ? updated : a)));
+        toast({ message: `Agent ${newStatus === "active" ? "resumed" : "paused"}.`, type: "success" });
+      }
+    } catch (err) {
+      toast({ message: err instanceof Error ? err.message : "Failed to update agent.", type: "error" });
+    } finally {
+      setLoadingId(null);
+    }
+  };
+
+  const handleDelete = async (agent: Agent) => {
+    if (!window.confirm(`Delete agent "${agent.name ?? agent.id}"? This cannot be undone.`)) return;
+    setLoadingId(`delete-${agent.id}`);
+    try {
+      await deleteAgent(agent.id, customerId);
+      setAgents((prev) => prev.filter((a) => a.id !== agent.id));
+      toast({ message: "Agent deleted.", type: "success" });
+    } catch (err) {
+      toast({ message: err instanceof Error ? err.message : "Failed to delete agent.", type: "error" });
+    } finally {
+      setLoadingId(null);
+    }
+  };
+
+  return (
+    <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {agents.map((agent) => (
+        <div key={agent.id} className="flex flex-col rounded-xl border border-gray-200 bg-gray-50 p-5 shadow-sm">
+          <div className="flex items-start justify-between gap-2">
+            <h3 className="font-semibold text-gray-900 truncate">{agent.name ?? "Unnamed Agent"}</h3>
+            <span
+              className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${
+                statusColors[agent.status ?? ""] ?? "bg-gray-100 text-gray-600"
+              }`}
+            >
+              {agent.status ?? "unknown"}
+            </span>
+          </div>
+          {agent.websiteUrl && (
+            <p className="mt-1 truncate text-xs text-gray-500">{agent.websiteUrl}</p>
+          )}
+          <p className="mt-1 text-xs text-gray-500">
+            Sessions: {agent.sessionCount ?? 0}
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Link
+              href={`/dashboard/agents/${agent.id}`}
+              className="rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-700"
+            >
+              View Embed Code
+            </Link>
+            <button
+              onClick={() => handleTogglePause(agent)}
+              disabled={loadingId === `pause-${agent.id}` || agent.status === "deleted"}
+              className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            >
+              {loadingId === `pause-${agent.id}` ? "…" : agent.status === "paused" ? "Resume" : "Pause"}
+            </button>
+            <button
+              onClick={() => handleDelete(agent)}
+              disabled={loadingId === `delete-${agent.id}`}
+              className="rounded-md border border-red-300 bg-white px-3 py-1.5 text-xs font-medium text-red-600 hover:bg-red-50 disabled:opacity-50"
+            >
+              {loadingId === `delete-${agent.id}` ? "…" : "Delete"}
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/admin/src/components/agent-detail-actions.tsx
+++ b/packages/admin/src/components/agent-detail-actions.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+import { regenerateToken } from "@/lib/api";
+import { useToast } from "@/components/toast";
+
+interface AgentDetailActionsProps {
+  agentId: string;
+  embedCode: string;
+  customerId?: string;
+}
+
+export function AgentDetailActions({ agentId, embedCode: initialEmbedCode, customerId }: AgentDetailActionsProps) {
+  const [embedCode, setEmbedCode] = useState(initialEmbedCode);
+  const [copied, setCopied] = useState(false);
+  const [regenerating, setRegenerating] = useState(false);
+  const { toast } = useToast();
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(embedCode);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+      toast({ message: "Copied to clipboard!", type: "success" });
+    } catch {
+      toast({ message: "Failed to copy.", type: "error" });
+    }
+  };
+
+  const handleRegenerate = async () => {
+    if (!window.confirm("Regenerate embed token? The old token will stop working.")) return;
+    setRegenerating(true);
+    try {
+      const updated = await regenerateToken(agentId, customerId);
+      if (updated?.embedCode) {
+        setEmbedCode(updated.embedCode);
+        toast({ message: "Token regenerated.", type: "success" });
+      } else if (updated?.embedToken) {
+        const newCode = `<script src="https://cdn.webagent.ai/widget.js" data-token="${updated.embedToken}"></script>`;
+        setEmbedCode(newCode);
+        toast({ message: "Token regenerated.", type: "success" });
+      }
+    } catch (err) {
+      toast({ message: err instanceof Error ? err.message : "Failed to regenerate token.", type: "error" });
+    } finally {
+      setRegenerating(false);
+    }
+  };
+
+  return (
+    <div className="mt-4 space-y-3">
+      <pre className="overflow-x-auto rounded-lg bg-gray-900 p-4 text-xs text-green-400">
+        <code>{embedCode || "No embed code available."}</code>
+      </pre>
+      <div className="flex flex-wrap gap-2">
+        <button
+          onClick={handleCopy}
+          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        >
+          {copied ? "Copied!" : "Copy Code"}
+        </button>
+        <button
+          onClick={handleRegenerate}
+          disabled={regenerating}
+          className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        >
+          {regenerating ? "Regenerating…" : "Regenerate Token"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/components/create-agent-chat.tsx
+++ b/packages/admin/src/components/create-agent-chat.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { createAgentViaMetaAgent, type MetaAgentMessage } from "@/lib/api";
+
+const STAGE_PROMPTS = [
+  "Great — tell me about your website and product.",
+  "Nice. What API endpoints, auth, or data sources should the agent use?",
+  "Got it. What personality and tone should the assistant have?",
+  "Perfect. Reply with any final tweaks, or type 'create' to build your agent.",
+] as const;
+
+const systemPrompt: MetaAgentMessage = {
+  role: "system",
+  content:
+    "You are helping create a website chat agent. Progress through website/product, API context, personality, then confirm/create. Keep responses short and actionable.",
+};
+
+export function CreateAgentChat() {
+  const [messages, setMessages] = useState<MetaAgentMessage[]>([
+    systemPrompt,
+    { role: "assistant", content: STAGE_PROMPTS[0] },
+  ]);
+  const [stage, setStage] = useState(0);
+  const [input, setInput] = useState("");
+  const [sessionId, setSessionId] = useState<string | undefined>();
+  const [loading, setLoading] = useState(false);
+  const [embedCode, setEmbedCode] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  const visibleMessages = useMemo(
+    () => messages.filter((message) => message.role !== "system"),
+    [messages],
+  );
+
+  const onSend = async () => {
+    const text = input.trim();
+    if (!text || loading) {
+      return;
+    }
+
+    setCopied(false);
+
+    const userMessage: MetaAgentMessage = { role: "user", content: text };
+    const nextMessages = [...messages, userMessage];
+
+    setMessages(nextMessages);
+    setInput("");
+    setLoading(true);
+
+    try {
+      const result = await createAgentViaMetaAgent(nextMessages, sessionId);
+      const assistantReply = result.response ?? result.message;
+      const nextSessionId = result.sessionId ?? result.session?.id ?? sessionId;
+      const nextEmbedCode = result.embedCode ?? result.agent?.embedCode ?? "";
+
+      const updatedMessages = [...nextMessages];
+
+      if (assistantReply) {
+        updatedMessages.push({ role: "assistant", content: assistantReply });
+      }
+
+      if (nextEmbedCode) {
+        setEmbedCode(nextEmbedCode);
+      } else if (stage < STAGE_PROMPTS.length - 1) {
+        const nextStage = stage + 1;
+        const nextPrompt = STAGE_PROMPTS[nextStage];
+        setStage(nextStage);
+        if (nextPrompt) {
+          updatedMessages.push({ role: "assistant", content: nextPrompt });
+        }
+      }
+
+      setSessionId(nextSessionId);
+      setMessages(updatedMessages);
+    } catch (error) {
+      setMessages((previous) => [
+        ...previous,
+        {
+          role: "assistant",
+          content: error instanceof Error ? error.message : "Failed to create agent.",
+        },
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onCopyEmbedCode = async () => {
+    if (!embedCode) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(embedCode);
+      setCopied(true);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+      <div className="max-h-[460px] space-y-3 overflow-y-auto rounded-lg border border-gray-200 bg-gray-50 p-4">
+        {visibleMessages.map((message, index) => {
+          const isUser = message.role === "user";
+
+          return (
+            <div key={`${message.role}-${index}`} className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
+              <div
+                className={`max-w-[85%] rounded-2xl px-4 py-3 text-sm ${
+                  isUser ? "bg-indigo-600 text-white" : "border border-gray-200 bg-white text-gray-800"
+                }`}
+              >
+                {message.content}
+              </div>
+            </div>
+          );
+        })}
+
+        {loading ? (
+          <div className="flex justify-start">
+            <div className="rounded-2xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-500">
+              Thinking...
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      {embedCode ? (
+        <div className="mt-4 rounded-lg border border-emerald-200 bg-emerald-50 p-4">
+          <div className="mb-2 flex items-center justify-between">
+            <p className="text-sm font-medium text-emerald-900">Embed Snippet</p>
+            <button
+              type="button"
+              onClick={onCopyEmbedCode}
+              className="rounded-md border border-emerald-300 bg-white px-3 py-1 text-xs font-medium text-emerald-800 hover:bg-emerald-100"
+            >
+              {copied ? "Copied" : "Copy"}
+            </button>
+          </div>
+          <pre className="overflow-x-auto rounded-md bg-gray-900 p-3 text-xs text-emerald-100">
+            <code>{embedCode}</code>
+          </pre>
+        </div>
+      ) : null}
+
+      <div className="mt-4 flex gap-2">
+        <input
+          type="text"
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              void onSend();
+            }
+          }}
+          placeholder="Type your message..."
+          className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm"
+          disabled={loading}
+        />
+        <button
+          type="button"
+          onClick={() => {
+            void onSend();
+          }}
+          disabled={loading || input.trim().length === 0}
+          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-60"
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/components/dashboard-nav.tsx
+++ b/packages/admin/src/components/dashboard-nav.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { signOut } from "next-auth/react";
+
+const navItems = [
+  { label: "Dashboard", href: "/dashboard" },
+  { label: "Create Agent", href: "/create" },
+  { label: "Settings", href: "/dashboard/settings" },
+];
+
+interface DashboardNavProps {
+  userEmail: string;
+}
+
+export function DashboardNav({ userEmail }: DashboardNavProps) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const pathname = usePathname();
+
+  const NavLinks = () => (
+    <nav className="flex-1 space-y-1 px-4 py-6">
+      {navItems.map((item) => {
+        const isActive = pathname === item.href || (item.href !== "/dashboard" && pathname.startsWith(item.href));
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            onClick={() => setSidebarOpen(false)}
+            className={`block rounded-lg px-3 py-2 text-sm font-medium transition ${
+              isActive
+                ? "bg-gray-800 text-white"
+                : "text-gray-300 hover:bg-gray-800 hover:text-white"
+            }`}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+
+  return (
+    <>
+      {/* Mobile top bar */}
+      <div className="fixed inset-x-0 top-0 z-30 flex items-center justify-between bg-gray-900 px-4 py-3 lg:hidden">
+        <span className="text-sm font-semibold text-white">WebAgent Admin</span>
+        <button
+          onClick={() => setSidebarOpen((o) => !o)}
+          className="rounded p-1 text-gray-300 hover:text-white"
+          aria-label="Toggle menu"
+        >
+          <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            {sidebarOpen ? (
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            ) : (
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+            )}
+          </svg>
+        </button>
+      </div>
+
+      {/* Mobile overlay */}
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 z-20 bg-black/50 lg:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+
+      {/* Sidebar */}
+      <aside
+        className={`fixed inset-y-0 left-0 z-40 flex w-64 flex-col bg-gray-900 transition-transform duration-200 lg:translate-x-0 ${
+          sidebarOpen ? "translate-x-0" : "-translate-x-full"
+        }`}
+      >
+        <div className="flex h-16 items-center px-6">
+          <span className="text-lg font-bold text-white">WebAgent Admin</span>
+        </div>
+        <NavLinks />
+        <div className="border-t border-gray-700 px-4 py-4">
+          <p className="truncate text-xs text-gray-400">{userEmail}</p>
+          <button
+            onClick={() => signOut({ callbackUrl: "/login" })}
+            className="mt-2 w-full rounded-lg bg-gray-800 px-3 py-2 text-left text-sm text-gray-300 hover:bg-gray-700 hover:text-white"
+          >
+            Sign Out
+          </button>
+        </div>
+      </aside>
+
+      {/* Spacer for mobile top bar */}
+      <div className="h-12 w-full lg:hidden" />
+    </>
+  );
+}

--- a/packages/admin/src/components/dashboard-topbar.tsx
+++ b/packages/admin/src/components/dashboard-topbar.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { signOut } from "next-auth/react";
+
+interface DashboardTopbarProps {
+  userEmail: string;
+}
+
+export function DashboardTopbar({ userEmail }: DashboardTopbarProps) {
+  const initial = userEmail.charAt(0).toUpperCase();
+
+  return (
+    <header className="flex items-center justify-end gap-3 border-b border-gray-200 bg-white px-4 py-3 sm:px-6 lg:px-8">
+      <span className="hidden sm:block max-w-[220px] truncate text-sm text-gray-600">
+        {userEmail}
+      </span>
+      <div
+        className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-gray-800 text-sm font-semibold text-white"
+        aria-label={`User: ${userEmail}`}
+      >
+        {initial}
+      </div>
+      <button
+        onClick={() => signOut({ callbackUrl: "/login" })}
+        className="rounded-lg bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-200"
+      >
+        Sign out
+      </button>
+    </header>
+  );
+}

--- a/packages/admin/src/components/toast.tsx
+++ b/packages/admin/src/components/toast.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { createContext, useCallback, useContext, useState } from "react";
+
+type ToastType = "success" | "error" | "info";
+
+interface ToastItem {
+  id: number;
+  message: string;
+  type: ToastType;
+}
+
+interface ToastOptions {
+  message: string;
+  type?: ToastType;
+}
+
+interface ToastContextValue {
+  toast: (opts: ToastOptions) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+let nextId = 0;
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const toast = useCallback(({ message, type = "info" }: ToastOptions) => {
+    const id = ++nextId;
+    setToasts((prev) => [...prev, { id, message, type }]);
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 4000);
+  }, []);
+
+  const colorMap: Record<ToastType, string> = {
+    success: "bg-green-600",
+    error: "bg-red-600",
+    info: "bg-indigo-600",
+  };
+
+  return (
+    <ToastContext.Provider value={{ toast }}>
+      {children}
+      <div className="fixed right-4 top-4 z-50 flex flex-col gap-2">
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            className={`max-w-sm rounded-lg px-4 py-3 text-sm text-white shadow-lg ${colorMap[t.type]}`}
+          >
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used within ToastProvider");
+  return ctx;
+}

--- a/packages/admin/src/lib/api.ts
+++ b/packages/admin/src/lib/api.ts
@@ -1,0 +1,327 @@
+const API_BASE_URL = process.env.NEXT_PUBLIC_PROXY_URL ?? "";
+
+type JsonObject = Record<string, unknown>;
+
+export type AgentStatus = "active" | "paused" | "deleted";
+
+export interface AgentSessionSummary {
+  id: string;
+  visitorId?: string;
+  lastActive?: string;
+  createdAt?: string;
+  [key: string]: unknown;
+}
+
+export interface Agent {
+  id: string;
+  name?: string;
+  websiteUrl?: string;
+  status?: AgentStatus | string;
+  sessionCount?: number;
+  embedCode?: string;
+  embedToken?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  recentSessions?: AgentSessionSummary[];
+  widgetPreviewUrl?: string;
+  [key: string]: unknown;
+}
+
+export interface MetaAgentMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+  [key: string]: unknown;
+}
+
+export interface CreateViaMetaAgentRequest {
+  messages: MetaAgentMessage[];
+  sessionId?: string;
+}
+
+export interface CreateViaMetaAgentResponse {
+  sessionId?: string;
+  session?: {
+    id?: string;
+    [key: string]: unknown;
+  };
+  agent?: Agent;
+  response?: string;
+  message?: string;
+  embedCode?: string;
+  [key: string]: unknown;
+}
+
+interface ApiEnvelope<T> {
+  data?: T;
+  item?: T;
+  payload?: T;
+  items?: T[];
+  message?: string;
+  error?: string;
+  [key: string]: unknown;
+}
+
+const isRecord = (value: unknown): value is JsonObject =>
+  typeof value === "object" && value !== null;
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === "string" ? value : undefined;
+
+const asNumber = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value)
+    ? value
+    : typeof value === "string" && value.trim() !== "" && !Number.isNaN(Number(value))
+      ? Number(value)
+      : undefined;
+
+const withApiPath = (path: string): string => {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  const fullPath = normalizedPath.startsWith("/api")
+    ? normalizedPath
+    : `/api${normalizedPath}`;
+
+  return `${API_BASE_URL}${fullPath}`;
+};
+
+const parseSessionSummary = (value: unknown): AgentSessionSummary | undefined => {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const id = asString(value.id) ?? asString(value.sessionId);
+  if (!id) {
+    return undefined;
+  }
+
+  return {
+    ...value,
+    id,
+    visitorId: asString(value.visitorId) ?? asString(value.externalUserId),
+    lastActive: asString(value.lastActive) ?? asString(value.updatedAt),
+    createdAt: asString(value.createdAt),
+  };
+};
+
+const parseAgent = (value: unknown): Agent | undefined => {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const id = asString(value.id);
+  if (!id) {
+    return undefined;
+  }
+
+  const recentSessionsRaw =
+    Array.isArray(value.recentSessions)
+      ? value.recentSessions
+      : Array.isArray(value.sessions)
+        ? value.sessions
+        : [];
+
+  return {
+    ...value,
+    id,
+    name: asString(value.name),
+    websiteUrl: asString(value.websiteUrl) ?? asString(value.website_url),
+    status: asString(value.status),
+    sessionCount:
+      asNumber(value.sessionCount) ??
+      asNumber(value.visitorCount) ??
+      asNumber(value.session_count),
+    embedCode: asString(value.embedCode) ?? asString(value.embed_code) ?? asString(value.scriptTag),
+    embedToken: asString(value.embedToken) ?? asString(value.embed_token),
+    createdAt: asString(value.createdAt) ?? asString(value.created_at),
+    updatedAt: asString(value.updatedAt) ?? asString(value.updated_at),
+    widgetPreviewUrl:
+      asString(value.widgetPreviewUrl) ?? asString(value.previewUrl) ?? asString(value.widget_preview_url),
+    recentSessions: recentSessionsRaw
+      .map(parseSessionSummary)
+      .filter((session): session is AgentSessionSummary => !!session),
+  };
+};
+
+const parseCreateViaMetaAgentResponse = (value: unknown): CreateViaMetaAgentResponse => {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  const session = isRecord(value.session) ? value.session : undefined;
+
+  return {
+    ...value,
+    session,
+    sessionId:
+      asString(value.sessionId) ??
+      asString(value.session_id) ??
+      (session ? asString(session.id) : undefined),
+    response: asString(value.response) ?? asString(value.reply),
+    message: asString(value.message),
+    embedCode: asString(value.embedCode) ?? asString(value.embed_code),
+    agent: parseAgent(value.agent),
+  };
+};
+
+const safeJson = async (response: Response): Promise<unknown> => {
+  const text = await response.text();
+  if (!text) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+};
+
+const getApiToken = (): string | undefined => {
+  if (typeof window !== "undefined") {
+    return process.env.NEXT_PUBLIC_PROXY_API_TOKEN;
+  }
+
+  return process.env.PROXY_CUSTOMER_API_TOKEN ?? process.env.PROXY_API_TOKEN;
+};
+
+const extractErrorMessage = (payload: unknown, statusText: string): string => {
+  if (isRecord(payload)) {
+    if (typeof payload.error === "string") {
+      return payload.error;
+    }
+
+    if (isRecord(payload.error) && typeof payload.error.message === "string") {
+      return payload.error.message;
+    }
+  }
+
+  return statusText;
+};
+
+const request = async <T>(
+  path: string,
+  init?: RequestInit,
+): Promise<T | undefined> => {
+  const token = getApiToken();
+  const headers = new Headers(init?.headers);
+  headers.set("Content-Type", "application/json");
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+
+  const response = await fetch(withApiPath(path), {
+    cache: "no-store",
+    ...init,
+    headers,
+  });
+
+  const payload = await safeJson(response);
+
+  if (!response.ok) {
+    const message = extractErrorMessage(payload, response.statusText);
+    throw new Error(message || `Request failed with ${response.status}`);
+  }
+
+  return payload as T | undefined;
+};
+
+const unwrapOne = (value: unknown): unknown => {
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  if ("data" in value) {
+    return value.data;
+  }
+
+  if ("item" in value) {
+    return value.item;
+  }
+
+  if ("payload" in value && !Array.isArray(value.payload)) {
+    return value.payload;
+  }
+
+  return value;
+};
+
+export async function getAgents(customerId?: string): Promise<Agent[]> {
+  const query = customerId ? `?customerId=${encodeURIComponent(customerId)}` : "";
+  const payload = await request<ApiEnvelope<unknown> | unknown[]>(`/api/agents${query}`);
+
+  const list = Array.isArray(payload)
+    ? payload
+    : isRecord(payload)
+      ? Array.isArray(payload.data)
+        ? payload.data
+        : Array.isArray(payload.items)
+          ? payload.items
+          : isRecord(payload.payload) && Array.isArray(payload.payload.agents)
+            ? payload.payload.agents
+            : Array.isArray(payload.payload)
+              ? payload.payload
+              : []
+      : [];
+
+  return list.map(parseAgent).filter((agent): agent is Agent => !!agent);
+}
+
+const withCustomerId = (path: string, customerId?: string): string =>
+  customerId ? `${path}?customerId=${encodeURIComponent(customerId)}` : path;
+
+export async function getAgent(id: string, customerId?: string): Promise<Agent | undefined> {
+  const payload = await request<ApiEnvelope<unknown> | unknown>(
+    withCustomerId(`/api/agents/${encodeURIComponent(id)}`, customerId),
+  );
+
+  return parseAgent(unwrapOne(payload));
+}
+
+export async function createAgentViaMetaAgent(
+  messages: MetaAgentMessage[],
+  sessionId?: string,
+): Promise<CreateViaMetaAgentResponse> {
+  const payload = await request<ApiEnvelope<unknown> | unknown>(
+    "/api/agents/create-via-meta",
+    {
+      method: "POST",
+      body: JSON.stringify({ messages, sessionId } satisfies CreateViaMetaAgentRequest),
+    },
+  );
+
+  return parseCreateViaMetaAgentResponse(unwrapOne(payload));
+}
+
+export async function updateAgent(
+  id: string,
+  data: Partial<Agent>,
+  customerId?: string,
+): Promise<Agent | undefined> {
+  const payload = await request<ApiEnvelope<unknown> | unknown>(
+    withCustomerId(`/api/agents/${encodeURIComponent(id)}`, customerId),
+    {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    },
+  );
+
+  return parseAgent(unwrapOne(payload));
+}
+
+export async function deleteAgent(id: string, customerId?: string): Promise<boolean> {
+  await request(withCustomerId(`/api/agents/${encodeURIComponent(id)}`, customerId), {
+    method: "DELETE",
+  });
+
+  return true;
+}
+
+export async function regenerateToken(id: string, customerId?: string): Promise<Agent | undefined> {
+  const payload = await request<ApiEnvelope<unknown> | unknown>(
+    withCustomerId(`/api/agents/${encodeURIComponent(id)}/embed-token`, customerId),
+    {
+      method: "POST",
+    },
+  );
+
+  return parseAgent(unwrapOne(payload));
+}

--- a/packages/admin/src/lib/customer-id.ts
+++ b/packages/admin/src/lib/customer-id.ts
@@ -1,0 +1,44 @@
+import "server-only";
+import { createHash } from "node:crypto";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const normalize = (value?: string | null): string | undefined => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const toDeterministicUuid = (value: string): string => {
+  const bytes = createHash("sha256").update(value).digest().subarray(0, 16);
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x50;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+
+  const hex = Buffer.from(bytes).toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+};
+
+export function normalizeCustomerIdToUuid(
+  userId?: string | null,
+  email?: string | null,
+): string | undefined {
+  const normalizedUserId = normalize(userId);
+  if (normalizedUserId) {
+    if (UUID_RE.test(normalizedUserId)) {
+      return normalizedUserId;
+    }
+
+    return toDeterministicUuid(normalizedUserId);
+  }
+
+  const normalizedEmail = normalize(email);
+  if (normalizedEmail) {
+    return toDeterministicUuid(normalizedEmail);
+  }
+
+  return undefined;
+}

--- a/packages/proxy/src/db/auth-schema.ts
+++ b/packages/proxy/src/db/auth-schema.ts
@@ -1,0 +1,55 @@
+import { integer, pgTable, primaryKey, text, timestamp } from 'drizzle-orm/pg-core';
+
+export const users = pgTable('users', {
+  id: text('id').primaryKey(),
+  name: text('name'),
+  email: text('email').notNull(),
+  emailVerified: timestamp('emailVerified', { mode: 'date' }),
+  image: text('image'),
+});
+
+export const accounts = pgTable(
+  'accounts',
+  {
+    userId: text('userId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    type: text('type').notNull(),
+    provider: text('provider').notNull(),
+    providerAccountId: text('providerAccountId').notNull(),
+    refresh_token: text('refresh_token'),
+    access_token: text('access_token'),
+    expires_at: integer('expires_at'),
+    token_type: text('token_type'),
+    scope: text('scope'),
+    id_token: text('id_token'),
+    session_state: text('session_state'),
+  },
+  (account) => ({
+    compoundKey: primaryKey({
+      columns: [account.provider, account.providerAccountId],
+    }),
+  }),
+);
+
+export const sessions = pgTable('sessions', {
+  sessionToken: text('sessionToken').primaryKey(),
+  userId: text('userId')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  expires: timestamp('expires', { mode: 'date' }).notNull(),
+});
+
+export const verificationTokens = pgTable(
+  'verification_tokens',
+  {
+    identifier: text('identifier').notNull(),
+    token: text('token').notNull(),
+    expires: timestamp('expires', { mode: 'date' }).notNull(),
+  },
+  (verificationToken) => ({
+    compositePk: primaryKey({
+      columns: [verificationToken.identifier, verificationToken.token],
+    }),
+  }),
+);

--- a/packages/proxy/src/db/plugin.ts
+++ b/packages/proxy/src/db/plugin.ts
@@ -1,0 +1,14 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { loadConfig } from '../config.js';
+import { createDb, type Database } from './client.js';
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    db: Database;
+  }
+}
+
+export const dbPlugin: FastifyPluginAsync = async (fastify) => {
+  const config = loadConfig();
+  fastify.decorate('db', createDb(config.databaseUrl));
+};

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -2,21 +2,67 @@ import Fastify from 'fastify';
 import websocket from '@fastify/websocket';
 
 import { loadConfig } from './config.js';
-import { handleConnection } from './ws/handler.js';
-import { registerWidgetRoutes } from './routes/widget.js';
+import { dbPlugin } from './db/plugin.js';
+import { registerApiRoutes } from './routes/api.js';
 import { registerHealthRoutes } from './routes/health.js';
+import { registerWidgetRoutes } from './routes/widget.js';
+import { handleConnection } from './ws/handler.js';
 import { DEFAULT_WS_PATH } from '@webagent/shared/constants';
+
+interface ManagedSocket {
+  close(code?: number, data?: string): void;
+  on(event: 'close', listener: () => void): void;
+}
 
 const config = loadConfig();
 const app = Fastify({ logger: true });
+const activeSockets = new Set<ManagedSocket>();
 
 await app.register(websocket);
+await app.register(dbPlugin);
 
 registerHealthRoutes(app);
 registerWidgetRoutes(app);
+registerApiRoutes(app);
 
-app.get(DEFAULT_WS_PATH, { websocket: true }, (connection) => {
-  handleConnection(connection.socket);
+app.get(DEFAULT_WS_PATH, { websocket: true }, (connection, request) => {
+  const socket = connection.socket as ManagedSocket;
+  activeSockets.add(socket);
+  socket.on('close', () => {
+    activeSockets.delete(socket);
+  });
+
+  const origin = typeof request.headers.origin === 'string' ? request.headers.origin : undefined;
+  handleConnection(connection.socket, { db: app.db, origin });
+});
+
+let shuttingDown = false;
+
+const shutdown = async (signal: 'SIGTERM' | 'SIGINT'): Promise<void> => {
+  if (shuttingDown) {
+    return;
+  }
+
+  shuttingDown = true;
+  app.log.info({ signal, sockets: activeSockets.size }, 'shutting down proxy server');
+
+  for (const socket of activeSockets) {
+    try {
+      socket.close(1001, 'Going Away');
+    } catch (error) {
+      app.log.warn({ error }, 'failed to close websocket during shutdown');
+    }
+  }
+
+  await app.close();
+};
+
+process.once('SIGTERM', () => {
+  void shutdown('SIGTERM');
+});
+
+process.once('SIGINT', () => {
+  void shutdown('SIGINT');
 });
 
 const start = async (): Promise<void> => {
@@ -24,7 +70,7 @@ const start = async (): Promise<void> => {
     await app.listen({ host: '0.0.0.0', port: config.port });
     app.log.info(
       { port: config.port, openClawHooksUrl: config.openClawHooksUrl },
-      'proxy server started'
+      'proxy server started',
     );
   } catch (error) {
     app.log.error(error, 'failed to start proxy server');

--- a/packages/proxy/src/openclaw/client.ts
+++ b/packages/proxy/src/openclaw/client.ts
@@ -32,6 +32,7 @@ export class OpenClawClient {
       body: JSON.stringify({
         message: opts.message,
         agentId: opts.agentId,
+        sessionKey: opts.sessionKey,
         name: opts.name || 'widget-chat',
         wakeMode: 'now',
       }),

--- a/packages/proxy/src/openclaw/sessions.ts
+++ b/packages/proxy/src/openclaw/sessions.ts
@@ -1,24 +1,44 @@
-// In-memory session map (will later use DB)
-const sessionMap = new Map<string, string>();
+import { and, eq } from 'drizzle-orm';
+import type { Database } from '../db/client.js';
+import { widgetSessions } from '../db/schema.js';
 
 function sessionKey(agentId: string, userId: string): string {
   return `widget:${agentId}:${userId}`;
 }
 
-export function getOrCreateSession(agentId: string, userId: string): string {
-  const key = `${agentId}::${userId}`;
-  let session = sessionMap.get(key);
-  if (!session) {
-    session = sessionKey(agentId, userId);
-    sessionMap.set(key, session);
-  }
-  return session;
+export async function getOrCreateSession(
+  db: Database,
+  agentId: string,
+  userId: string,
+): Promise<string> {
+  const openclawSessionKey = sessionKey(agentId, userId);
+
+  await db
+    .insert(widgetSessions)
+    .values({
+      agentId,
+      externalUserId: userId,
+      openclawSessionKey,
+      lastActiveAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: [widgetSessions.agentId, widgetSessions.externalUserId],
+      set: {
+        openclawSessionKey,
+        lastActiveAt: new Date(),
+      },
+    });
+
+  return openclawSessionKey;
 }
 
-export function getSession(agentId: string, userId: string): string | undefined {
-  return sessionMap.get(`${agentId}::${userId}`);
-}
-
-export function removeSession(agentId: string, userId: string): boolean {
-  return sessionMap.delete(`${agentId}::${userId}`);
+export async function touchSessionLastActiveAt(
+  db: Database,
+  agentId: string,
+  userId: string,
+): Promise<void> {
+  await db
+    .update(widgetSessions)
+    .set({ lastActiveAt: new Date() })
+    .where(and(eq(widgetSessions.agentId, agentId), eq(widgetSessions.externalUserId, userId)));
 }

--- a/packages/proxy/src/routes/api.ts
+++ b/packages/proxy/src/routes/api.ts
@@ -1,0 +1,431 @@
+import { randomUUID } from 'node:crypto';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { and, count, eq, ne } from 'drizzle-orm';
+import { z } from 'zod';
+import { agents, widgetEmbeds, widgetSessions } from '../db/schema.js';
+import { invalidateEmbedTokenCache } from '../ws/handler.js';
+
+const localhostIps = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+
+const createInternalAgentBodySchema = z.object({
+  customerId: z.string().uuid(),
+  openclawAgentId: z.string().min(1),
+  name: z.string().min(1),
+  websiteUrl: z.string().url().optional(),
+  description: z.string().optional(),
+  apiDescription: z.string().optional(),
+  widgetConfig: z.record(z.string(), z.unknown()).optional(),
+  allowedOrigins: z.array(z.string().min(1)).optional(),
+});
+
+const agentsQuerySchema = z.object({
+  customerId: z.string().uuid(),
+});
+
+const idParamsSchema = z.object({
+  id: z.string().uuid(),
+});
+
+const updateAgentBodySchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    websiteUrl: z.string().url().nullable().optional(),
+    description: z.string().nullable().optional(),
+    status: z.string().min(1).optional(),
+    widgetConfig: z.record(z.string(), z.unknown()).optional(),
+    apiDescription: z.string().nullable().optional(),
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: 'At least one field is required',
+  });
+
+const createEmbedBodySchema = z.object({
+  allowedOrigins: z.array(z.string().min(1)).optional(),
+});
+
+function sendError(
+  reply: FastifyReply,
+  statusCode: number,
+  code: string,
+  message: string,
+  details?: unknown,
+) {
+  return reply.status(statusCode).send({
+    error: {
+      code,
+      message,
+      details,
+    },
+  });
+}
+
+function parseOrError<T>(
+  schema: z.ZodSchema<T>,
+  input: unknown,
+  reply: FastifyReply,
+  code: string,
+): T | null {
+  const parsed = schema.safeParse(input);
+  if (parsed.success) {
+    return parsed.data;
+  }
+
+  sendError(reply, 400, code, 'Validation failed', parsed.error.flatten());
+  return null;
+}
+
+function isLocalhost(request: FastifyRequest): boolean {
+  if (localhostIps.has(request.ip)) return true;
+
+  const remoteAddress = request.raw.socket.remoteAddress;
+  if (!remoteAddress) return false;
+  return localhostIps.has(remoteAddress);
+}
+
+function readBearerToken(request: FastifyRequest): string | null {
+  const value = request.headers.authorization;
+  if (!value) return null;
+
+  const [scheme, token] = value.split(' ');
+  if (scheme?.toLowerCase() !== 'bearer' || !token) {
+    return null;
+  }
+
+  return token;
+}
+
+function getCustomerApiToken(): string | null {
+  return (
+    process.env.PROXY_CUSTOMER_API_TOKEN?.trim()
+    || process.env.PROXY_API_TOKEN?.trim()
+    || process.env.OPENCLAW_HOOKS_TOKEN?.trim()
+    || null
+  );
+}
+
+function requireCustomerAuth(request: FastifyRequest, reply: FastifyReply): boolean {
+  const expected = getCustomerApiToken();
+  if (!expected) {
+    sendError(reply, 500, 'missing_api_token', 'Server API token is not configured');
+    return false;
+  }
+
+  const token = readBearerToken(request);
+  if (!token || token !== expected) {
+    sendError(reply, 401, 'unauthorized', 'Invalid or missing bearer token');
+    return false;
+  }
+
+  return true;
+}
+
+export function registerApiRoutes(app: FastifyInstance) {
+  app.post('/api/internal/agents', async (request, reply) => {
+    if (!isLocalhost(request)) {
+      return sendError(reply, 403, 'forbidden', 'Route is restricted to localhost requests');
+    }
+
+    const body = parseOrError(
+      createInternalAgentBodySchema,
+      request.body,
+      reply,
+      'invalid_internal_agent_payload',
+    );
+    if (!body) return;
+
+    try {
+      const createdAgentRows = await app.db
+        .insert(agents)
+        .values({
+          customerId: body.customerId,
+          openclawAgentId: body.openclawAgentId,
+          name: body.name,
+          websiteUrl: body.websiteUrl,
+          description: body.description,
+          status: 'active',
+          widgetConfig: body.widgetConfig ?? {},
+          apiDescription: body.apiDescription,
+          updatedAt: new Date(),
+        })
+        .returning();
+
+      const createdAgent = createdAgentRows[0];
+      if (!createdAgent) {
+        return sendError(reply, 500, 'agent_create_failed', 'Failed to create agent');
+      }
+
+      const embedToken = randomUUID();
+      const createdEmbedRows = await app.db
+        .insert(widgetEmbeds)
+        .values({
+          agentId: createdAgent.id,
+          embedToken,
+          allowedOrigins: body.allowedOrigins,
+        })
+        .returning();
+
+      return reply.status(201).send({
+        agent: createdAgent,
+        embedToken,
+      });
+    } catch (error) {
+      request.log.error({ error }, 'failed to create internal agent');
+      return sendError(reply, 500, 'internal_error', 'Failed to create internal agent');
+    }
+  });
+
+  app.get('/api/agents', async (request, reply) => {
+    if (!requireCustomerAuth(request, reply)) return;
+
+    const query = parseOrError(agentsQuerySchema, request.query, reply, 'invalid_agents_query');
+    if (!query) return;
+
+    try {
+      const rows = await app.db
+        .select()
+        .from(agents)
+        .where(and(eq(agents.customerId, query.customerId), ne(agents.status, 'deleted')));
+
+      const sessionCountRows = await app.db
+        .select({
+          agentId: widgetSessions.agentId,
+          sessionCount: count(widgetSessions.id),
+        })
+        .from(widgetSessions)
+        .innerJoin(agents, eq(widgetSessions.agentId, agents.id))
+        .where(and(eq(agents.customerId, query.customerId), ne(agents.status, 'deleted')))
+        .groupBy(widgetSessions.agentId);
+
+      const sessionCountByAgentId = new Map(
+        sessionCountRows.map((row) => [row.agentId, Number(row.sessionCount) || 0]),
+      );
+
+      return reply.send({
+        data: rows.map((row) => ({
+          ...row,
+          sessionCount: sessionCountByAgentId.get(row.id) ?? 0,
+        })),
+      });
+    } catch (error) {
+      request.log.error({ error }, 'failed to list agents');
+      return sendError(reply, 500, 'internal_error', 'Failed to list agents');
+    }
+  });
+
+  app.get('/api/agents/:id', async (request, reply) => {
+    if (!requireCustomerAuth(request, reply)) return;
+
+    const params = parseOrError(idParamsSchema, request.params, reply, 'invalid_agent_id');
+    if (!params) return;
+    const query = parseOrError(agentsQuerySchema, request.query, reply, 'invalid_agents_query');
+    if (!query) return;
+
+    try {
+      const rows = await app.db
+        .select()
+        .from(agents)
+        .where(
+          and(
+            eq(agents.id, params.id),
+            eq(agents.customerId, query.customerId),
+            ne(agents.status, 'deleted'),
+          ),
+        )
+        .limit(1);
+      const agent = rows[0];
+      if (!agent) {
+        return sendError(reply, 404, 'not_found', 'Agent not found');
+      }
+
+      const embedRows = await app.db
+        .select()
+        .from(widgetEmbeds)
+        .where(eq(widgetEmbeds.agentId, params.id))
+        .limit(1);
+      const embed = embedRows[0] ?? null;
+
+      return reply.send({
+        data: {
+          ...agent,
+          embed,
+          embedToken: embed?.embedToken ?? null,
+          allowedOrigins: embed?.allowedOrigins ?? null,
+        },
+      });
+    } catch (error) {
+      request.log.error({ error }, 'failed to fetch agent');
+      return sendError(reply, 500, 'internal_error', 'Failed to fetch agent');
+    }
+  });
+
+  app.patch('/api/agents/:id', async (request, reply) => {
+    if (!requireCustomerAuth(request, reply)) return;
+
+    const params = parseOrError(idParamsSchema, request.params, reply, 'invalid_agent_id');
+    if (!params) return;
+
+    const query = parseOrError(agentsQuerySchema, request.query, reply, 'invalid_agents_query');
+    if (!query) return;
+
+    const body = parseOrError(updateAgentBodySchema, request.body, reply, 'invalid_agent_patch');
+    if (!body) return;
+
+    try {
+      const existingAgentRows = await app.db
+        .select()
+        .from(agents)
+        .where(
+          and(
+            eq(agents.id, params.id),
+            eq(agents.customerId, query.customerId),
+            ne(agents.status, 'deleted'),
+          ),
+        )
+        .limit(1);
+      const existingAgent = existingAgentRows[0];
+      if (!existingAgent) {
+        return sendError(reply, 404, 'not_found', 'Agent not found');
+      }
+
+      const updatedRows = await app.db
+        .update(agents)
+        .set({
+          ...body,
+          updatedAt: new Date(),
+        })
+        .where(and(eq(agents.id, params.id), eq(agents.customerId, query.customerId)))
+        .returning();
+
+      const updated = updatedRows[0];
+      if (!updated) {
+        return sendError(reply, 404, 'not_found', 'Agent not found');
+      }
+
+      if (body.status && body.status !== existingAgent.status) {
+        const embedRows = await app.db
+          .select({ embedToken: widgetEmbeds.embedToken })
+          .from(widgetEmbeds)
+          .where(eq(widgetEmbeds.agentId, params.id));
+        for (const embedRow of embedRows) {
+          invalidateEmbedTokenCache(embedRow.embedToken);
+        }
+      }
+
+      return reply.send({ data: updated });
+    } catch (error) {
+      request.log.error({ error }, 'failed to update agent');
+      return sendError(reply, 500, 'internal_error', 'Failed to update agent');
+    }
+  });
+
+  app.delete('/api/agents/:id', async (request, reply) => {
+    if (!requireCustomerAuth(request, reply)) return;
+
+    const params = parseOrError(idParamsSchema, request.params, reply, 'invalid_agent_id');
+    if (!params) return;
+
+    const query = parseOrError(agentsQuerySchema, request.query, reply, 'invalid_agents_query');
+    if (!query) return;
+
+    try {
+      const embedRows = await app.db
+        .select({ embedToken: widgetEmbeds.embedToken })
+        .from(widgetEmbeds)
+        .innerJoin(agents, eq(widgetEmbeds.agentId, agents.id))
+        .where(and(eq(agents.id, params.id), eq(agents.customerId, query.customerId)));
+
+      const updatedRows = await app.db
+        .update(agents)
+        .set({
+          status: 'deleted',
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(agents.id, params.id),
+            eq(agents.customerId, query.customerId),
+            ne(agents.status, 'deleted'),
+          ),
+        )
+        .returning();
+
+      const updated = updatedRows[0];
+      if (!updated) {
+        return sendError(reply, 404, 'not_found', 'Agent not found');
+      }
+
+      for (const embedRow of embedRows) {
+        invalidateEmbedTokenCache(embedRow.embedToken);
+      }
+
+      return reply.send({ data: updated });
+    } catch (error) {
+      request.log.error({ error }, 'failed to soft delete agent');
+      return sendError(reply, 500, 'internal_error', 'Failed to soft delete agent');
+    }
+  });
+
+  app.post('/api/agents/:id/embed-token', async (request, reply) => {
+    if (!requireCustomerAuth(request, reply)) return;
+
+    const params = parseOrError(idParamsSchema, request.params, reply, 'invalid_agent_id');
+    if (!params) return;
+
+    const query = parseOrError(agentsQuerySchema, request.query, reply, 'invalid_agents_query');
+    if (!query) return;
+
+    const body = parseOrError(createEmbedBodySchema, request.body ?? {}, reply, 'invalid_embed_payload');
+    if (!body) return;
+
+    try {
+      const existingRows = await app.db
+        .select({ id: agents.id })
+        .from(agents)
+        .where(
+          and(
+            eq(agents.id, params.id),
+            eq(agents.customerId, query.customerId),
+            ne(agents.status, 'deleted'),
+          ),
+        )
+        .limit(1);
+
+      if (!existingRows[0]) {
+        return sendError(reply, 404, 'not_found', 'Agent not found');
+      }
+
+      const embedRows = await app.db
+        .select()
+        .from(widgetEmbeds)
+        .where(eq(widgetEmbeds.agentId, params.id))
+        .limit(1);
+
+      const existingEmbed = embedRows[0];
+      const embedToken = randomUUID();
+
+      if (existingEmbed) {
+        await app.db
+          .update(widgetEmbeds)
+          .set({
+            embedToken,
+            allowedOrigins: body.allowedOrigins ?? existingEmbed.allowedOrigins,
+          })
+          .where(eq(widgetEmbeds.id, existingEmbed.id));
+        invalidateEmbedTokenCache(existingEmbed.embedToken);
+      } else {
+        await app.db.insert(widgetEmbeds).values({
+          agentId: params.id,
+          embedToken,
+          allowedOrigins: body.allowedOrigins,
+        });
+      }
+
+      invalidateEmbedTokenCache(embedToken);
+
+      return reply.send({ embedToken });
+    } catch (error) {
+      request.log.error({ error }, 'failed to create embed token');
+      return sendError(reply, 500, 'internal_error', 'Failed to create embed token');
+    }
+  });
+}

--- a/packages/proxy/src/ws/handler.ts
+++ b/packages/proxy/src/ws/handler.ts
@@ -1,6 +1,9 @@
 import type { ClientMessage, ServerMessage } from '@webagent/shared/protocol';
+import { and, eq } from 'drizzle-orm';
+import type { Database } from '../db/client.js';
+import { agents, widgetEmbeds } from '../db/schema.js';
 import { OpenClawClient } from '../openclaw/client.js';
-import { getOrCreateSession } from '../openclaw/sessions.js';
+import { getOrCreateSession, touchSessionLastActiveAt } from '../openclaw/sessions.js';
 
 interface WebSocket {
   readyState: number;
@@ -16,17 +19,33 @@ interface AuthenticatedSocket {
   agentToken: string;
   userId: string;
   agentId: string;
+  openclawAgentId: string;
   sessionKey: string;
   authenticated: boolean;
 }
 
+interface TokenLookup {
+  agentId: string;
+  openclawAgentId: string;
+  allowedOrigins: string[] | null;
+}
+
+interface TokenCacheEntry {
+  value: TokenLookup;
+  expiresAt: number;
+}
+
 const openclawClient = new OpenClawClient();
+const TOKEN_CACHE_TTL_MS = 60_000;
+const tokenCache = new Map<string, TokenCacheEntry>();
 
-// In-memory token→agentId map (will later use DB)
-const tokenAgentMap = new Map<string, string>();
+export function invalidateEmbedTokenCache(token?: string): void {
+  if (token) {
+    tokenCache.delete(token);
+    return;
+  }
 
-export function registerAgentToken(token: string, agentId: string) {
-  tokenAgentMap.set(token, agentId);
+  tokenCache.clear();
 }
 
 function send(ws: WebSocket, msg: ServerMessage) {
@@ -35,12 +54,85 @@ function send(ws: WebSocket, msg: ServerMessage) {
   }
 }
 
-export function handleConnection(ws: WebSocket) {
+function isOriginAllowed(origin: string | undefined, allowedOrigins: string[] | null): boolean {
+  if (!allowedOrigins || allowedOrigins.length === 0) {
+    return true;
+  }
+
+  if (!origin) {
+    return false;
+  }
+
+  return allowedOrigins.includes(origin);
+}
+
+function getCachedTokenLookup(embedToken: string): TokenLookup | null {
+  const cached = tokenCache.get(embedToken);
+  if (!cached) {
+    return null;
+  }
+
+  if (cached.expiresAt <= Date.now()) {
+    tokenCache.delete(embedToken);
+    return null;
+  }
+
+  return cached.value;
+}
+
+function setCachedTokenLookup(embedToken: string, value: TokenLookup): void {
+  tokenCache.set(embedToken, { value, expiresAt: Date.now() + TOKEN_CACHE_TTL_MS });
+}
+
+function extractAuthToken(msg: unknown): string {
+  if (!msg || typeof msg !== 'object') {
+    return '';
+  }
+
+  const authMsg = msg as { agentToken?: unknown; token?: unknown };
+  const token = typeof authMsg.agentToken === 'string' ? authMsg.agentToken : authMsg.token;
+  return typeof token === 'string' ? token : '';
+}
+
+async function lookupEmbedToken(db: Database, embedToken: string): Promise<TokenLookup | null> {
+  const cached = getCachedTokenLookup(embedToken);
+  if (cached) {
+    return cached;
+  }
+
+  const rows = await db
+    .select({
+      agentId: agents.id,
+      openclawAgentId: agents.openclawAgentId,
+      allowedOrigins: widgetEmbeds.allowedOrigins,
+    })
+    .from(widgetEmbeds)
+    .innerJoin(agents, eq(widgetEmbeds.agentId, agents.id))
+    .where(and(eq(widgetEmbeds.embedToken, embedToken), eq(agents.status, 'active')))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) {
+    return null;
+  }
+
+  const value = {
+    agentId: row.agentId,
+    openclawAgentId: row.openclawAgentId,
+    allowedOrigins: row.allowedOrigins,
+  };
+
+  setCachedTokenLookup(embedToken, value);
+  return value;
+}
+
+export function handleConnection(ws: WebSocket, ctx: { db: Database; origin?: string }) {
   const state: AuthenticatedSocket = {
     ws,
     agentToken: '',
     userId: '',
     agentId: '',
+    openclawAgentId: '',
     sessionKey: '',
     authenticated: false,
   };
@@ -55,7 +147,7 @@ export function handleConnection(ws: WebSocket) {
 
   ws.on('message', async (raw: Buffer | string) => {
     const text = typeof raw === 'string' ? raw : raw.toString('utf8');
-    
+
     let msg: ClientMessage;
     try {
       msg = JSON.parse(text) as ClientMessage;
@@ -64,68 +156,110 @@ export function handleConnection(ws: WebSocket) {
       return;
     }
 
-    switch (msg.type) {
-      case 'auth': {
-        if (state.authenticated) {
-          send(ws, { type: 'error', message: 'Already authenticated' });
-          return;
-        }
-
-        const agentId = tokenAgentMap.get(msg.agentToken);
-        if (!agentId) {
-          send(ws, { type: 'auth_error', reason: 'Invalid agent token' });
-          ws.close(4003, 'Invalid token');
-          return;
-        }
-
-        state.agentToken = msg.agentToken;
-        state.userId = msg.userId;
-        state.agentId = agentId;
-        state.sessionKey = getOrCreateSession(agentId, msg.userId);
-        state.authenticated = true;
-        clearTimeout(authTimeout);
-
-        send(ws, { type: 'auth_ok', sessionId: state.sessionKey });
-        break;
+    try {
+      if (state.authenticated && msg.type !== 'auth') {
+        await touchSessionLastActiveAt(ctx.db, state.agentId, state.userId);
       }
 
-      case 'message': {
-        if (!state.authenticated) {
-          send(ws, { type: 'auth_error', reason: 'Not authenticated' });
-          return;
-        }
-
-        if (!msg.content?.trim()) {
-          send(ws, { type: 'error', message: 'Empty message' });
-          return;
-        }
-
-        try {
-          const result = await openclawClient.sendMessage({
-            message: msg.content,
-            agentId: state.agentId,
-            sessionKey: state.sessionKey,
-          });
-
-          if (result.success) {
-            send(ws, { type: 'message', content: result.response || '', done: true });
-          } else {
-            send(ws, { type: 'error', message: result.error || 'Agent error' });
+      switch (msg.type) {
+        case 'auth': {
+          if (state.authenticated) {
+            send(ws, { type: 'error', message: 'Already authenticated' });
+            return;
           }
-        } catch (err) {
-          send(ws, { type: 'error', message: 'Internal error processing message' });
+
+          const authToken = extractAuthToken(msg);
+          if (!authToken) {
+            send(ws, { type: 'auth_error', reason: 'Invalid agent token' });
+            ws.close(4003, 'Invalid token');
+            return;
+          }
+
+          let tokenData: TokenLookup | null;
+          try {
+            tokenData = await lookupEmbedToken(ctx.db, authToken);
+          } catch {
+            send(ws, { type: 'auth_error', reason: 'Internal server error' });
+            ws.close(1011, 'Internal error');
+            return;
+          }
+
+          if (!tokenData) {
+            send(ws, { type: 'auth_error', reason: 'Invalid agent token' });
+            ws.close(4003, 'Invalid token');
+            return;
+          }
+
+          if (!isOriginAllowed(ctx.origin, tokenData.allowedOrigins)) {
+            send(ws, { type: 'auth_error', reason: 'Origin not allowed' });
+            ws.close(4003, 'Origin not allowed');
+            return;
+          }
+
+          state.agentToken = authToken;
+          state.userId = msg.userId;
+          state.agentId = tokenData.agentId;
+          state.openclawAgentId = tokenData.openclawAgentId;
+          try {
+            state.sessionKey = await getOrCreateSession(ctx.db, tokenData.agentId, msg.userId);
+          } catch {
+            send(ws, { type: 'auth_error', reason: 'Internal server error' });
+            ws.close(1011, 'Internal error');
+            return;
+          }
+          state.authenticated = true;
+          clearTimeout(authTimeout);
+
+          send(ws, { type: 'auth_ok', sessionId: state.sessionKey });
+          break;
         }
-        break;
+
+        case 'message': {
+          if (!state.authenticated) {
+            send(ws, { type: 'auth_error', reason: 'Not authenticated' });
+            return;
+          }
+
+          if (!msg.content?.trim()) {
+            send(ws, { type: 'error', message: 'Empty message' });
+            return;
+          }
+
+          try {
+            const result = await openclawClient.sendMessage({
+              message: msg.content,
+              agentId: state.openclawAgentId,
+              sessionKey: state.sessionKey,
+            });
+
+            if (result.success) {
+              send(ws, { type: 'message', content: result.response || '', done: true });
+            } else {
+              send(ws, { type: 'error', message: result.error || 'Agent error' });
+            }
+          } catch {
+            send(ws, { type: 'error', message: 'Internal error processing message' });
+          }
+          break;
+        }
+
+        case 'ping': {
+          send(ws, { type: 'pong' });
+          break;
+        }
+
+        default: {
+          send(ws, { type: 'error', message: 'Unknown message type' });
+        }
+      }
+    } catch {
+      if (msg.type === 'auth' && !state.authenticated) {
+        send(ws, { type: 'auth_error', reason: 'Internal server error' });
+        ws.close(1011, 'Internal error');
+        return;
       }
 
-      case 'ping': {
-        send(ws, { type: 'pong' });
-        break;
-      }
-
-      default: {
-        send(ws, { type: 'error', message: 'Unknown message type' });
-      }
+      send(ws, { type: 'error', message: 'Internal error processing message' });
     }
   });
 


### PR DESCRIPTION
## Summary\n- build admin dashboard with agent cards, actions, empty state, and create CTA\n- add create-agent chat flow page and meta-agent API integration\n- add agent detail page with embed code, token regeneration, and recent sessions\n- add dashboard shell (sidebar + mobile nav + topbar), toast notifications, and settings placeholder\n- add typed API client + customerId normalization + Next rewrites for proxy endpoints\n\n## Validation\n- pnpm --filter @webagent/admin build\n\nCloses #24