### PR TITLE
fix: rename widget markdown tokens to avoid italic regex collision

### DIFF
--- a/packages/proxy/src/widget/widget.ts
+++ b/packages/proxy/src/widget/widget.ts
@@ -179,7 +179,7 @@
     const codeBlocks: Array<{ token: string; html: string }> = [];
     // Strip optional language label (e.g. ```json) from the code content
     escaped = escaped.replace(/```([a-zA-Z0-9_-]*)\n?([\s\S]*?)(?:```|$)/g, (_match, _lang: string, code: string) => {
-      const token = `@@LAMOOM_CODE_BLOCK_${codeBlocks.length}@@`;
+      const token = `@@LAMBLK${codeBlocks.length}@@`;
       codeBlocks.push({
         token,
         html: `<pre class="lamoom-code-block"><code>${code.replace(/\n$/, '')}</code></pre>`,
@@ -190,7 +190,7 @@
     // --- Inline code ---
     const inlineCodes: Array<{ token: string; html: string }> = [];
     escaped = escaped.replace(/`([^`\n]+?)`/g, (_match, code: string) => {
-      const token = `@@LAMOOM_INLINE_CODE_${inlineCodes.length}@@`;
+      const token = `@@LAMINC${inlineCodes.length}@@`;
       inlineCodes.push({
         token,
         html: `<code class="lamoom-inline-code">${code}</code>`,
@@ -239,7 +239,7 @@
           }
 
           // Code block token (pass through)
-          if (/^@@LAMOOM_CODE_BLOCK_\d+@@$/.test(trimmed)) {
+          if (/^@@LAMBLK\d+@@$/.test(trimmed)) {
             flushText();
             flushList();
             parts.push(trimmed);


### PR DESCRIPTION
## Problem

The markdown tokenizer in `widget.ts` used `@@LAMOOM_INLINE_CODE_N@@` and `@@LAMOOM_CODE_BLOCK_N@@` as placeholder tokens. These tokens contain underscores, which were matched by the italic regex (`_..._`) further down in the same function, corrupting the tokens before `applyTokens` could restore them.

**Observed in DOM:**
```html
<p>Based on your billing info, you're on the @@LAMOOM<em>INLINE</em>CODE_0@@ plan.</p>
```

## Fix

Renamed both token formats to remove all underscores from their interiors:

- `@@LAMOOM_INLINE_CODE_N@@` → `@@LAMINCN@@`
- `@@LAMOOM_CODE_BLOCK_N@@` → `@@LAMBLKN@@`

Also updated the code-block pass-through regex to match the new format.