### PR TITLE
fix: restore kimi-k2.5-thinking as default model ID

### DIFF
--- a/openclaw/config/openclaw.json5
+++ b/openclaw/config/openclaw.json5
@@ -15,7 +15,7 @@
   agents: {
     defaults: {
       workspace: "~/.openclaw/workspace",
-      model: "azure-openai/gpt-5.1",
+      model: "azure-openai/kimi-k2.5-thinking",
       // Workspace-scoped sandboxing: no Docker, file tools restricted to workspace only
       sandbox: { mode: "off" },
       heartbeat: {
@@ -101,8 +101,7 @@
         apiKey: "${AZURE_DEV_AI_API_KEY}",
         api: "openai-completions",
         models: [
-          { id: "kimi-k2.5-thinking", name: "Kimi K2.5 Thinking" },
-          { id: "gpt-5.1", name: "GPT-5.1 (Azure)" },
+          { id: "kimi-k2.5-thinking", name: "GPT-5.1 (Azure)" },
         ],
       },
     },


### PR DESCRIPTION
PR #150 accidentally changed the default model to `azure-openai/gpt-5.1` and added a spurious `gpt-5.1` model entry. The Azure deployment only has `kimi-k2.5-thinking` — its **display name** is "GPT-5.1 (Azure)". This reverts to the correct model ID and sets the display name correctly.