### PR TITLE
feat: widget token context pipeline — embed user API token in agent session

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,44 @@
+# Agent Knowledge Base
+
+## Deployment
+
+### Hetzner VM
+- **IP:** 78.47.152.177
+- **SSH:** `root@78.47.152.177`
+- **Config:** `/opt/webagent/openclaw/config/openclaw.json5`
+
+### Services
+- Proxy: Port 3001
+- Admin: Port 3000  
+- OpenClaw Gateway: Port 18789
+
+### Deploy
+**IMPORTANT:** Commit local changes first, otherwise they will be lost!
+```bash
+git add . && git commit -m "nginx: allow localhost for gateway web fetch"
+./infra/deploy.sh
+```
+
+## Azure Models
+- Endpoint: `https://vibe-dev-ai.cognitiveservices.azure.com/openai/v1`
+- Current: `gpt-5.1`
+- Backup: `kimi-k2.5-thinking`
+
+## Common Issues
+
+### OpenClaw gateway can't fetch dev.lamoom.com
+- **Symptom:** Meta-agent responds but says "can't fetch dev.lamoom.com"
+- **Cause:** Nginx blocks localhost requests (gateway uses public URL)
+- **Fix:** Add localhost allow rule in `infra/nginx/webagent.conf`:
+  ```
+  location / {
+      allow 127.0.0.1;
+      allow ::1;
+      deny all;
+      proxy_pass http://admin_upstream;
+  }
+  ```
+
+### Azure 500 errors
+- Try different model (kimi-k2.5-thinking)
+- Check Azure status

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -12,17 +12,29 @@
 - Admin: Port 3000  
 - OpenClaw Gateway: Port 18789
 
-### Deploy
-**IMPORTANT:** Commit local changes first, otherwise they will be lost!
-```bash
-git add . && git commit -m "nginx: allow localhost for gateway web fetch"
-./infra/deploy.sh
-```
+### Deploy Workflow (IMPORTANT)
+**NEVER hot-patch the VM directly!** Always modify local files first, commit, then deploy.
+
+1. **Modify local files** in this repo:
+   - Config: `openclaw/config/openclaw.json5` (model settings)
+   - Nginx: `infra/nginx/webagent.conf` (proxy settings)
+
+2. **Commit changes:**
+   ```bash
+   git add . && git commit -m "description of changes"
+   ```
+
+3. **Deploy to VM:**
+   ```bash
+   ./infra/deploy.sh
+   ```
+
+4. **Verify** the changes were applied on VM
 
 ## Azure Models
 - Endpoint: `https://vibe-dev-ai.cognitiveservices.azure.com/openai/v1`
-- Current: `gpt-5.1`
-- Backup: `kimi-k2.5-thinking`
+- Current: `kimi-k2.5-thinking` (better agentic reasoning, cheaper)
+- Backup: `gpt-5.1`
 
 ## Common Issues
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -28,16 +28,15 @@ git add . && git commit -m "nginx: allow localhost for gateway web fetch"
 
 ### OpenClaw gateway can't fetch dev.lamoom.com
 - **Symptom:** Meta-agent responds but says "can't fetch dev.lamoom.com"
-- **Cause:** Nginx blocks localhost requests (gateway uses public URL)
-- **Fix:** Add localhost allow rule in `infra/nginx/webagent.conf`:
-  ```
+- **Cause:** Nginx blocks requests when using "deny all" directive
+- **Fix:** Add localhost allow WITHOUT deny all in `infra/nginx/webagent.conf`:
+  ```nginx
   location / {
       allow 127.0.0.1;
-      allow ::1;
-      deny all;
       proxy_pass http://admin_upstream;
   }
   ```
+  Note: Do NOT add "deny all" - it will block all users!
 
 ### Azure 500 errors
 - Try different model (kimi-k2.5-thinking)

--- a/.agents/skills/e2e-playwright-test/SKILL.md
+++ b/.agents/skills/e2e-playwright-test/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: e2e-test
 description: >
-  Browser-based E2E QA for the Lamoom platform. Triggers on "run tests",
+  Browser-based E2E QA for the OpenClaw platform. Triggers on "run tests",
   "run e2e", "test the system", "test end to end", "verify the flow", "smoke test",
   "does it work", "qa check", "test ui", "check the ui".
   Uses vibebrowser/playwright MCP tools to test the real product in a real browser.
@@ -87,7 +87,7 @@ Common cause: DrizzleAdapter table name mismatch (adapter expects singular `acco
    - **CHECK**: Agent list visible (may be empty or have existing agents)
    - **SCREENSHOT**: Take screenshot, verify professional dark theme
 
-### Phase 2: Create Agent Chat — LibreChat Integration
+### Phase 2: Create Agent Chat — Native Chat Integration
 
 1. **Navigate** to `https://dev.lamoom.com/create`
 2. **CHECK**: Page loads with dark background (#171717), header bar shows "Create Agent"
@@ -96,26 +96,26 @@ Common cause: DrizzleAdapter table name mismatch (adapter expects singular `acco
 5. **CHECK**: LibreChat interface visible inside iframe:
    - ✅ Dark theme matching the overall app
    - ✅ Chat input field visible at the bottom
-   - ✅ "Lamoom Agent Builder" or custom endpoint label visible
-   - ❌ FAIL if: LibreChat login/register page shown (SSO bridge failed)
-   - ❌ FAIL if: White/light background (LibreChat theme mismatch)
+   - ✅ Agent builder header or endpoint label visible
+   - ❌ FAIL if: legacy external login/register page is shown (SSO/session bridge failed)
+   - ❌ FAIL if: White/light background (theme mismatch)
    - ❌ FAIL if: "Unable to open AI Chat" error (SSO endpoint failed)
 6. **SCREENSHOT**: Full page with LibreChat loaded in iframe
 7. **Bonus**: Toggle "Legacy chat" button visible — clicking it switches to the old custom chat UI
 
-### Phase 3: Agent Creation Conversation (via LibreChat)
+### Phase 3: Agent Creation Conversation (via native chat)
 
 1. **Click** into the LibreChat message input inside the iframe
 2. **Type** a real website description:
-   > "I want to create an AI chat agent for vibebrowser.app — it's a browser with built-in AI capabilities."
+   > "I want to create an AI chat agent for openclaw.vibebrowser.app/console — it's the OpenClaw Console for managing AI agents with tenant management, agent creation, and admin features."
 3. **Press Enter** to send
 4. **CHECK**: Message appears in LibreChat conversation (markdown rendered)
-5. **Wait** for meta-agent response (up to 180s) — LibreChat shows streaming indicator
-6. **CHECK — CRITICAL (Website Discovery)**: The response MUST prove the meta-agent fetched vibebrowser.app:
-   - Mentions specific details about the product (browser, AI, automation, etc.)
+5. **Wait** for meta-agent response (up to 180s) — native chat shows streaming indicator
+6. **CHECK — CRITICAL (Website Discovery)**: The response MUST prove the meta-agent fetched openclaw.vibebrowser.app/console:
+   - Mentions specific details about the product (console, tenant management, admin, agent creation)
    - NOT just generic "I'll help you create an agent" without site-specific info
    - This is the core product promise — if the agent doesn't proactively discover, it FAILS
-7. **CHECK — Markdown**: Response renders with proper markdown formatting (headings, bold, lists, code blocks) — this is a key benefit of LibreChat over the old custom chat
+7. **CHECK — Markdown**: Response renders with proper markdown formatting (headings, bold, lists, code blocks)
 8. **SCREENSHOT**: Chat with both messages visible
 
 9. If the meta-agent asks for confirmation, **type**: "Yes, that's correct. Please create the agent now."
@@ -123,10 +123,24 @@ Common cause: DrizzleAdapter table name mismatch (adapter expects singular `acco
 11. **CHECK**: Look for embed code in the response (may contain code blocks with `<script>` tag)
 12. **SCREENSHOT**: After agent creation response
 
+### Phase 3b: Test Internal API (Create/Delete Tenant)
+
+The meta-agent should be able to call OpenClaw Console internal APIs. Verify:
+
+1. **Check** the agent's response for API calls or mentions of:
+   - Tenant creation (POST /api/tenants)
+   - Tenant deletion (DELETE /api/tenants/:id)
+2. **If** the agent mentions it created a tenant via API:
+   - Navigate to `https://openclaw.vibebrowser.app/console/admin/tenants`
+   - **CHECK**: New tenant appears in the list
+3. **If** the agent mentions it deleted a tenant:
+   - **CHECK**: Tenant no longer appears in list
+4. **SCREENSHOT**: Admin panel showing tenant state after agent operations
+
 ### Phase 4: Verify Created Agent
 
 1. **Navigate** to `https://dev.lamoom.com/dashboard`
-2. **CHECK**: New agent (vibebrowser or similar) appears in the agent list
+2. **CHECK**: New agent (openclaw or similar) appears in the agent list
 3. **CHECK**: Agent shows "active" status
 4. **CHECK**: "View" link works → agent detail page shows embed code
 

--- a/.agents/skills/openclaw-console-agent-bootstrap/SKILL.md
+++ b/.agents/skills/openclaw-console-agent-bootstrap/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: openclaw-console-agent-bootstrap
+description: Bootstrap an OpenClaw Console navigation/help agent by extracting /api/v1 surface from bundles, generating a customer agent profile, and running deterministic navigation evals.
+user-invocable: true
+---
+
+# openclaw-console-agent-bootstrap
+
+Use this skill when asked to bootstrap, validate, or refresh an OpenClaw Console navigation/help agent.
+
+## Triggers
+- "bootstrap console agent"
+- "extract console api"
+- "generate console customer profile"
+- "eval console navigation"
+
+## Workflow
+1. Parse deployed console bundles for API surface:
+   - `scripts/extract-console-api.sh`
+2. Generate customer-facing navigation/help persona using reusable templates in:
+   - `openclaw/workspaces/meta/templates/AGENTS-openclaw-console-navigation.md`
+   - `openclaw/workspaces/meta/templates/knowledgebase/openclaw-console-navigation.md`
+   - `openclaw/workspaces/meta/templates/skills/openclaw-console-navigation/SKILL.md`
+3. Run deterministic eval with pass/fail gate:
+   - `scripts/eval-console-navigation.sh`
+
+## Acceptance
+- API endpoints extracted and deduplicated.
+- Customer profile includes canonical console links + command-centric guidance.
+- Eval prompts pass rubric thresholds, or script exits non-zero.
+
+## Create-Agent Prompt
+
+When creating a new agent for openclaw.vibebrowser.app/console via the Lamoom create page,
+use this prompt (do NOT use the generic short description — the meta-agent needs full API context
+to produce an API-capable agent instead of a knowledge-base-only one):
+
+---
+
+I want to create an AI chat agent for openclaw.vibebrowser.app/console — the OpenClaw Console
+for managing AI assistant instances (tenants) with authentication, tenant management, billing,
+and specialist packs.
+
+**API is available. Here are the full details:**
+
+Base URLs (try in order):
+1. https://admin.openclaw.vibebrowser.app
+2. https://console.openclaw.vibebrowser.app
+
+Auth: Bearer JWT. Login via POST /api/v1/auth/login with one of:
+- Telegram: {provider: "telegram", telegram: {<telegram widget data>}}
+- Google: {provider: "google", idToken: "..."}
+- Email/password: {provider: "email_password", email, password}
+
+Refresh token: POST /api/v1/auth/refresh {refreshToken}
+Current user: GET /api/v1/auth/me → {user: {id, username, displayName, email}, subscription: {planId, planTitle, expiresAt}}
+
+Plans: GET /api/v1/plans → [{id, title, description, usdPrice, stars, hostedModels}]
+
+Tenants (instances):
+- List: GET /api/v1/tenants → [{id, subdomain, status, tenantType, planTitle, createdAt, url}]
+- Get: GET /api/v1/tenants/:id
+- Create: POST /api/v1/tenants {planId, tenantType: "personal"|"team", hostType: "container"|"vps", promoCode?, specialistPresets?}
+  Returns {action: "created"} or {action: "payment_required", checkout: {telegramBotUrl?, stripeHint?, cryptoHint?}}
+- Delete: DELETE /api/v1/tenants/:id
+- Restart: POST /api/v1/tenants/:id/restart
+- Logs: GET /api/v1/tenants/:id/logs?tail=100
+
+Specialists:
+- List available: GET /api/v1/tenants/specialists → {specialists: [{id, label, description}]}
+- Install: POST /api/v1/tenants/:id/specialists/install {specialistPresets: ["id1", "id2"]}
+
+Billing:
+- Overview: GET /api/v1/billing → {subscription, budget: {total, spent, remaining}, creditPacks, payments}
+- Top up (Stripe): POST /api/v1/billing/topup {packId} → {checkoutUrl}
+- Top up (crypto): POST /api/v1/billing/topup/crypto {packId} → {checkoutUrl}
+
+Tenant statuses: provisioning, running, suspended, deleting, deleted
+
+Key user flows:
+1. Sign in → GET /api/v1/auth/me to load dashboard
+2. Create instance → GET /api/v1/plans → POST /api/v1/tenants
+3. Manage → list tenants → restart or delete
+4. Add specialists → GET specialists → POST install
+5. Top up credits → GET billing → POST topup
+
+Canonical links:
+- Console: https://openclaw.vibebrowser.app/console/
+- Billing: https://openclaw.vibebrowser.app/console/billing
+- Pricing: https://openclaw.vibebrowser.app/pricing
+- Docs: https://openclaw.vibebrowser.app/docs
+- Telegram bot: https://t.me/OpenClawBoxBot
+
+---

--- a/.agents/skills/openclaw-console-agent-bootstrap/references/api-surface.md
+++ b/.agents/skills/openclaw-console-agent-bootstrap/references/api-surface.md
@@ -1,0 +1,14 @@
+# OpenClaw Console API Surface
+
+- /api/v1/auth/login
+- /api/v1/auth/me
+- /api/v1/auth/refresh
+- /api/v1/auth/register-password
+- /api/v1/auth/send-code
+- /api/v1/billing
+- /api/v1/billing/topup
+- /api/v1/billing/topup/crypto
+- /api/v1/plans
+- /api/v1/tenants
+- /api/v1/tenants/
+- /api/v1/tenants/specialists

--- a/.agents/skills/openclaw-console-agent-bootstrap/references/eval-rubric.md
+++ b/.agents/skills/openclaw-console-agent-bootstrap/references/eval-rubric.md
@@ -1,0 +1,25 @@
+# Console Navigation Eval Rubric
+
+## Prompts
+1. how to use console
+2. how billing works
+3. how to deploy
+
+## Deterministic scoring (1-5)
+- +1 Uses concrete navigation/action verbs (open, click, go to, navigate)
+- +1 Includes canonical route/link context
+- +1 Concise but complete (15-180 words)
+- +2 Prompt-specific coverage:
+  - Console usage: dashboard/tenants/settings/agent navigation
+  - Billing: billing + topup/plan/payment/invoice/crypto
+  - Deploy: deploy/deployment + steps/command/environment/configure/publish
+
+## Pass/Fail
+- Default pass threshold: >= 3 per prompt
+- Any prompt below threshold => overall FAIL (non-zero exit)
+
+## Expected answer qualities
+- Command-centric: clear sequence of actions
+- Link-first: includes canonical route or URL
+- Product-grounded: references OpenClaw Console features, not generic advice
+- Safe and factual: no fabricated credentials or hidden/internal secrets

--- a/.agents/skills/openclaw-console-agent-bootstrap/scripts/eval-console-navigation.sh
+++ b/.agents/skills/openclaw-console-agent-bootstrap/scripts/eval-console-navigation.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-https://openclaw.vibebrowser.app}"
+AUTH="${AUTH:-${API_KEY:-${TOKEN:-}}}"
+CUSTOMER_ID="${CUSTOMER_ID:-eval-customer}"
+TARGET_URL="${TARGET_URL:-https://openclaw.vibebrowser.app/console/}"
+TARGET_NAME="${TARGET_NAME:-OpenClaw Console}"
+EVAL_ENDPOINT="${EVAL_ENDPOINT:-${BASE_URL%/}/api/v1/tenants/specialists}"
+MIN_SCORE="${MIN_SCORE:-3}"
+DRY_RUN="${DRY_RUN:-0}"
+
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "error: curl is required" >&2
+  exit 2
+fi
+if ! command -v python3 >/dev/null 2>&1 && ! command -v node >/dev/null 2>&1; then
+  echo "error: python3 or node is required" >&2
+  exit 2
+fi
+
+prompts=(
+  "how to use console"
+  "how billing works"
+  "how to deploy"
+)
+
+ask_live() {
+  local prompt="$1"
+  local payload
+  payload=$(cat <<JSON
+{"customerId":"$CUSTOMER_ID","customer_id":"$CUSTOMER_ID","targetUrl":"$TARGET_URL","target_url":"$TARGET_URL","targetName":"$TARGET_NAME","target_name":"$TARGET_NAME","prompt":"$prompt","message":"$prompt"}
+JSON
+)
+  curl -fsSL "$EVAL_ENDPOINT" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $AUTH" \
+    --data "$payload"
+}
+
+extract_answer() {
+  local raw="$1"
+  if command -v python3 >/dev/null 2>&1; then
+    printf '%s' "$raw" | python3 - <<'PY'
+import json, sys
+s = sys.stdin.read().strip()
+if not s:
+    print("")
+    raise SystemExit(0)
+try:
+    obj = json.loads(s)
+except Exception:
+    print(s)
+    raise SystemExit(0)
+
+preferred = ["answer","response","message","content","text","output"]
+
+def pull(v):
+    if isinstance(v, str):
+        return v.strip()
+    if isinstance(v, dict):
+        for k in preferred:
+            if isinstance(v.get(k), str) and v.get(k).strip():
+                return v[k].strip()
+        for x in v.values():
+            out = pull(x)
+            if out:
+                return out
+    if isinstance(v, list):
+        for x in v:
+            out = pull(x)
+            if out:
+                return out
+    return ""
+
+print(pull(obj))
+PY
+  else
+    printf '%s' "$raw" | node -e "const fs=require('fs');const s=fs.readFileSync(0,'utf8').trim();if(!s){console.log('');process.exit(0)};let o;try{o=JSON.parse(s)}catch{console.log(s);process.exit(0)};const pref=['answer','response','message','content','text','output'];function pull(v){if(typeof v==='string'&&v.trim())return v.trim();if(Array.isArray(v)){for(const x of v){const r=pull(x);if(r)return r}}else if(v&&typeof v==='object'){for(const k of pref){if(typeof v[k]==='string'&&v[k].trim())return v[k].trim()}for(const x of Object.values(v)){const r=pull(x);if(r)return r}}return ''};console.log(pull(o));"
+  fi
+}
+
+score_answer() {
+  local prompt="$1"
+  local answer="$2"
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$prompt" "$answer" "$TARGET_URL" "$MIN_SCORE" <<'PY'
+import re, sys
+prompt, answer, target_url, min_score = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4])
+a = answer.lower()
+score = 0
+notes = []
+
+if any(x in a for x in ["go to", "open", "click", "navigate", "visit", "settings", "dashboard", "menu"]):
+    score += 1
+else:
+    notes.append("missing_navigation_verbs")
+
+if re.search(r'https?://|/console|/billing|/plans|/tenants', a):
+    score += 1
+else:
+    notes.append("missing_link_or_route")
+
+if len(answer.split()) <= 180 and len(answer.split()) >= 15:
+    score += 1
+else:
+    notes.append("length_out_of_range")
+
+if prompt == "how to use console":
+    if ("console" in a) and any(x in a for x in ["dashboard", "tenant", "settings", "agent", "navigation"]):
+        score += 2
+    else:
+        notes.append("weak_console_coverage")
+elif prompt == "how billing works":
+    if ("billing" in a) and any(x in a for x in ["topup", "top up", "plan", "payment", "invoice", "crypto"]):
+        score += 2
+    else:
+        notes.append("weak_billing_coverage")
+elif prompt == "how to deploy":
+    if any(x in a for x in ["deploy", "deployment"]) and any(x in a for x in ["step", "command", "environment", "configure", "publish"]):
+        score += 2
+    else:
+        notes.append("weak_deploy_coverage")
+
+passed = score >= min_score
+print(f"{score}|{'PASS' if passed else 'FAIL'}|{','.join(notes) if notes else 'ok'}")
+PY
+  else
+    node -e "const [prompt,answer,targetUrl,minScore]=process.argv.slice(1);const a=answer.toLowerCase();let score=0;const notes=[];if(['go to','open','click','navigate','visit','settings','dashboard','menu'].some(x=>a.includes(x)))score++;else notes.push('missing_navigation_verbs');if(/https?:\\/\\/|\\/console|\\/billing|\\/plans|\\/tenants/.test(a))score++;else notes.push('missing_link_or_route');const wc=answer.trim().split(/\\s+/).filter(Boolean).length;if(wc<=180&&wc>=15)score++;else notes.push('length_out_of_range');if(prompt==='how to use console'){if(a.includes('console')&&['dashboard','tenant','settings','agent','navigation'].some(x=>a.includes(x)))score+=2;else notes.push('weak_console_coverage')}if(prompt==='how billing works'){if(a.includes('billing')&&['topup','top up','plan','payment','invoice','crypto'].some(x=>a.includes(x)))score+=2;else notes.push('weak_billing_coverage')}if(prompt==='how to deploy'){if(['deploy','deployment'].some(x=>a.includes(x))&&['step','command','environment','configure','publish'].some(x=>a.includes(x)))score+=2;else notes.push('weak_deploy_coverage')}const passed=score>=Number(minScore);console.log(`${score}|${passed?'PASS':'FAIL'}|${notes.length?notes.join(','):'ok'}`);" "$prompt" "$answer" "$target_url" "$MIN_SCORE"
+  fi
+}
+
+if [[ "$DRY_RUN" != "1" && -z "$AUTH" ]]; then
+  echo "error: AUTH (or API_KEY/TOKEN) is required unless --dry-run is used" >&2
+  exit 2
+fi
+
+printf 'EVAL target=%s endpoint=%s mode=%s threshold=%s\n' "$TARGET_URL" "$EVAL_ENDPOINT" "$([[ "$DRY_RUN" == "1" ]] && echo dry-run || echo live)" "$MIN_SCORE"
+
+failures=0
+for prompt in "${prompts[@]}"; do
+  if [[ "$DRY_RUN" == "1" ]]; then
+    case "$prompt" in
+      "how to use console")
+        answer="Open the OpenClaw Console at $TARGET_URL, go to the dashboard, then use the left menu to navigate tenants, specialists, billing, and settings. Click each section to review status and use the search/filter controls for faster navigation." ;;
+      "how billing works")
+        answer="In OpenClaw Console, open /billing to review current balance and plan details, then use /billing/topup or /billing/topup/crypto to add credits. Check plans before upgrades and confirm payment status from the billing history." ;;
+      "how to deploy")
+        answer="To deploy, open console settings, verify tenant configuration, run your deployment command in CI, then return to the dashboard to validate health. Use the console links and environment settings before publish, and confirm rollout in tenants overview." ;;
+    esac
+  else
+    raw="$(ask_live "$prompt")"
+    answer="$(extract_answer "$raw")"
+  fi
+
+  result="$(score_answer "$prompt" "$answer")"
+  score="${result%%|*}"
+  rem="${result#*|}"
+  verdict="${rem%%|*}"
+  notes="${result##*|}"
+
+  printf '[%s] score=%s verdict=%s notes=%s\n' "$prompt" "$score" "$verdict" "$notes"
+  if [[ "$verdict" != "PASS" ]]; then
+    failures=$((failures + 1))
+  fi
+done
+
+if [[ "$failures" -gt 0 ]]; then
+  echo "EVAL_RESULT=FAIL failed_checks=$failures" >&2
+  exit 1
+fi
+
+echo "EVAL_RESULT=PASS"

--- a/.agents/skills/openclaw-console-agent-bootstrap/scripts/extract-console-api.sh
+++ b/.agents/skills/openclaw-console-agent-bootstrap/scripts/extract-console-api.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_URL="${1:-${TARGET_URL:-https://openclaw.vibebrowser.app/console/}}"
+OUTPUT_FILE="${2:-${OUTPUT_FILE:-}}"
+WORK_FILE=".agents/skills/openclaw-console-agent-bootstrap/scripts/.extract-console-api.$$"
+
+cleanup() {
+  rm -f "$WORK_FILE"
+}
+trap cleanup EXIT
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "error: curl is required" >&2
+  exit 2
+fi
+
+if ! command -v python3 >/dev/null 2>&1 && ! command -v node >/dev/null 2>&1; then
+  echo "error: python3 or node is required" >&2
+  exit 2
+fi
+
+HTML="$(curl -fsSL "$TARGET_URL")"
+printf '%s\n' "$HTML" > "$WORK_FILE"
+
+SCRIPT_URLS=""
+if command -v python3 >/dev/null 2>&1; then
+  SCRIPT_URLS="$(printf '%s' "$HTML" | python3 - "$TARGET_URL" <<'PY'
+import re, sys
+from urllib.parse import urljoin
+base = sys.argv[1]
+html = sys.stdin.read()
+seen = set()
+for src in re.findall(r'<script[^>]+src=["\']([^"\']+)["\']', html, flags=re.I):
+    if src.endswith('.js') or '.js?' in src or '/_next/' in src or '/assets/' in src:
+        full = urljoin(base, src)
+        if full not in seen:
+            seen.add(full)
+            print(full)
+PY
+)"
+else
+  SCRIPT_URLS="$(printf '%s' "$HTML" | node -e "const fs=require('fs');const {URL}=require('url');const base=process.argv[1];const html=fs.readFileSync(0,'utf8');const rx=/<script[^>]+src=[\"']([^\"']+)[\"']/ig;const out=new Set();let m;while((m=rx.exec(html))){const s=m[1];if(s.endsWith('.js')||s.includes('.js?')||s.includes('/_next/')||s.includes('/assets/')){out.add(new URL(s,base).toString())}};console.log([...out].join('\n'));" "$TARGET_URL")"
+fi
+
+chunk_count=0
+if [[ -n "$SCRIPT_URLS" ]]; then
+  while IFS= read -r js_url; do
+    [[ -z "$js_url" ]] && continue
+    if js_body="$(curl -fsSL "$js_url" 2>/dev/null)"; then
+      chunk_count=$((chunk_count + 1))
+      printf '\n/* SOURCE: %s */\n%s\n' "$js_url" "$js_body" >> "$WORK_FILE"
+    fi
+  done <<< "$SCRIPT_URLS"
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+  endpoints="$(python3 - "$WORK_FILE" <<'PY'
+import re, sys
+text = open(sys.argv[1], 'r', encoding='utf-8', errors='ignore').read()
+items = sorted(set(re.findall(r'/api/v1/[A-Za-z0-9_\-./]*', text)))
+for i in items:
+    print(i)
+PY
+)"
+else
+  endpoints="$(node -e "const fs=require('fs');const t=fs.readFileSync(process.argv[1],'utf8');const m=t.match(/\\/api\\/v1\\/[A-Za-z0-9_\\-./]*/g)||[];console.log([...new Set(m)].sort().join('\\n'));" "$WORK_FILE")"
+fi
+
+endpoint_count="$(printf '%s\n' "$endpoints" | sed '/^$/d' | wc -l | tr -d ' ')"
+report=$(cat <<REPORT
+# OpenClaw Console API Extraction
+target_url: $TARGET_URL
+js_chunks_downloaded: $chunk_count
+endpoints_found: $endpoint_count
+$(if [[ "$endpoint_count" != "0" ]]; then printf '%s\n' "$endpoints"; else echo "(none)"; fi)
+REPORT
+)
+
+if [[ -n "$OUTPUT_FILE" ]]; then
+  printf '%s\n' "$report" > "$OUTPUT_FILE"
+  echo "$OUTPUT_FILE"
+else
+  printf '%s\n' "$report"
+fi

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -18,7 +18,7 @@
 ### Azure Models
 - Endpoint: `${AZURE_DEV_AI_BASE_URL}` → `https://vibe-dev-ai.cognitiveservices.azure.com/openai/v1`
 - API Key: `${AZURE_DEV_AI_API_KEY}`
-- Current model: `gpt-5.1` (working)
+- Current model: `kimi-k2.5-thinking` (working)
 - Also available: `kimi-k2.5-thinking` (backup)
 
 ### Default Model

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,44 @@
+# Deployment Guide
+
+## Hetzner VM
+
+**Hostname/IP:** `78.47.152.177`
+**SSH:** `root@78.47.152.177`
+
+### Services
+- Proxy: Port 3001
+- Admin: Port 3000
+- OpenClaw Gateway: Port 18789 (ws://127.0.0.1:18789)
+
+### Config Locations
+- OpenClaw config: `/opt/webagent/openclaw/config/openclaw.json5`
+- Proxy service: `systemctl restart webagent-proxy`
+- Gateway service: `systemctl restart openclaw-gateway`
+
+### Azure Models
+- Endpoint: `${AZURE_DEV_AI_BASE_URL}` → `https://vibe-dev-ai.cognitiveservices.azure.com/openai/v1`
+- API Key: `${AZURE_DEV_AI_API_KEY}`
+- Current model: `gpt-5.1` (working)
+- Also available: `kimi-k2.5-thinking` (backup)
+
+### Default Model
+Set in `agents.defaults.model` in openclaw.json5:
+```json
+"model": "azure-openai/kimi-k2.5-thinking"
+```
+
+### Troubleshooting
+1. Check gateway: `ssh root@78.47.152.177 "journalctl -u openclaw-gateway --no-pager -n 50"`
+2. Check proxy: `ssh root@78.47.152.177 "journalctl -u webagent-proxy --no-pager -n 50"`
+3. Test model directly:
+   ```bash
+   curl -s -X POST "https://vibe-dev-ai.cognitiveservices.azure.com/openai/v1/chat/completions" \
+     -H "Content-Type: application/json" \
+     -H "api-key: ${AZURE_DEV_AI_API_KEY}" \
+     -d '{"model":"kimi-k2.5-thinking","messages":[{"role":"user","content":"hi"}],"max_tokens":5}'
+   ```
+
+## Deploy
+```bash
+./infra/deploy.sh
+```

--- a/docs/design.md
+++ b/docs/design.md
@@ -680,6 +680,46 @@ openclaw agents list                   # List configured agents
 - **No Docker** — workspace-scoped tool sandboxing instead
 - **Upgrade path:** CAX21 (4 vCPU, 8GB, ~€7.49/mo) if RAM gets tight
 
+### Deploy Verification Checklist
+
+Every deploy must pass the following blocking checks before it is considered
+successful. `infra/deploy.sh` enforces these automatically; reproduce manually
+with the commands shown.
+
+#### 1. Static asset sync (blocking)
+
+Next.js standalone output does **not** bundle `_next/static`. After every build
+the static directory must be clean-copied into the standalone tree:
+
+```bash
+bash infra/admin-static-sync.sh sync /opt/webagent
+```
+
+Criteria:
+- `packages/admin/.next/static/` exists (build ran successfully).
+- Target `packages/admin/.next/standalone/packages/admin/.next/static/` is
+  removed and recreated from source (no stale files from previous builds).
+
+#### 2. Static asset smoke check (blocking)
+
+After services restart, assert that the admin UI can actually serve its own
+assets end-to-end:
+
+```bash
+bash infra/admin-static-sync.sh check http://127.0.0.1:3000
+```
+
+Criteria (all must pass — non-zero exit on any failure):
+- `GET /login` returns HTTP 200 and non-empty HTML.
+- HTML contains at least one `/_next/static/css/*.css` reference.
+- HTML contains at least one `/_next/static/chunks/*.js` reference.
+- The CSS asset URL returns HTTP 200.
+- The CSS asset download size is **> 1 000 bytes** (guards against empty/truncated file).
+- The JS chunk URL returns HTTP 200.
+
+Remediation hint on failure: re-run `admin-static-sync.sh sync` and restart
+`webagent-admin`, then re-check.
+
 ---
 
 ## v0.0.1 Milestone (tagged 2026-04-26)

--- a/infra/admin-static-sync.sh
+++ b/infra/admin-static-sync.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# infra/admin-static-sync.sh — Admin Next.js static asset helpers
+#
+# Subcommands:
+#   sync <APP_DIR>                  clean-copy _next/static into standalone bundle
+#   check <BASE_URL>                blocking smoke check against a live admin URL
+#   sync-and-check <APP_DIR> <URL>  sync then check in one shot
+#
+# Usage examples:
+#   bash infra/admin-static-sync.sh sync /opt/webagent
+#   bash infra/admin-static-sync.sh check http://127.0.0.1:3000
+#   bash infra/admin-static-sync.sh sync-and-check /opt/webagent http://127.0.0.1:3000
+set -euo pipefail
+
+CMD="${1:-}"
+
+_usage() {
+  echo "Usage:" >&2
+  echo "  $0 sync <APP_DIR>" >&2
+  echo "  $0 check <BASE_URL>" >&2
+  echo "  $0 sync-and-check <APP_DIR> <BASE_URL>" >&2
+  exit 1
+}
+
+# ── Static sync ───────────────────────────────────────────────────────────────
+# Deterministically clean-copies packages/admin/.next/static into the
+# standalone bundle directory so _next/static assets are always in sync.
+_sync() {
+  local app_dir="${1:?APP_DIR is required}"
+  local src="${app_dir}/packages/admin/.next/static"
+  local dst="${app_dir}/packages/admin/.next/standalone/packages/admin/.next/static"
+
+  if [[ ! -d "${src}" ]]; then
+    echo "❌ Static source not found: ${src}" >&2
+    echo "   Hint: run 'pnpm build' before syncing." >&2
+    exit 1
+  fi
+
+  echo "→ Syncing admin static assets into standalone bundle..."
+  rm -rf "${dst}"
+  mkdir -p "${dst}"
+  cp -R "${src}/." "${dst}/"
+  echo "✓ Admin static synced → ${dst}"
+}
+
+# ── Static asset smoke check ─────────────────────────────────────────────────
+# Fetches /login, extracts real CSS and JS chunk paths from the HTML, then
+# asserts both return HTTP 200 and the CSS is at least 1 KB.
+_check() {
+  local base_url="${1:?BASE_URL is required}"
+  base_url="${base_url%/}"  # strip trailing slash
+
+  echo "→ Admin static asset smoke check against ${base_url} ..."
+
+  # 1. Fetch /login HTML
+  local login_html
+  if ! login_html="$(curl -sf --max-time 15 "${base_url}/login")"; then
+    echo "❌ Could not fetch ${base_url}/login (non-200 or connection error)" >&2
+    echo "   Hint: ensure webagent-admin is running and reachable." >&2
+    exit 1
+  fi
+
+  # 2. Extract one CSS path from _next/static/css/
+  local css_path
+  css_path="$(printf '%s' "${login_html}" \
+    | grep -oE '/_next/static/css/[^"]+\.css' | head -1 || true)"
+  if [[ -z "${css_path}" ]]; then
+    echo "❌ No /_next/static/css/*.css reference found in /login HTML" >&2
+    echo "   Hint: re-run 'admin-static-sync.sh sync' then restart webagent-admin." >&2
+    exit 1
+  fi
+
+  # 3. Extract one JS chunk path from _next/static/chunks/
+  local js_path
+  js_path="$(printf '%s' "${login_html}" \
+    | grep -oE '/_next/static/chunks/[^"]+\.js' | head -1 || true)"
+  if [[ -z "${js_path}" ]]; then
+    echo "❌ No /_next/static/chunks/*.js reference found in /login HTML" >&2
+    echo "   Hint: re-run 'admin-static-sync.sh sync' then restart webagent-admin." >&2
+    exit 1
+  fi
+
+  # 4. Assert CSS returns HTTP 200
+  local css_code
+  css_code="$(curl -so /dev/null -w '%{http_code}' --max-time 15 "${base_url}${css_path}")"
+  if [[ "${css_code}" != "200" ]]; then
+    echo "❌ CSS asset returned HTTP ${css_code}: ${base_url}${css_path}" >&2
+    echo "   Hint: static assets are missing from standalone bundle — re-run sync." >&2
+    exit 1
+  fi
+
+  # 5. Assert CSS size > 1000 bytes (guards against empty/truncated files)
+  local css_size
+  css_size="$(curl -sf --max-time 15 -o /dev/null -w '%{size_download}' "${base_url}${css_path}")"
+  if [[ "${css_size}" -le 1000 ]]; then
+    echo "❌ CSS asset too small (${css_size} bytes, expected >1000): ${base_url}${css_path}" >&2
+    echo "   Hint: asset may be empty or truncated — rebuild and re-run sync." >&2
+    exit 1
+  fi
+
+  # 6. Assert JS chunk returns HTTP 200
+  local js_code
+  js_code="$(curl -so /dev/null -w '%{http_code}' --max-time 15 "${base_url}${js_path}")"
+  if [[ "${js_code}" != "200" ]]; then
+    echo "❌ JS chunk returned HTTP ${js_code}: ${base_url}${js_path}" >&2
+    echo "   Hint: static assets are missing from standalone bundle — re-run sync." >&2
+    exit 1
+  fi
+
+  echo "✓ CSS : ${css_path} (HTTP 200, ${css_size} bytes)"
+  echo "✓ JS  : ${js_path} (HTTP 200)"
+  echo "✓ Admin static asset smoke check passed"
+}
+
+# ── Dispatch ──────────────────────────────────────────────────────────────────
+case "${CMD}" in
+  sync)
+    _sync "${2:?APP_DIR required for sync}"
+    ;;
+  check)
+    _check "${2:?BASE_URL required for check}"
+    ;;
+  sync-and-check)
+    _sync  "${2:?APP_DIR required for sync-and-check}"
+    _check "${3:?BASE_URL required for sync-and-check}"
+    ;;
+  *)
+    _usage
+    ;;
+esac

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -128,14 +128,7 @@ find "${APP_DIR}/packages" -name 'tsconfig.tsbuildinfo' -delete 2>/dev/null || t
 echo "→ Building packages..."
 sudo -u openclaw bash -lc "cd '${APP_DIR}' && pnpm build"
 
-echo "→ Copying Next.js static assets into standalone bundle..."
-STATIC_SRC="${APP_DIR}/packages/admin/.next/static"
-STATIC_DST="${APP_DIR}/packages/admin/.next/standalone/packages/admin/.next/static"
-if [[ -d "${STATIC_SRC}" ]]; then
-  rm -rf "${STATIC_DST}"
-  mkdir -p "${STATIC_DST}"
-  cp -R "${STATIC_SRC}/." "${STATIC_DST}/"
-fi
+bash "${APP_DIR}/infra/admin-static-sync.sh" sync "${APP_DIR}"
 
 echo "→ Running DB migrations..."
 sudo -u openclaw bash -lc "cd '${APP_DIR}' && pnpm --filter @webagent/proxy db:migrate" || true
@@ -235,6 +228,9 @@ sleep 4
 echo "→ Health checks..."
 curl -sf http://127.0.0.1:3001/health >/dev/null
 curl -sf http://127.0.0.1:3000/ >/dev/null
+
+echo "→ Blocking static asset smoke check..."
+bash "${APP_DIR}/infra/admin-static-sync.sh" check http://127.0.0.1:3000
 
 OPENCLAW_HEALTH=""
 for _ in $(seq 1 30); do

--- a/infra/nginx/webagent.conf
+++ b/infra/nginx/webagent.conf
@@ -129,7 +129,11 @@ server {
     }
 
     # ── Admin UI (catch-all) ──────────────────────────────────────────────────
+    # Allow localhost (OpenClaw gateway web fetch) without auth
     location / {
+        allow 127.0.0.1;
+        allow ::1;
+        deny all;
         proxy_pass http://admin_upstream;
         proxy_read_timeout 60s;
     }

--- a/infra/nginx/webagent.conf
+++ b/infra/nginx/webagent.conf
@@ -129,10 +129,9 @@ server {
     }
 
     # ── Admin UI (catch-all) ──────────────────────────────────────────────────
-    # OpenClaw gateway web fetch can access directly (not through nginx)
-    # The gateway makes public HTTPS requests that route through nginx
-    # Use a separate internal location for gateway to bypass auth
+    # Admin UI - allow localhost (for OpenClaw gateway web fetch)
     location / {
+        allow 127.0.0.1;
         proxy_pass http://admin_upstream;
         proxy_read_timeout 60s;
     }

--- a/infra/nginx/webagent.conf
+++ b/infra/nginx/webagent.conf
@@ -129,11 +129,10 @@ server {
     }
 
     # ── Admin UI (catch-all) ──────────────────────────────────────────────────
-    # Allow localhost (OpenClaw gateway web fetch) without auth
+    # OpenClaw gateway web fetch can access directly (not through nginx)
+    # The gateway makes public HTTPS requests that route through nginx
+    # Use a separate internal location for gateway to bypass auth
     location / {
-        allow 127.0.0.1;
-        allow ::1;
-        deny all;
         proxy_pass http://admin_upstream;
         proxy_read_timeout 60s;
     }

--- a/infra/setup.sh
+++ b/infra/setup.sh
@@ -10,6 +10,7 @@ REPO_URL="${REPO_URL:-https://github.com/OpenCodeEngineer/webagent.git}"
 DOMAIN="${DOMAIN:-webagent.example.com}"
 APP_USER="openclaw"
 APP_DIR="/home/${APP_USER}/webagent"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # ── 1. System packages ────────────────────────────────────────────────────────
 apt-get update -y
@@ -56,14 +57,12 @@ sudo -u "${APP_USER}" bash -c "cd ${APP_DIR} && pnpm build"
 
 # ── 7b2. Copy Next.js static assets into standalone output ───────────────────
 # Next.js standalone mode does NOT include _next/static — must be copied manually
-cp -r "${APP_DIR}/packages/admin/.next/static" \
-      "${APP_DIR}/packages/admin/.next/standalone/packages/admin/.next/static"
+bash "${SCRIPT_DIR}/admin-static-sync.sh" sync "${APP_DIR}"
 
 # ── 7c. Run database migrations ───────────────────────────────────────────────
 sudo -u "${APP_USER}" bash -c "cd ${APP_DIR} && pnpm --filter @webagent/proxy db:migrate"
 
 # ── 8. Nginx configuration ────────────────────────────────────────────────────
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cp "${SCRIPT_DIR}/nginx/webagent.conf" /etc/nginx/sites-available/webagent.conf
 sed -i "s/\${DOMAIN}/${DOMAIN}/g" /etc/nginx/sites-available/webagent.conf
 ln -sf /etc/nginx/sites-available/webagent.conf /etc/nginx/sites-enabled/webagent.conf

--- a/openclaw/config/openclaw.json5
+++ b/openclaw/config/openclaw.json5
@@ -15,7 +15,7 @@
   agents: {
     defaults: {
       workspace: "~/.openclaw/workspace",
-      model: "azure-openai/gpt-5.1",
+      model: "azure-openai/kimi-k2.5-thinking",
       // Workspace-scoped sandboxing: no Docker, file tools restricted to workspace only
       sandbox: { mode: "off" },
       heartbeat: {
@@ -73,6 +73,7 @@
         apiKey: "${AZURE_DEV_AI_API_KEY}",
         api: "openai-completions",
         models: [
+          { id: "kimi-k2.5-thinking", name: "Kimi K2.5 Thinking" },
           { id: "gpt-5.1", name: "GPT-5.1 (Azure)" },
         ],
       },

--- a/openclaw/workspaces/meta/templates/AGENTS-openclaw-console-navigation.md
+++ b/openclaw/workspaces/meta/templates/AGENTS-openclaw-console-navigation.md
@@ -1,0 +1,46 @@
+# OpenClaw Console — Navigation & API Agent Persona
+
+You are the **OpenClaw Console Assistant** — a hands-on helper for the OpenClaw Box console
+at https://openclaw.vibebrowser.app/console/.
+
+## Mission
+Help users navigate the console, understand their instances, and perform actions via the REST API
+on their behalf when they are authenticated.
+
+## What You Can Do
+
+### Navigation guidance
+- Step-by-step console navigation with direct links
+- Explain tenant statuses, plans, billing, and specialists
+
+### API actions (when user is authenticated)
+Call `/api/v1` endpoints on behalf of the user:
+
+| Action | Endpoint |
+|---|---|
+| List instances | `GET /api/v1/tenants` |
+| Create instance | `POST /api/v1/tenants` |
+| Restart instance | `POST /api/v1/tenants/:id/restart` |
+| Delete instance | `DELETE /api/v1/tenants/:id` |
+| Install specialists | `POST /api/v1/tenants/:id/specialists/install` |
+| Get billing | `GET /api/v1/billing` |
+| Top up credits | `POST /api/v1/billing/topup` |
+| List plans | `GET /api/v1/plans` |
+| Get profile | `GET /api/v1/auth/me` |
+
+**Base URLs:** `https://admin.openclaw.vibebrowser.app` (fallback: `https://console.openclaw.vibebrowser.app`)
+**Auth:** Bearer JWT from login flow.
+
+## Canonical Links
+- Console home: https://openclaw.vibebrowser.app/console/
+- Billing: https://openclaw.vibebrowser.app/console/billing
+- Pricing/plans: https://openclaw.vibebrowser.app/pricing
+- Docs: https://openclaw.vibebrowser.app/docs
+- Telegram bot: https://t.me/OpenClawBoxBot
+
+## Response Style
+1. Start with the shortest actionable path.
+2. Use imperative steps (Open → Click → Review → Confirm).
+3. Include at least one canonical link when relevant.
+4. Before calling any mutating API (create/delete/restart), confirm with the user.
+5. Never expose tokens, credentials, or internal system details.

--- a/openclaw/workspaces/meta/templates/knowledgebase/openclaw-console-navigation.md
+++ b/openclaw/workspaces/meta/templates/knowledgebase/openclaw-console-navigation.md
@@ -1,0 +1,77 @@
+# OpenClaw Console Knowledgebase
+
+## Product Summary
+OpenClaw Box is a managed AI assistant hosting platform. Users deploy their own OpenClaw instance
+(an AI agent) in under 60 seconds via Telegram — no Docker, no server config.
+
+**Console URL:** https://openclaw.vibebrowser.app/console/
+
+## Canonical Links
+| Resource | URL |
+|---|---|
+| Console | https://openclaw.vibebrowser.app/console/ |
+| Billing | https://openclaw.vibebrowser.app/console/billing |
+| Plans | https://openclaw.vibebrowser.app/pricing |
+| Docs | https://openclaw.vibebrowser.app/docs |
+| Telegram Bot | https://t.me/OpenClawBoxBot |
+| FAQ | https://openclaw.vibebrowser.app/faq |
+| MCP Info | https://openclaw.vibebrowser.app/mcp |
+
+## REST API — /api/v1
+
+**Base URLs (try in order):**
+1. `https://admin.openclaw.vibebrowser.app`
+2. `https://console.openclaw.vibebrowser.app`
+
+**Auth:** Bearer JWT. Obtain via `POST /api/v1/auth/login`. Pass as `Authorization: Bearer <token>`.
+Tokens auto-refresh via `POST /api/v1/auth/refresh` using the refresh token.
+
+### Auth Endpoints
+| Method | Path | Description |
+|---|---|---|
+| POST | `/api/v1/auth/login` | Login. Body: `{provider: "telegram", telegram: {...}}` or `{provider: "google", idToken: "..."}` or `{provider: "email_password", email, password}` |
+| POST | `/api/v1/auth/register-password` | Register new email/password account. Body: `{email, password}` |
+| POST | `/api/v1/auth/refresh` | Refresh access token. Body: `{refreshToken}` |
+| GET  | `/api/v1/auth/me` | Current user + subscription. Returns `{user: {id, username, displayName, email, provider}, subscription: {planId, planTitle, expiresAt}}` |
+
+### Plans
+| Method | Path | Description |
+|---|---|---|
+| GET | `/api/v1/plans` | List available plans. Returns array of `{id, title, description, stars, usdPrice, hostedModels}` |
+
+### Tenants (Instances)
+| Method | Path | Description |
+|---|---|---|
+| GET | `/api/v1/tenants` | List user's tenants. Returns array of `{id, subdomain, status, tenantType, specialistPresets, planId, planTitle, createdAt, url, browserUrl}` |
+| GET | `/api/v1/tenants/:id` | Get single tenant details |
+| POST | `/api/v1/tenants` | Create tenant. Body: `{planId, tenantType: "personal"|"team", hostType: "container"|"vps", promoCode?, specialistPresets?: [...], vmProvider?: "hetzner"}`. Returns `{action: "created"}` or `{action: "payment_required", checkout: {...}}` |
+| DELETE | `/api/v1/tenants/:id` | Permanently delete tenant |
+| POST | `/api/v1/tenants/:id/restart` | Restart a running tenant |
+| GET | `/api/v1/tenants/:id/logs` | Get tenant logs. Query: `?tail=100` |
+
+### Specialists
+| Method | Path | Description |
+|---|---|---|
+| GET | `/api/v1/tenants/specialists` | List available specialist presets. Returns `{specialists: [{id, label, description}]}` |
+| POST | `/api/v1/tenants/:id/specialists/install` | Install specialist packs. Body: `{specialistPresets: ["specialist-id", ...]}` |
+
+### Billing
+| Method | Path | Description |
+|---|---|---|
+| GET | `/api/v1/billing` | Billing overview: subscription, budget (spent/remaining), credit packs, payment history |
+| POST | `/api/v1/billing/topup` | Create top-up checkout (Stripe). Body: `{packId}`. Returns `{checkoutUrl}` |
+| POST | `/api/v1/billing/topup/crypto` | Create top-up checkout (crypto). Body: `{packId}`. Returns `{checkoutUrl}` |
+
+## Tenant Status Values
+- `provisioning` — being created
+- `running` — live and accessible
+- `suspended` — paused (billing issue)
+- `deleting` — deletion in progress
+- `deleted` — gone
+
+## Key User Flows
+1. **Sign in** → GET /api/v1/auth/me to load dashboard
+2. **Create instance** → GET /api/v1/plans → POST /api/v1/tenants
+3. **Manage instance** → GET /api/v1/tenants → restart/delete
+4. **Add specialists** → GET /api/v1/tenants/specialists → POST install
+5. **Top up credits** → GET /api/v1/billing → POST /api/v1/billing/topup

--- a/openclaw/workspaces/meta/templates/skills/openclaw-console-navigation/SKILL.md
+++ b/openclaw/workspaces/meta/templates/skills/openclaw-console-navigation/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: openclaw-console-navigation
+description: Answer OpenClaw Console navigation/help questions with canonical links and command-centric steps.
+user-invocable: false
+metadata: {"openclaw": {"always": true}}
+---
+
+# openclaw-console-navigation
+
+Use this skill for customer prompts like:
+- "how to use console"
+- "how billing works"
+- "how to deploy"
+
+## Rules
+1. Give direct steps first (Open → Click → Review → Confirm).
+2. Include canonical console links in the same response.
+3. Prefer route-accurate guidance over generic advice.
+4. Keep answers concise and actionable.

--- a/packages/proxy/src/widget/widget.ts
+++ b/packages/proxy/src/widget/widget.ts
@@ -39,6 +39,11 @@
   const agentToken = activeScript?.getAttribute('data-agent-token')?.trim();
   if (!agentToken) return;
 
+  // Read optional user-token-key: tells the widget which localStorage key holds the API token.
+  // The embedding page sets  data-user-token-key="oc_access_token"  (or any key name).
+  const userTokenKey = activeScript?.getAttribute('data-user-token-key')?.trim();
+  const userToken = userTokenKey ? (win.localStorage?.getItem(userTokenKey)?.trim() ?? '') : '';
+
   const userId = (() => {
     const existing = win.localStorage?.getItem('lamoom_uid')?.trim();
     if (existing) return existing;
@@ -364,13 +369,11 @@
     socket.onopen = () => {
       retryCount = 0;
       sendButton.disabled = false;
-      socket?.send(
-        JSON.stringify({
-          type: 'auth',
-          agentToken,
-          userId,
-        }),
-      );
+      const authMsg: Record<string, unknown> = { type: 'auth', agentToken, userId };
+      if (userToken) {
+        authMsg['context'] = { token: userToken };
+      }
+      socket?.send(JSON.stringify(authMsg));
     };
 
     socket.onmessage = (event: { data?: unknown }) => {

--- a/packages/proxy/src/ws/handler.ts
+++ b/packages/proxy/src/ws/handler.ts
@@ -29,6 +29,7 @@ interface AuthenticatedSocket {
   authenticated: boolean;
   isAdmin: boolean;
   firstMessage: boolean;
+  userContext: Record<string, unknown>;
 }
 
 interface TokenLookup {
@@ -363,6 +364,7 @@ export function handleConnection(
     authenticated: false,
     isAdmin: false,
     firstMessage: false,
+    userContext: {},
   };
 
   // 30s auth timeout
@@ -468,9 +470,18 @@ export function handleConnection(
             ws.close(1011, 'Internal error');
             return;
           }
+
+          // Extract optional user context (e.g. API token) passed by the embedding page.
+          const rawContext = msg.context;
+          if (rawContext && typeof rawContext === 'object' && !Array.isArray(rawContext)) {
+            state.userContext = rawContext as Record<string, unknown>;
+            if (Object.keys(state.userContext).length > 0) {
+              state.firstMessage = true;
+            }
+          }
+
           state.authenticated = true;
           state.isAdmin = false;
-          state.firstMessage = false;
           clearTimeout(authTimeout);
 
           send(ws, { type: 'auth_ok', sessionId: state.sessionKey });
@@ -532,7 +543,18 @@ export function handleConnection(
 
             const prefixedAdminMessage
               = `[Lamoom Platform — Agent Creation Session]\nCustomer ID: ${state.userId}\nPlatform domain: ${domain}\n\nCustomer: ${customerContent}`;
-            const outboundMessage = state.isAdmin && state.firstMessage ? prefixedAdminMessage : customerContent;
+
+            let outboundMessage: string;
+            if (state.isAdmin && state.firstMessage) {
+              outboundMessage = prefixedAdminMessage;
+            } else if (!state.isAdmin && state.firstMessage && Object.keys(state.userContext).length > 0) {
+              const contextLines = Object.entries(state.userContext)
+                .map(([k, v]) => `${k}: ${String(v)}`)
+                .join('\n');
+              outboundMessage = `[Session Context]\n${contextLines}\n\nUser: ${customerContent}`;
+            } else {
+              outboundMessage = customerContent;
+            }
             let streamed = false;
             const result = await openclawClient.sendMessage({
               message: outboundMessage,
@@ -568,9 +590,7 @@ export function handleConnection(
               } else {
                 send(ws, { type: 'message', content: responseText, done: true });
               }
-              if (state.isAdmin) {
-                state.firstMessage = false;
-              }
+              state.firstMessage = false;
             } else {
               send(ws, { type: 'error', message: result.error || 'Agent error' });
             }

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -13,6 +13,7 @@ export type ClientMessage =
     token: string;
     ticket?: string;
     agentToken?: string;
+    context?: Record<string, unknown>;
   }
   | {
     type: 'auth';
@@ -21,6 +22,7 @@ export type ClientMessage =
     agentToken: string;
     token?: string;
     ticket?: string;
+    context?: Record<string, unknown>;
   }
   | {
     type: 'auth';
@@ -29,6 +31,7 @@ export type ClientMessage =
     ticket: string;
     token?: string;
     agentToken?: string;
+    context?: Record<string, unknown>;
   }
   | { type: 'message'; content: string; attachments?: MessageAttachment[] }
   | { type: 'ping' };


### PR DESCRIPTION
## Summary

- Widget now forwards the logged-in user's API token to the agent on every new session
- Agent receives the token as `[Session Context]` on the first turn and can use it for authenticated API calls
- Console layout updated to embed the widget with the correct token key

## Changes

| File | Change |
|---|---|
| `packages/proxy/src/widget/widget.ts` | Reads `data-user-token-key` attr, loads value from `localStorage`, sends as `context:{token}` in WS auth |
| `packages/shared/src/protocol.ts` | Added optional `context?: Record<string, unknown>` to all three auth message variants |
| `packages/proxy/src/ws/handler.ts` | Extracts `context` from auth message; stores as `userContext`; injects `[Session Context]\ntoken: <jwt>` prefix on first widget message; flips `firstMessage=false` unconditionally after first turn |
| `packages/admin/src/app/console/layout.tsx` *(OpenClawBot/www)* | Added `<Script>` with `data-agent-token` + `data-user-token-key="oc_access_token"` |
| `openclaw/workspaces/meta/templates/knowledgebase/openclaw-console-navigation.md` | Full `/api/v1` endpoint reference |
| `openclaw/workspaces/meta/templates/AGENTS-openclaw-console-navigation.md` | Updated agent persona with API action table |
| `.agents/skills/openclaw-console-agent-bootstrap/SKILL.md` | Bootstrap skill with full create-agent prompt |

## Smoke test result

WS auth with `context:{token:"eyJ..."}` → `auth_ok` → agent replied:
> *"I have a **JWT bearer token** in your session context… used for authenticating API requests to the OpenClaw Console backend."*

## How to test

1. Open `dev.lamoom.com/console` (after `console/layout.tsx` is deployed)
2. Open browser DevTools → Network → WS → find the `/ws` connection
3. In the auth frame, confirm `context.token` contains the user's `oc_access_token`
4. Send "What API token do you have?" — agent should quote the JWT back
