### PR TITLE
Implement meta history, streaming, markdown, and real widget embed

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -210,23 +210,34 @@ Admin UI /create page (WS) or POST /api/agents/create-via-meta (REST)
   │ Sends latest customer message
   ▼
 Proxy routes to OpenClaw (model: "openclaw/meta")
-  │ sessionKey:
-  │ - REST path: "agent:meta:admin-<customerId>-<sessionId>"
-  │ - WS path:   "agent:meta:admin-<customerId>-<randomUUID>"
+  │ sessionKey: stable per-customer from DB
+  │ - "agent:meta:admin-<customerId>"
+  │   (stored in meta_agent_sessions; one row per customer;
+  │    reused on every reconnect for conversation continuity)
+  ▼
+WS auth flow:
+  │ 1. proxy calls getMetaHistory(customerId)
+  │ 2. sends { type: "history", messages[], embedCode? } to client
+  │ 3. client restores chat state from history
   ▼
 OpenClaw meta-agent (workspace: openclaw/workspaces/meta/)
   │ Phase 1: fetch + due diligence packet + one confirmation
-  │ Phase 2: create-agent skill writes customer workspace from templates:
+  │ Phase 2: create-agent skill (Step 0: select specialized templates if available)
+  │   writes customer workspace from templates:
   │    AGENTS.md, SOUL.md, IDENTITY.md, TOOLS.md, USER.md
-  │    + skills + knowledgebase + agent-config.json
+  │    + skills (website-knowledge, website-api, any specialized skills)
+  │    + knowledgebase (overview, key-links, use-cases, api-reference)
+  │    + agent-config.json  ← includes skills[] array
   │ Emits [AGENT_CREATED::<slug>] marker in response
+  │ Streaming: tokens delivered via onDelta → { type:"message", done:false }
   ▼
 Proxy detects [AGENT_CREATED::<slug>] marker in response
   │ Reads <workspace>/agent-config.json
-  │ Registers slug in OpenClaw config (configured path precedence)
+  │ Registers slug + skills[] in OpenClaw config (path precedence)
   │ Reloads openclaw-gateway (SIGHUP, systemctl fallback)
   │ Upserts DB records (agent + widget_embed) and embed token
-  │ Appends embed snippet to response
+  │ Appends embed snippet to done:true message (admin WS)
+  │ Persists user + assistant messages to meta_agent_messages
   ▼
 Customer sees agent confirmation + widget <script> snippet
 ```
@@ -251,12 +262,13 @@ Customer logs in → Dashboard
 | Widget embed identity | `widget_embeds.embedToken` | Script token resolves to one active `agents` row |
 | Website visitor identity | `widget_sessions.externalUserId` | Provided by widget auth payload (`userId`) |
 | Widget chat session | `widget_sessions` row keyed by `(agentId, externalUserId)` | `openclawSessionKey = agent:<openclawAgentId>:widget-<openclawAgentId>-<externalUserId>` |
-| Admin create/manage session | Session key only | `agent:meta:admin-<customerId>-<sessionId-or-uuid>` |
+| Admin create/manage session | `meta_agent_sessions` row keyed by `customerId` | `openclawSessionKey = agent:meta:admin-<customerId>` (stable; one per customer) |
 
 Deterministic mapping in proxy:
 - `getOrCreateSession(agentId, externalUserId, openclawAgentId)` upserts one `widget_sessions` row per `(agentId, externalUserId)`.
 - Reconnecting with same `agentToken + userId` reuses the same OpenClaw conversation context.
 - Changing `userId` creates a different OpenClaw session key and isolated thread.
+- Admin WS auth retrieves the persisted `meta_agent_sessions.openclawSessionKey` and sends the full `history` message before the first response.
 
 ## Meta-agent template generation process
 
@@ -264,12 +276,58 @@ Deterministic mapping in proxy:
 After discovery is confirmed, the meta-agent derives customer-specific values and writes files into:
 `/opt/webagent/openclaw/workspaces/<agentSlug>/`.
 
-Template roles used for each customer agent:
+### Step 0 — Specialized template selection
+
+Before writing any files, the meta-agent scans the `templates/` directory (relative to its workspace)
+for site-specific templates matching the target website. Specialized templates are identified by suffix,
+for example `AGENTS-openclaw-console-navigation.md` or `skills/openclaw-console-navigation/SKILL.md`.
+When a match is found, the specialized template is used **instead of** the generic base template, since
+it already contains verified endpoint tables, auth flows, and canonical links for that site.
+
+### Template roles
+
 - `AGENTS.md` — operating instructions, scope boundaries, and behavior rules.
 - `SOUL.md` — persona/tone profile for response style.
 - `IDENTITY.md` — identity metadata (name, creature, vibe, emoji, optional avatar).
 - `TOOLS.md` — local operational notes (API base URL/auth scheme/integration labels); never secrets.
 - `USER.md` — per-session visitor context assumptions.
+
+### Skills and knowledgebase generation
+
+Always written:
+- `skills/website-knowledge/SKILL.md` — knowledge skill grounded in verified website facts.
+- `knowledgebase/overview.md`, `key-links.md`, `use-cases.md`.
+
+Written when API is detected:
+- `skills/website-api/SKILL.md` — API interaction skill with:
+  - full endpoint table (method, path, description, request body, response shape)
+  - `fetch` tool usage examples with correct base URL, auth header format, content type
+  - exact request body shapes for all mutating endpoints
+- `knowledgebase/api-reference.md` — structured endpoint reference table.
+
+Written for specialized sites (from Step 0):
+- Any specialized skills found in the templates directory (e.g., `skills/openclaw-console-navigation/SKILL.md`).
+
+### `agent-config.json`
+
+`write` at `<workspacePath>/agent-config.json`:
+```json
+{
+  "agentSlug": "<agentSlug>",
+  "agentName": "<agentName>",
+  "websiteName": "<websiteName>",
+  "websiteUrl": "<websiteUrl>",
+  "apiDescription": "<short description of API capabilities>",
+  "apiBaseUrl": "<API base URL if provided>",
+  "skills": ["website-api"],
+  "createdAt": "<ISO timestamp>"
+}
+```
+
+The `skills` array lists **all skill directory names** created in the workspace. The proxy reads this
+array and propagates it into the OpenClaw gateway config entry for the new agent (`agents.list[].skills`).
+This is the mechanism by which generated skills become active on the gateway — without it, the gateway
+registers the agent with no skills.
 
 Generation inputs come from meta-agent due diligence:
 - verified website facts and product summary,
@@ -277,8 +335,8 @@ Generation inputs come from meta-agent due diligence:
 - API capabilities/auth/base URL (when available),
 - brand voice cues.
 
-The meta-agent then writes skills + knowledgebase files, emits `[AGENT_CREATED::<slug>]`,
-and the proxy completes registration + embed issuance.
+The meta-agent emits `[AGENT_CREATED::<slug>]` after writing files; the proxy completes registration
+and embed issuance.
 
 OpenClaw template references:
 - `https://docs.openclaw.ai/reference/templates/AGENTS`
@@ -427,7 +485,7 @@ webagent/
 - Widget session key format:
   `agent:<openclawAgentId>:widget-<openclawAgentId>-<externalUserId>`
 - Admin/meta session key format:
-  `agent:meta:admin-<customerId>-<sessionId-or-uuid>`
+  `agent:meta:admin-<customerId>` (stable; stored in `meta_agent_sessions`; reused on every reconnect)
 - Streaming: gateway sends `agent` events token-by-token; proxy relays to client
 - Fallback: `/v1/responses` HTTP endpoint available for simple request-response
 - Hooks API (`/hooks/agent`) kept only for fire-and-forget (wake, cron triggers)
@@ -513,6 +571,23 @@ audit_log
   action      TEXT NOT NULL
   details     JSONB DEFAULT '{}'
   createdAt   TIMESTAMP
+
+meta_agent_sessions                        ← durable meta-agent session record (one per customer)
+  id                  UUID PK
+  customerId          UUID FK → customers.id (CASCADE)
+  openclawSessionKey  TEXT UNIQUE NOT NULL  ← "agent:meta:admin-<customerId>"
+  lastActiveAt        TIMESTAMP
+  createdAt           TIMESTAMP
+  UNIQUE(customerId)                        ← enforces one active thread per customer
+  INDEX(customerId)
+
+meta_agent_messages                        ← ordered message log for the meta-agent thread
+  id          UUID PK
+  sessionId   UUID FK → meta_agent_sessions.id (CASCADE)
+  role        TEXT NOT NULL                ← 'user' | 'assistant'
+  content     TEXT NOT NULL
+  createdAt   TIMESTAMP
+  INDEX(sessionId, createdAt)              ← efficient ordered retrieval
 ```
 
 ---
@@ -595,6 +670,9 @@ Proxy websocket `maxPayload` is configured to 12 MiB so base64-encoded attachmen
 ```typescript
 { type: "auth_ok", sessionId: string }                  // Auth succeeded
 { type: "auth_error", reason: string }                  // Auth failed
+{ type: "history", sessionId: string, messages: Array<{ role: "user" | "assistant", content: string }>, embedCode?: string }
+                                                         // Sent immediately after auth_ok in admin mode;
+                                                         // delivers persisted conversation history + any prior embed code
 { type: "message", content: string, done: boolean }     // Agent response
 { type: "error", message: string }                      // Error
 { type: "pong" }                                        // Keepalive response
@@ -613,8 +691,14 @@ POST   /api/agents/:id/embed-token   Regenerate embed token
 
 # Meta-agent chat (admin UI WS or REST fallback)
 POST   /api/agents/create-via-meta   Send message to meta-agent, returns response
-                                     Proxy detects agent creation in response,
-                                     auto-creates DB records + embed token
+                                     Proxy uses persisted sessionKey from DB;
+                                     detects agent creation marker in response,
+                                     auto-creates DB records + embed token;
+                                     persists user + assistant messages to DB
+
+GET    /api/agents/meta-history      Retrieve durable meta-agent conversation history
+                                     Returns { sessionId, messages[], embedCode? }
+                                     Used by admin UI to restore chat state on reload
 
 # Health
 GET    /health                       Proxy health
@@ -839,7 +923,162 @@ Current VM usage ~1.5GB → total ~1.85GB on 4GB CAX11. Feasible.
 
 ---
 
-## Production Gaps (updated 2026-04-25)
+---
+
+## Meta-Agent History Persistence (issue #164)
+
+### Why
+
+Before this change, each browser navigation to `/create` started a fresh meta-agent thread.
+OpenClaw retained conversation state server-side as long as the session key was reused, but
+the proxy always generated a new random UUID suffix for the admin session key on each page
+load (`agent:meta:admin-<customerId>-<randomUUID>`). Widget continuity (existing embed codes)
+was also lost because the proxy could not find an earlier response containing the embed code.
+
+### Architecture
+
+Two new DB tables added via migration (`0001_public_electro.sql`):
+
+```
+meta_agent_sessions  — one row per customer; stores the stable OpenClaw session key
+meta_agent_messages  — append-only message log (role + content + createdAt)
+```
+
+The session key is now **deterministic**: `agent:meta:admin-<customerId>` (no random suffix).
+`meta_agent_sessions` enforces a unique index on `customerId` — upsert on conflict so reconnects
+refresh `last_active_at` without creating a second row.
+
+`meta_agent_messages_session_created_idx` (compound index on `sessionId, createdAt`) exists for
+efficient ordered retrieval of message history.
+
+### Retrieval paths
+
+| Path | How |
+|---|---|
+| WS admin auth | After `auth_ok`, proxy calls `getMetaHistory`, sends `{ type: "history", sessionId, messages[], embedCode? }` |
+| REST `GET /api/agents/meta-history` | Returns same shape; used for page-load hydration |
+| REST `POST /api/agents/create-via-meta` | Reads history to reuse `openclawSessionKey`; response includes `sessionId` |
+
+### Persistence guarantee
+
+Messages are written to DB **only after** a successful OpenClaw response. If the OpenClaw send
+fails, neither the user nor the assistant message is persisted — preventing DB state from diverging
+from the agent's in-memory conversation context.
+
+---
+
+## Streaming Behavior (issue #164)
+
+Both the meta/admin (WS) and widget (WS) flows now stream token-by-token using `onDelta` callbacks.
+
+### WS flow (both admin and widget)
+
+```
+OpenClaw gateway                 Proxy WS handler            Client
+      │                                 │                        │
+      │  agent event (delta token)      │                        │
+      ├────────────────────────────────►│  { type:"message",     │
+      │                                 │    content: delta,     │
+      │                                 │    done: false }       │
+      │                                 ├───────────────────────►│
+      │  ...more deltas...              │  ...                   │
+      │  last delta                     │                        │
+      ├────────────────────────────────►│  { type:"message",     │
+      │                                 │    content: embedSuffix│
+      │                                 │    or "",              │
+      │                                 │    done: true }        │
+      │                                 ├───────────────────────►│
+```
+
+If no `onDelta` events arrive (non-streaming model), the full response is delivered as a single
+`{ type: "message", content: fullText, done: true }` message.
+
+For admin sessions where an agent was just created, any embed code suffix is appended as the
+`done: true` message (after streaming chunks have already delivered the main response text).
+
+### REST `create-via-meta`
+
+This endpoint uses a blocking `sendMessage` call (no streaming). The full response is returned
+in a single JSON envelope. Streaming is a WS-only feature for this route.
+
+---
+
+## Markdown Rendering (issue #164)
+
+### Widget (`packages/proxy/src/widget/widget.ts`)
+
+The widget uses a hand-rolled tokenizer that converts Markdown to HTML strings:
+- `renderMarkdown(raw)` → HTML string → assigned via `innerHTML` for assistant messages
+- User messages use `textContent` (no interpretation of any formatting)
+- Supported: bold, italic, inline code, fenced code blocks, ordered/unordered lists, links, headings
+
+**Safety model:** links have their `href` stripped and the `target="_blank" rel="noopener noreferrer"`
+attributes set. No external HTML or script injection is possible because user messages always use
+`textContent`, and the assistant Markdown parser emits only the known node types above.
+
+### Admin chat (`packages/admin/src/lib/markdown.tsx`)
+
+The admin uses a custom parser that returns **React nodes** (not HTML strings), so there is no
+`dangerouslySetInnerHTML` or `innerHTML` path:
+- `renderMarkdownToReactNodes(input)` → `ReactNode[]` rendered by React's reconciler
+- `isSafeHref(href)` validates all link hrefs; only `http:`, `https:`, `mailto:`, `tel:`,
+  and relative paths are allowed — everything else is rendered as plain text.
+- Supported: paragraphs, ordered/unordered lists, inline code, fenced code blocks, links.
+
+---
+
+## Real Widget Embed on Agent Detail Page (issue #164)
+
+### Before
+
+`WidgetPreview` was a fully custom React chat UI that opened its own WebSocket connection to the
+proxy. It looked like the widget but was a simulated facsimile — it did not load or execute the
+actual `widget.js` bundle, so UI regressions in the real widget would not be visible here.
+
+### Now
+
+`WidgetPreview` renders an `<iframe>` whose `srcDoc` contains the real `<script>` embed tag:
+
+```html
+<script src="<widgetHost>/widget.js"
+        data-agent-token="<embedToken>" async></script>
+```
+
+The iframe's `srcDoc` is a minimal HTML document; `widgetHost` is resolved at runtime from
+`window.location.origin` (so it works on both dev and production without hardcoded URLs).
+This means the agent detail page now exercises the exact same code path a website visitor sees.
+
+---
+
+## Operational Notes — Migrations (issue #164)
+
+### Required: run migration after deploy
+
+Two new tables (`meta_agent_sessions`, `meta_agent_messages`) were added via Drizzle migration
+`0001_public_electro.sql`. A second migration `0002_conscious_true_believers.sql` adds the
+performance index on `(session_id, created_at)`.
+
+Run after each deploy that includes these migrations:
+
+```bash
+pnpm --filter @webagent/proxy drizzle-kit push
+```
+
+or using the deploy script which runs `db:migrate` automatically.
+
+### No data loss on rollback
+
+Rolling back to the pre-history code without dropping the new tables is safe — the old code
+simply does not read or write them. The tables can be dropped manually if needed:
+
+```sql
+DROP TABLE IF EXISTS meta_agent_messages;
+DROP TABLE IF EXISTS meta_agent_sessions;
+```
+
+---
+
+## Production Gaps (updated 2026-04-28)
 
 ### ✅ Done & Working
 - Monorepo scaffold (pnpm + Turborepo, all packages build)
@@ -871,6 +1110,12 @@ Current VM usage ~1.5GB → total ~1.85GB on 4GB CAX11. Feasible.
 - CORS: Widget embed origin validation enforced in WS auth handshake
 - Graceful shutdown: SIGTERM/SIGINT handlers with WS drain
 - E2E: Full agent creation flow verified (BookNest: create → register → chat → widget preview)
+- ✅ Meta-agent history persisted to DB (`meta_agent_sessions` + `meta_agent_messages`); restored on WS auth and `GET /api/agents/meta-history` (issue #164)
+- ✅ Admin meta-session key is stable (`agent:meta:admin-<customerId>`); embed code survives page refresh via history retrieval (issue #164)
+- ✅ Generation pipeline: `agent-config.json` `skills` array propagated to gateway config on registration; specialized templates selected at Step 0 (issue #164)
+- ✅ Streaming: WS admin and widget flows deliver token-by-token via `onDelta`; `done:true` sent after last delta (issue #164)
+- ✅ Markdown: widget uses `innerHTML`-based renderer (assistant only); admin chat uses React-node renderer with `isSafeHref` — no raw HTML execution in either path (issue #164)
+- ✅ Agent detail page: `WidgetPreview` loads real `<script>` embed in an iframe instead of a custom WS simulator (issue #164)
 
 ### 🔴 BLOCKING — Must Fix Before Any Production Launch
 
@@ -935,7 +1180,7 @@ Current VM usage ~1.5GB → total ~1.85GB on 4GB CAX11. Feasible.
 31. Magic link form shown even when `EMAIL_SERVER` is unset — will error on click.
 32. Widget preview has no auto-reconnect on disconnect.
 33. No inline agent editing (name, URL, prompt) after creation.
-34. No conversation persistence in create-agent-chat across page refresh.
+34. **(resolved 2026-04-28)** Conversation persistence in create-agent-chat across page refresh — now backed by `meta_agent_sessions` + `meta_agent_messages` (issue #164).
 35. Hardcoded `dev.lamoom.com` fallbacks in proxy and admin code.
 36. Settings page is a non-functional stub.
 37. No migration rollback strategy.

--- a/openclaw/templates/AGENTS.md
+++ b/openclaw/templates/AGENTS.md
@@ -13,8 +13,9 @@ You help website visitors with questions about {{WEBSITE_NAME}}. You can:
 1. **Stay in scope.** Only help with topics related to {{WEBSITE_NAME}}. Politely redirect off-topic questions.
 2. **Be accurate.** If you don't know something, say so. Never fabricate information about the product.
 3. **Use the API.** When a visitor asks to perform an action (check order status, search products, etc.), use the website-api skill.
-4. **Be concise.** Website visitors want quick answers, not essays.
-5. **Respect privacy.** Never expose internal system details, API keys, or other visitors' data.
+4. **Use `fetch` for HTTP.** Make API calls with the `fetch` tool — never use `exec` or shell commands.
+5. **Be concise.** Website visitors want quick answers, not essays.
+6. **Respect privacy.** Never expose internal system details, API keys, or other visitors' data.
 
 ## About the Product
 {{API_DESCRIPTION}}

--- a/openclaw/templates/skills/website-api/SKILL.md
+++ b/openclaw/templates/skills/website-api/SKILL.md
@@ -19,6 +19,32 @@ This skill enables you to interact with **{{WEBSITE_NAME}}**'s API on behalf of 
 
 {{API_ENDPOINTS}}
 
+<!-- GENERATION NOTE: When filling this section, use a structured table format:
+| Method | Path | Description | Request Body | Response |
+|--------|------|-------------|-------------|----------|
+| GET | /resource | List all | — | [{id, name}] |
+| POST | /resource | Create one | {name, type} | {id, name} |
+| POST | /resource/:id/restart | Restart | — | {status: "ok"} |
+| DELETE | /resource/:id | Delete | — | 204 |
+
+List EVERY endpoint from the API. Do not omit any. -->
+
+## How to Call the API
+
+Use the **`fetch`** tool to make HTTP requests. Example:
+
+```
+fetch("{{API_BASE_URL}}/endpoint", {
+  method: "POST",
+  headers: { "Content-Type": "application/json", "Authorization": "Bearer <token>" },
+  body: JSON.stringify({ key: "value" })
+})
+```
+
+- For GET requests: `fetch("{{API_BASE_URL}}/resource")`
+- For POST/PUT/DELETE: include `method`, `headers`, and `body` as needed.
+- Parse the JSON response and present results in plain language.
+
 ## Usage Rules
 
 1. **Always confirm** before performing actions that modify data (e.g., placing orders, updating profiles).
@@ -30,10 +56,10 @@ This skill enables you to interact with **{{WEBSITE_NAME}}**'s API on behalf of 
 ## Example Interaction
 
 Visitor: "What products do you have?"
-→ Call `GET {{API_BASE_URL}}/products`
+→ Use `fetch` to call `GET {{API_BASE_URL}}/products`
 → Format the response as a friendly list
 
 Visitor: "Add the blue shirt to my cart"
 → Confirm: "I'll add the Blue Shirt ($29.99) to your cart. Proceed?"
-→ On yes: Call `POST {{API_BASE_URL}}/cart/items` with product ID
+→ On yes: Use `fetch` to call `POST {{API_BASE_URL}}/cart/items` with product ID
 → Respond: "Done! Blue Shirt added to your cart."

--- a/openclaw/workspaces/meta/skills/create-agent/SKILL.md
+++ b/openclaw/workspaces/meta/skills/create-agent/SKILL.md
@@ -26,23 +26,34 @@ If links are missing, infer from fetched content and include only verified URLs.
 
 ## 4-Step Flow
 
+### Step 0 — Select templates (BEFORE writing files)
+
+Before generating, scan the `templates/` directory (relative to this workspace) for **specialized templates** that match the target website. Specialized templates have a site-specific suffix — for example:
+- `AGENTS-openclaw-console-navigation.md` → use for openclaw console agents instead of generic `AGENTS.md`
+- `skills/openclaw-console-navigation/SKILL.md` → include as an extra skill
+- `knowledgebase/openclaw-console-navigation.md` → include as the API reference knowledgebase
+
+**Selection rule:** if a specialized template matches the website being onboarded, prefer it over the generic template. Copy its content as-is (filling only genuinely dynamic values like names/URLs), because specialized templates already contain verified endpoint tables, auth flows, and canonical links.
+
 ### Step 1 — Generate workspace files via `write`
 
 Derive:
 - `agentSlug` = website name lowercased, non-alphanumeric collapsed to hyphens, trim edge hyphens, then append `-<customerIdFirst8>` (first 8 chars of customer ID) for customer-unique slugs.
 - `workspacePath` = `/opt/webagent/openclaw/workspaces/<agentSlug>`
 
-Read templates from `templates/` directory (relative to this workspace) as starting point, then `write`:
-- `<workspacePath>/AGENTS.md` — agent personality and instructions
+Read templates from `templates/` directory as starting point (using specialized templates from Step 0 when available), then `write`:
+- `<workspacePath>/AGENTS.md` — agent personality and instructions (use specialized AGENTS template if found)
 - `<workspacePath>/SOUL.md` — brand voice and values
 - `<workspacePath>/IDENTITY.md` — name and role
 - `<workspacePath>/TOOLS.md` — environment/local operational notes (no secrets)
 - `<workspacePath>/USER.md` — expected user context
 - `<workspacePath>/skills/website-knowledge/SKILL.md` — knowledge skill grounded in website facts and links
 - `<workspacePath>/skills/website-api/SKILL.md` — API interaction skill (only if API exists)
+- Any specialized skills found in Step 0 (e.g., `<workspacePath>/skills/openclaw-console-navigation/SKILL.md`)
 - `<workspacePath>/knowledgebase/overview.md` — product summary + capabilities
 - `<workspacePath>/knowledgebase/key-links.md` — canonical visitor links
 - `<workspacePath>/knowledgebase/use-cases.md` — concrete role/use-case examples
+- `<workspacePath>/knowledgebase/api-reference.md` — **required when API exists**: full endpoint table with method, path, request body, response shape, and auth requirements. Use specialized knowledgebase template if found.
 
 Fill all files with customer-specific values (website name, product, API details, tone, links).
 
@@ -60,6 +71,12 @@ In generated files, always include:
 5. A rule in AGENTS/knowledge skill: when asked "how do I install", return the direct install link (and docs link) explicitly.
 6. `TOOLS.md` entries for practical operator context (API base URL, auth scheme, important integration labels) without storing credentials or secrets.
 
+**API quality bar (when API exists):**
+7. `knowledgebase/api-reference.md` must contain a **structured endpoint table** with columns: Method, Path, Description, Request Body (if applicable), Response Shape.
+8. The `website-api` skill's `Available Actions` section must list **every** API endpoint as a table row — never omit endpoints mentioned in the user prompt or discovered during due diligence.
+9. The `website-api` skill must include `fetch` tool usage examples specific to the API (correct base URL, auth header format, content type).
+10. For mutating endpoints (POST, PUT, DELETE, PATCH), the skill must include the exact request body shape.
+
 ### Step 3 — Write agent config file
 
 `write` a JSON file at `<workspacePath>/agent-config.json`:
@@ -71,9 +88,12 @@ In generated files, always include:
   "websiteUrl": "<websiteUrl>",
   "apiDescription": "<short description of API capabilities>",
   "apiBaseUrl": "<API base URL if provided>",
+  "skills": ["website-api"],
   "createdAt": "<ISO timestamp>"
 }
 ```
+
+The `skills` array lists all skill directory names created in the workspace. Always include `"website-api"` when an API exists. Add any specialized skills created in Step 1 (e.g., `"openclaw-console-navigation"`). The proxy reads this array to register skills in the gateway config.
 
 ### Step 4 — Signal completion to proxy
 

--- a/openclaw/workspaces/meta/templates/AGENTS-openclaw-console-navigation.md
+++ b/openclaw/workspaces/meta/templates/AGENTS-openclaw-console-navigation.md
@@ -14,7 +14,7 @@ on their behalf when they are authenticated.
 - Explain tenant statuses, plans, billing, and specialists
 
 ### API actions (when user is authenticated)
-Call `/api/v1` endpoints on behalf of the user:
+Call `/api/v1` endpoints on behalf of the user using the **`fetch`** tool:
 
 | Action | Endpoint |
 |---|---|
@@ -44,3 +44,4 @@ Call `/api/v1` endpoints on behalf of the user:
 3. Include at least one canonical link when relevant.
 4. Before calling any mutating API (create/delete/restart), confirm with the user.
 5. Never expose tokens, credentials, or internal system details.
+6. Use the `fetch` tool for all HTTP/API calls — never use `exec` or shell commands.

--- a/openclaw/workspaces/meta/templates/AGENTS.md
+++ b/openclaw/workspaces/meta/templates/AGENTS.md
@@ -14,9 +14,10 @@ You help website visitors with questions about {{WEBSITE_NAME}}. You can:
 1. **Stay in scope.** Only help with topics related to {{WEBSITE_NAME}}. Politely redirect off-topic questions.
 2. **Be accurate.** If you don't know something, say so. Never fabricate information about the product.
 3. **Use the API.** When a visitor asks to perform an action (check order status, search products, etc.), use the website-api skill.
-4. **Be concise.** Website visitors want quick answers, not essays.
-5. **Respect privacy.** Never expose internal system details, API keys, or other visitors' data.
-6. **Link-first for setup/support.** For install, onboarding, docs, pricing, and support questions, include direct URLs when known.
+4. **Use `fetch` for HTTP.** Make API calls with the `fetch` tool — never use `exec` or shell commands.
+5. **Be concise.** Website visitors want quick answers, not essays.
+6. **Respect privacy.** Never expose internal system details, API keys, or other visitors' data.
+7. **Link-first for setup/support.** For install, onboarding, docs, pricing, and support questions, include direct URLs when known.
 
 ## About the Product
 {{API_DESCRIPTION}}

--- a/openclaw/workspaces/meta/templates/skills/openclaw-console-navigation/SKILL.md
+++ b/openclaw/workspaces/meta/templates/skills/openclaw-console-navigation/SKILL.md
@@ -17,3 +17,4 @@ Use this skill for customer prompts like:
 2. Include canonical console links in the same response.
 3. Prefer route-accurate guidance over generic advice.
 4. Keep answers concise and actionable.
+5. For API actions (restart, delete, create), use the `fetch` tool to call the endpoint and report the result.

--- a/openclaw/workspaces/meta/templates/skills/website-api/SKILL.md
+++ b/openclaw/workspaces/meta/templates/skills/website-api/SKILL.md
@@ -19,6 +19,32 @@ This skill enables you to interact with **{{WEBSITE_NAME}}**'s API on behalf of 
 
 {{API_ENDPOINTS}}
 
+<!-- GENERATION NOTE: When filling this section, use a structured table format:
+| Method | Path | Description | Request Body | Response |
+|--------|------|-------------|-------------|----------|
+| GET | /resource | List all | — | [{id, name}] |
+| POST | /resource | Create one | {name, type} | {id, name} |
+| POST | /resource/:id/restart | Restart | — | {status: "ok"} |
+| DELETE | /resource/:id | Delete | — | 204 |
+
+List EVERY endpoint from the API. Do not omit any. -->
+
+## How to Call the API
+
+Use the **`fetch`** tool to make HTTP requests. Example:
+
+```
+fetch("{{API_BASE_URL}}/endpoint", {
+  method: "POST",
+  headers: { "Content-Type": "application/json", "Authorization": "Bearer <token>" },
+  body: JSON.stringify({ key: "value" })
+})
+```
+
+- For GET requests: `fetch("{{API_BASE_URL}}/resource")`
+- For POST/PUT/DELETE: include `method`, `headers`, and `body` as needed.
+- Parse the JSON response and present results in plain language.
+
 ## Usage Rules
 
 1. **Always confirm** before performing actions that modify data (e.g., placing orders, updating profiles).
@@ -30,10 +56,10 @@ This skill enables you to interact with **{{WEBSITE_NAME}}**'s API on behalf of 
 ## Example Interaction
 
 Visitor: "What products do you have?"
-→ Call `GET {{API_BASE_URL}}/products`
+→ Use `fetch` to call `GET {{API_BASE_URL}}/products`
 → Format the response as a friendly list
 
 Visitor: "Add the blue shirt to my cart"
 → Confirm: "I'll add the Blue Shirt ($29.99) to your cart. Proceed?"
-→ On yes: Call `POST {{API_BASE_URL}}/cart/items` with product ID
+→ On yes: Use `fetch` to call `POST {{API_BASE_URL}}/cart/items` with product ID
 → Respond: "Done! Blue Shirt added to your cart."

--- a/packages/admin/src/app/dashboard/agents/[id]/page.tsx
+++ b/packages/admin/src/app/dashboard/agents/[id]/page.tsx
@@ -83,7 +83,7 @@ export default async function AgentDetailPage({ params }: Props) {
             <CardDescription>Try chatting with your agent below. This is exactly what your visitors will see.</CardDescription>
           </CardHeader>
           <CardContent>
-            <WidgetPreview agentToken={agent.embedToken} />
+            <WidgetPreview agentToken={agent.embedToken} widgetBaseUrl={WIDGET_BASE_URL} />
           </CardContent>
         </Card>
       )}

--- a/packages/admin/src/components/create-agent-chat.tsx
+++ b/packages/admin/src/components/create-agent-chat.tsx
@@ -3,6 +3,7 @@
 import { useRef, useEffect, useState, useCallback } from "react";
 import { Bot, SendHorizontal, Copy, Check, Paperclip, X } from "lucide-react";
 import { type MetaAgentMessage } from "@/lib/api";
+import { renderMarkdownToReactNodes } from "@/lib/markdown";
 import { cn } from "@/lib/utils";
 
 const EMBED_CODE_RE = /<script[^>]*data-agent-token[^>]*><\/script>/;
@@ -61,6 +62,7 @@ export function CreateAgentChat({ customerId }: CreateAgentChatProps) {
   const mountedRef = useRef(true);
   const shouldReconnectRef = useRef(true);
   const authFailureNotifiedRef = useRef(false);
+  const streamingIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -130,6 +132,25 @@ export function CreateAgentChat({ customerId }: CreateAgentChatProps) {
           return;
         }
 
+        if (data.type === "history") {
+          const rawMessages = Array.isArray(data.messages) ? data.messages : [];
+          const parsedMessages: MetaAgentMessage[] = rawMessages
+            .map((message) => {
+              if (!message || typeof message !== "object") return null;
+              const value = message as { role?: unknown; content?: unknown };
+              if ((value.role !== "user" && value.role !== "assistant") || typeof value.content !== "string") {
+                return null;
+              }
+              return { role: value.role, content: value.content };
+            })
+            .filter((message): message is MetaAgentMessage => !!message);
+          setMessages(parsedMessages);
+          if (typeof data.embedCode === "string" && data.embedCode.trim()) {
+            setEmbedCode(data.embedCode.trim());
+          }
+          return;
+        }
+
         if (data.type === "auth_error") {
           const reason = typeof data.reason === "string" && data.reason.trim().length > 0
             ? data.reason
@@ -151,19 +172,57 @@ export function CreateAgentChat({ customerId }: CreateAgentChatProps) {
         if (data.type === "error") {
           const errMsg = typeof data.message === "string" ? data.message : "An error occurred";
           setMessages((prev) => [...prev, { role: "assistant", content: `⚠️ ${errMsg}` }]);
+          streamingIdRef.current = null;
           setLoading(false);
           return;
         }
 
-        if (data.type === "message" && data.done === true) {
+        if (data.type === "message" && typeof data.done === "boolean") {
           const content = typeof data.content === "string" ? data.content : "";
-          if (content) {
-            setMessages((prev) => [...prev, { role: "assistant", content }]);
-            const embedMatch = content.match(EMBED_CODE_RE)?.[0];
-            if (embedMatch) setEmbedCode(embedMatch);
+          if (!data.done) {
+            // Streaming chunk — append to in-progress assistant message
+            if (!streamingIdRef.current) {
+              streamingIdRef.current = `s-${Date.now()}`;
+              setMessages((prev) => [...prev, { role: "assistant", content }]);
+            } else {
+              setMessages((prev) => {
+                const last = prev[prev.length - 1];
+                if (last?.role === "assistant") {
+                  return [...prev.slice(0, -1), { ...last, content: last.content + content }];
+                }
+                return prev;
+              });
+            }
+          } else {
+            // Done — finalize
+            if (streamingIdRef.current) {
+              streamingIdRef.current = null;
+              if (content) {
+                // Append any trailing content (e.g. embed code suffix)
+                setMessages((prev) => {
+                  const last = prev[prev.length - 1];
+                  if (last?.role === "assistant") {
+                    return [...prev.slice(0, -1), { ...last, content: last.content + content }];
+                  }
+                  return [...prev, { role: "assistant", content }];
+                });
+              }
+            } else if (content) {
+              // Non-streamed fallback: full response in one message
+              setMessages((prev) => [...prev, { role: "assistant", content }]);
+            }
+            // Check for embed code in the final assembled message
+            setMessages((prev) => {
+              const last = prev[prev.length - 1];
+              if (last?.role === "assistant") {
+                const embedMatch = last.content.match(EMBED_CODE_RE)?.[0];
+                if (embedMatch) setEmbedCode(embedMatch);
+              }
+              return prev;
+            });
+            setLoading(false);
+            textareaRef.current?.focus();
           }
-          setLoading(false);
-          textareaRef.current?.focus();
         }
       });
 
@@ -328,8 +387,8 @@ export function CreateAgentChat({ customerId }: CreateAgentChatProps) {
               const isUser = message.role === "user";
               return isUser ? (
                 <div key={`${message.role}-${index}`} className="flex justify-end py-2">
-                  <div className="max-w-[85%] rounded-2xl bg-zinc-800 px-4 py-3 text-sm text-zinc-100">
-                    {message.content}
+                  <div className="max-w-[85%] space-y-2 rounded-2xl bg-zinc-800 px-4 py-3 text-sm text-zinc-100">
+                    {renderMarkdownToReactNodes(message.content)}
                   </div>
                 </div>
               ) : (
@@ -337,8 +396,8 @@ export function CreateAgentChat({ customerId }: CreateAgentChatProps) {
                   <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-zinc-700 mt-0.5">
                     <Bot className="h-4 w-4 text-zinc-400" />
                   </div>
-                  <div className="min-w-0 flex-1 text-base leading-relaxed text-zinc-200 whitespace-pre-wrap">
-                    {message.content}
+                  <div className="min-w-0 flex-1 space-y-3 text-base leading-relaxed text-zinc-200">
+                    {renderMarkdownToReactNodes(message.content)}
                   </div>
                 </div>
               );

--- a/packages/admin/src/components/widget-preview.tsx
+++ b/packages/admin/src/components/widget-preview.tsx
@@ -1,201 +1,47 @@
 "use client";
 
-import { useRef, useEffect, useState, useCallback } from "react";
-import { Bot, SendHorizontal, Wifi, WifiOff } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 
-type WsMessage = {
-  type: string;
-  content?: string;
-  sessionId?: string;
-  agentId?: string;
-  done?: boolean;
-  error?: string;
-};
+const DEFAULT_WIDGET_HOST = "https://dev.lamoom.com";
 
-export function WidgetPreview({ agentToken }: { agentToken: string }) {
-  const [messages, setMessages] = useState<{ role: "user" | "bot"; content: string }[]>([]);
-  const [input, setInput] = useState("");
-  const [connected, setConnected] = useState(false);
-  const [connecting, setConnecting] = useState(false);
-  const [streaming, setStreaming] = useState(false);
-  const wsRef = useRef<WebSocket | null>(null);
-  const bottomRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const partialRef = useRef("");
+function escapeAttr(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}
+
+export function WidgetPreview({ agentToken, widgetBaseUrl }: { agentToken: string; widgetBaseUrl?: string }) {
+  const [runtimeOrigin, setRuntimeOrigin] = useState<string | null>(null);
 
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages, streaming]);
+    setRuntimeOrigin(window.location.origin);
+  }, []);
 
-  const connect = useCallback(() => {
-    if (wsRef.current?.readyState === WebSocket.OPEN) return;
-    setConnecting(true);
+  const widgetHost = widgetBaseUrl ?? runtimeOrigin ?? DEFAULT_WIDGET_HOST;
+  const scriptSrc = `${widgetHost.replace(/\/+$/, "")}/widget.js`;
+  const safeToken = escapeAttr(agentToken);
+  const safeScriptSrc = escapeAttr(scriptSrc);
 
-    const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const ws = new WebSocket(`${proto}//${window.location.host}/ws`);
-    wsRef.current = ws;
-
-    ws.onopen = () => {
-      ws.send(JSON.stringify({
-        type: "auth",
-        agentToken,
-        userId: `preview-${Date.now()}`,
-      }));
-    };
-
-    ws.onmessage = (ev) => {
-      const msg: WsMessage = JSON.parse(ev.data);
-
-      if (msg.type === "auth_ok") {
-        setConnected(true);
-        setConnecting(false);
-        return;
-      }
-
-      if (msg.type === "error") {
-        setMessages((prev) => [...prev, { role: "bot", content: `⚠️ ${msg.error ?? msg.content ?? "Error"}` }]);
-        setStreaming(false);
-        return;
-      }
-
-      if (msg.type === "message") {
-        if (msg.done) {
-          const final = msg.content || partialRef.current;
-          partialRef.current = "";
-          setStreaming(false);
-          if (final) {
-            setMessages((prev) => {
-              const filtered = prev.filter((m) => m.content !== "__streaming__");
-              return [...filtered, { role: "bot", content: final }];
-            });
-          }
-        } else if (msg.content) {
-          partialRef.current += msg.content;
-          setStreaming(true);
-        }
-      }
-    };
-
-    ws.onerror = () => {
-      setConnecting(false);
-      setConnected(false);
-    };
-
-    ws.onclose = () => {
-      setConnected(false);
-      setConnecting(false);
-      wsRef.current = null;
-    };
-
-    return () => {
-      ws.close();
-    };
-  }, [agentToken]);
-
-  useEffect(() => {
-    const cleanup = connect();
-    return cleanup;
-  }, [connect]);
-
-  const send = () => {
-    const text = input.trim();
-    if (!text || !wsRef.current || wsRef.current.readyState !== WebSocket.OPEN || streaming) return;
-
-    setMessages((prev) => [...prev, { role: "user", content: text }]);
-    setInput("");
-    setStreaming(true);
-    wsRef.current.send(JSON.stringify({ type: "message", content: text }));
-    inputRef.current?.focus();
-  };
+  const srcDoc = useMemo(
+    () => `<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /></head>
+  <body style="margin:0;background:#111;">
+    <script src="${safeScriptSrc}" data-agent-token="${safeToken}" async></script>
+  </body>
+</html>`,
+    [safeScriptSrc, safeToken],
+  );
 
   return (
-    <div className="flex flex-col rounded-xl border border-zinc-700 bg-[#1a1a1a] overflow-hidden" style={{ height: 420 }}>
-      {/* Header */}
-      <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-2.5">
-        <div className="flex items-center gap-2">
-          <Bot className="h-4 w-4 text-zinc-400" />
-          <span className="text-sm font-medium text-zinc-300">Widget Preview</span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          {connected ? (
-            <Wifi className="h-3.5 w-3.5 text-green-500" />
-          ) : (
-            <WifiOff className="h-3.5 w-3.5 text-zinc-500" />
-          )}
-          <span className="text-xs text-zinc-500">
-            {connected ? "Connected" : connecting ? "Connecting…" : "Disconnected"}
-          </span>
-        </div>
-      </div>
-
-      {/* Messages */}
-      <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3">
-        {messages.length === 0 && !streaming && (
-          <div className="flex h-full items-center justify-center">
-            <p className="text-sm text-zinc-500">
-              {connected ? "Send a message to test your agent" : "Connecting to agent…"}
-            </p>
-          </div>
-        )}
-
-        {messages.map((msg, i) => (
-          <div key={i} className={msg.role === "user" ? "flex justify-end" : "flex justify-start"}>
-            <div
-              className={
-                msg.role === "user"
-                  ? "max-w-[80%] rounded-2xl bg-zinc-700 px-3 py-2 text-sm text-zinc-100"
-                  : "max-w-[80%] rounded-2xl bg-zinc-800 px-3 py-2 text-sm text-zinc-200"
-              }
-            >
-              {msg.content}
-            </div>
-          </div>
-        ))}
-
-        {streaming && (
-          <div className="flex justify-start">
-            <div className="rounded-2xl bg-zinc-800 px-3 py-2 text-sm text-zinc-400">
-              {partialRef.current || (
-                <span className="inline-flex gap-0.5">
-                  <span className="animate-bounce" style={{ animationDelay: "0ms" }}>·</span>
-                  <span className="animate-bounce" style={{ animationDelay: "150ms" }}>·</span>
-                  <span className="animate-bounce" style={{ animationDelay: "300ms" }}>·</span>
-                </span>
-              )}
-            </div>
-          </div>
-        )}
-
-        <div ref={bottomRef} />
-      </div>
-
-      {/* Input */}
-      <div className="border-t border-zinc-800 px-3 py-2.5">
-        <div className="flex items-center gap-2 rounded-xl bg-zinc-800 px-3 py-2">
-          <input
-            ref={inputRef}
-            type="text"
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                send();
-              }
-            }}
-            placeholder={connected ? "Type a message…" : "Connecting…"}
-            disabled={!connected || streaming}
-            className="flex-1 bg-transparent text-sm text-zinc-200 placeholder:text-zinc-500 outline-none"
-          />
-          <button
-            onClick={send}
-            disabled={!connected || streaming || !input.trim()}
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-zinc-600 text-zinc-300 transition-colors hover:bg-zinc-500 disabled:opacity-40"
-          >
-            <SendHorizontal className="h-3.5 w-3.5" />
-          </button>
-        </div>
-      </div>
+    <div className="space-y-3">
+      <p className="text-xs text-muted-foreground">
+        Real embed preview loaded from <code className="font-mono">{scriptSrc}</code>.
+      </p>
+      <iframe
+        title="Real widget preview"
+        srcDoc={srcDoc}
+        className="w-full rounded-xl border border-zinc-700 bg-black"
+        style={{ height: 540 }}
+      />
     </div>
   );
 }

--- a/packages/admin/src/lib/markdown.tsx
+++ b/packages/admin/src/lib/markdown.tsx
@@ -1,0 +1,187 @@
+import React, { Fragment, type ReactNode } from "react";
+
+type InlineToken =
+  | { type: "text"; value: string }
+  | { type: "code"; value: string }
+  | { type: "link"; value: string; href: string };
+
+type MarkdownBlock =
+  | { type: "paragraph"; lines: InlineToken[][] }
+  | { type: "code"; language?: string; value: string }
+  | { type: "list"; ordered: boolean; items: InlineToken[][] };
+
+const INLINE_TOKEN_RE = /`([^`\n]+)`|\[([^\]]+)\]\(([^)\s]+)\)/g;
+const ORDERED_LIST_RE = /^(\d+)\.\s+(.*)$/;
+const UNORDERED_LIST_RE = /^[-*+]\s+(.*)$/;
+
+const isSafeHref = (href: string): boolean => {
+  if (!href) return false;
+  if (href.startsWith("#") || href.startsWith("/") || href.startsWith("./") || href.startsWith("../")) {
+    return true;
+  }
+
+  try {
+    const parsed = new URL(href, "https://example.com");
+    return ["http:", "https:", "mailto:", "tel:"].includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+};
+
+const parseInlineTokens = (input: string): InlineToken[] => {
+  const tokens: InlineToken[] = [];
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+
+  INLINE_TOKEN_RE.lastIndex = 0;
+  while ((match = INLINE_TOKEN_RE.exec(input)) !== null) {
+    const [fullMatch, code, label, href] = match;
+    const start = match.index;
+    if (start > cursor) {
+      tokens.push({ type: "text", value: input.slice(cursor, start) });
+    }
+
+    if (code !== undefined) {
+      tokens.push({ type: "code", value: code });
+    } else if (label !== undefined && href !== undefined && isSafeHref(href.trim())) {
+      tokens.push({ type: "link", value: label, href: href.trim() });
+    } else {
+      tokens.push({ type: "text", value: fullMatch });
+    }
+
+    cursor = start + fullMatch.length;
+  }
+
+  if (cursor < input.length) {
+    tokens.push({ type: "text", value: input.slice(cursor) });
+  }
+
+  return tokens;
+};
+
+const parseMarkdown = (input: string): MarkdownBlock[] => {
+  const lines = input.replace(/\r\n/g, "\n").split("\n");
+  const blocks: MarkdownBlock[] = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index] ?? "";
+    if (!line.trim()) {
+      index += 1;
+      continue;
+    }
+
+    const codeStart = line.match(/^```(\w+)?\s*$/);
+    if (codeStart) {
+      const language = codeStart[1];
+      const codeLines: string[] = [];
+      index += 1;
+      while (index < lines.length && !(lines[index] ?? "").startsWith("```")) {
+        codeLines.push(lines[index] ?? "");
+        index += 1;
+      }
+      if (index < lines.length) {
+        index += 1;
+      }
+      blocks.push({ type: "code", language, value: codeLines.join("\n") });
+      continue;
+    }
+
+    const listMatch = line.match(ORDERED_LIST_RE) ?? line.match(UNORDERED_LIST_RE);
+    if (listMatch) {
+      const ordered = ORDERED_LIST_RE.test(line);
+      const items: InlineToken[][] = [];
+      while (index < lines.length) {
+        const current = lines[index] ?? "";
+        const currentMatch = ordered ? current.match(ORDERED_LIST_RE) : current.match(UNORDERED_LIST_RE);
+        if (!currentMatch) break;
+        items.push(parseInlineTokens((currentMatch[2] ?? currentMatch[1] ?? "").trim()));
+        index += 1;
+      }
+      blocks.push({ type: "list", ordered, items });
+      continue;
+    }
+
+    const paragraphLines: InlineToken[][] = [];
+    while (index < lines.length) {
+      const current = lines[index] ?? "";
+      if (!current.trim()) break;
+      if (current.startsWith("```")) break;
+      if (current.match(ORDERED_LIST_RE) || current.match(UNORDERED_LIST_RE)) break;
+      paragraphLines.push(parseInlineTokens(current));
+      index += 1;
+    }
+    blocks.push({ type: "paragraph", lines: paragraphLines });
+  }
+
+  return blocks;
+};
+
+const renderInlineTokens = (tokens: InlineToken[], keyPrefix: string): ReactNode[] =>
+  tokens.map((token, tokenIndex) => {
+    const key = `${keyPrefix}-${tokenIndex}`;
+    if (token.type === "code") {
+      return (
+        <code key={key} className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-100">
+          {token.value}
+        </code>
+      );
+    }
+
+    if (token.type === "link") {
+      return (
+        <a
+          key={key}
+          href={token.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sky-300 underline decoration-sky-500/70 underline-offset-2 hover:text-sky-200"
+        >
+          {token.value}
+        </a>
+      );
+    }
+
+    return <Fragment key={key}>{token.value}</Fragment>;
+  });
+
+export const renderMarkdownToReactNodes = (input: string): ReactNode[] =>
+  parseMarkdown(input).map((block, blockIndex) => {
+    if (block.type === "code") {
+      return (
+        <pre
+          key={`code-${blockIndex}`}
+          className="overflow-x-auto rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100"
+        >
+          <code>{block.value}</code>
+        </pre>
+      );
+    }
+
+    if (block.type === "list") {
+      const ListTag = block.ordered ? "ol" : "ul";
+      return (
+        <ListTag
+          key={`list-${blockIndex}`}
+          className={block.ordered ? "list-decimal space-y-1 pl-5" : "list-disc space-y-1 pl-5"}
+        >
+          {block.items.map((tokens, itemIndex) => (
+            <li key={`list-item-${blockIndex}-${itemIndex}`}>
+              {renderInlineTokens(tokens, `list-token-${blockIndex}-${itemIndex}`)}
+            </li>
+          ))}
+        </ListTag>
+      );
+    }
+
+    return (
+      <p key={`p-${blockIndex}`}>
+        {block.lines.map((lineTokens, lineIndex) => (
+          <Fragment key={`line-${blockIndex}-${lineIndex}`}>
+            {lineIndex > 0 ? <br /> : null}
+            {renderInlineTokens(lineTokens, `p-token-${blockIndex}-${lineIndex}`)}
+          </Fragment>
+        ))}
+      </p>
+    );
+  });

--- a/packages/proxy/drizzle/0001_public_electro.sql
+++ b/packages/proxy/drizzle/0001_public_electro.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "meta_agent_messages" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"session_id" uuid NOT NULL,
+	"role" text NOT NULL,
+	"content" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "meta_agent_sessions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"customer_id" uuid NOT NULL,
+	"openclaw_session_key" text NOT NULL,
+	"last_active_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "meta_agent_sessions_openclaw_session_key_unique" UNIQUE("openclaw_session_key")
+);
+--> statement-breakpoint
+ALTER TABLE "meta_agent_messages" ADD CONSTRAINT "meta_agent_messages_session_id_meta_agent_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."meta_agent_sessions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "meta_agent_sessions" ADD CONSTRAINT "meta_agent_sessions_customer_id_customers_id_fk" FOREIGN KEY ("customer_id") REFERENCES "public"."customers"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "meta_agent_sessions_customer_idx" ON "meta_agent_sessions" USING btree ("customer_id");

--- a/packages/proxy/drizzle/0002_conscious_true_believers.sql
+++ b/packages/proxy/drizzle/0002_conscious_true_believers.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "meta_agent_messages_session_created_idx" ON "meta_agent_messages" USING btree ("session_id","created_at");

--- a/packages/proxy/drizzle/meta/0001_snapshot.json
+++ b/packages/proxy/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,560 @@
+{
+  "id": "8abe9272-dc8a-49b4-9632-bb456b6cc223",
+  "prevId": "5540cd1d-22f5-4426-b49e-c438bef89685",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openclaw_agent_id": {
+          "name": "openclaw_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "widget_config": {
+          "name": "widget_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "api_description": {
+          "name": "api_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agents_customer_id_customers_id_fk": {
+          "name": "agents_customer_id_customers_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_openclaw_agent_id_unique": {
+          "name": "agents_openclaw_agent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "openclaw_agent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_log_customer_id_customers_id_fk": {
+          "name": "audit_log_customer_id_customers_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_provider": {
+          "name": "oauth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_id": {
+          "name": "oauth_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "customers_email_unique": {
+          "name": "customers_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_agent_messages": {
+      "name": "meta_agent_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "meta_agent_messages_session_id_meta_agent_sessions_id_fk": {
+          "name": "meta_agent_messages_session_id_meta_agent_sessions_id_fk",
+          "tableFrom": "meta_agent_messages",
+          "tableTo": "meta_agent_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_agent_sessions": {
+      "name": "meta_agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openclaw_session_key": {
+          "name": "openclaw_session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meta_agent_sessions_customer_idx": {
+          "name": "meta_agent_sessions_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meta_agent_sessions_customer_id_customers_id_fk": {
+          "name": "meta_agent_sessions_customer_id_customers_id_fk",
+          "tableFrom": "meta_agent_sessions",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "meta_agent_sessions_openclaw_session_key_unique": {
+          "name": "meta_agent_sessions_openclaw_session_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "openclaw_session_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.widget_embeds": {
+      "name": "widget_embeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embed_token": {
+          "name": "embed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "widget_embeds_agent_id_agents_id_fk": {
+          "name": "widget_embeds_agent_id_agents_id_fk",
+          "tableFrom": "widget_embeds",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "widget_embeds_embed_token_unique": {
+          "name": "widget_embeds_embed_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "embed_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.widget_sessions": {
+      "name": "widget_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_user_id": {
+          "name": "external_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openclaw_session_key": {
+          "name": "openclaw_session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "widget_sessions_agent_user_idx": {
+          "name": "widget_sessions_agent_user_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "widget_sessions_agent_id_agents_id_fk": {
+          "name": "widget_sessions_agent_id_agents_id_fk",
+          "tableFrom": "widget_sessions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/proxy/drizzle/meta/0002_snapshot.json
+++ b/packages/proxy/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,582 @@
+{
+  "id": "b6b6d30d-9b86-4d6f-88a4-0d3df6edb21a",
+  "prevId": "8abe9272-dc8a-49b4-9632-bb456b6cc223",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openclaw_agent_id": {
+          "name": "openclaw_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "widget_config": {
+          "name": "widget_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "api_description": {
+          "name": "api_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agents_customer_id_customers_id_fk": {
+          "name": "agents_customer_id_customers_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_openclaw_agent_id_unique": {
+          "name": "agents_openclaw_agent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "openclaw_agent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_log_customer_id_customers_id_fk": {
+          "name": "audit_log_customer_id_customers_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_provider": {
+          "name": "oauth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_id": {
+          "name": "oauth_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "customers_email_unique": {
+          "name": "customers_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_agent_messages": {
+      "name": "meta_agent_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meta_agent_messages_session_created_idx": {
+          "name": "meta_agent_messages_session_created_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meta_agent_messages_session_id_meta_agent_sessions_id_fk": {
+          "name": "meta_agent_messages_session_id_meta_agent_sessions_id_fk",
+          "tableFrom": "meta_agent_messages",
+          "tableTo": "meta_agent_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_agent_sessions": {
+      "name": "meta_agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openclaw_session_key": {
+          "name": "openclaw_session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meta_agent_sessions_customer_idx": {
+          "name": "meta_agent_sessions_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meta_agent_sessions_customer_id_customers_id_fk": {
+          "name": "meta_agent_sessions_customer_id_customers_id_fk",
+          "tableFrom": "meta_agent_sessions",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "meta_agent_sessions_openclaw_session_key_unique": {
+          "name": "meta_agent_sessions_openclaw_session_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "openclaw_session_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.widget_embeds": {
+      "name": "widget_embeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embed_token": {
+          "name": "embed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "widget_embeds_agent_id_agents_id_fk": {
+          "name": "widget_embeds_agent_id_agents_id_fk",
+          "tableFrom": "widget_embeds",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "widget_embeds_embed_token_unique": {
+          "name": "widget_embeds_embed_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "embed_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.widget_sessions": {
+      "name": "widget_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_user_id": {
+          "name": "external_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openclaw_session_key": {
+          "name": "openclaw_session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "widget_sessions_agent_user_idx": {
+          "name": "widget_sessions_agent_user_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "widget_sessions_agent_id_agents_id_fk": {
+          "name": "widget_sessions_agent_id_agents_id_fk",
+          "tableFrom": "widget_sessions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/proxy/drizzle/meta/_journal.json
+++ b/packages/proxy/drizzle/meta/_journal.json
@@ -8,6 +8,20 @@
       "when": 1776970257555,
       "tag": "0000_good_lady_deathstrike",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1777361479912,
+      "tag": "0001_public_electro",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1777362433050,
+      "tag": "0002_conscious_true_believers",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/proxy/src/db/schema.ts
+++ b/packages/proxy/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, timestamp, jsonb, bigserial, uniqueIndex } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, text, timestamp, jsonb, bigserial, uniqueIndex, index } from 'drizzle-orm/pg-core';
 
 export const customers = pgTable('customers', {
   id: uuid('id').defaultRandom().primaryKey(),
@@ -65,3 +65,38 @@ export const auditLog = pgTable('audit_log', {
   details: jsonb('details'),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow()
 });
+
+export const metaAgentSessions = pgTable(
+  'meta_agent_sessions',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    customerId: uuid('customer_id')
+      .notNull()
+      .references(() => customers.id, { onDelete: 'cascade' }),
+    openclawSessionKey: text('openclaw_session_key').notNull().unique(),
+    lastActiveAt: timestamp('last_active_at', { withTimezone: true }).notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    metaAgentSessionsCustomerIdx: uniqueIndex('meta_agent_sessions_customer_idx').on(table.customerId),
+  }),
+);
+
+export const metaAgentMessages = pgTable(
+  'meta_agent_messages',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    sessionId: uuid('session_id')
+      .notNull()
+      .references(() => metaAgentSessions.id, { onDelete: 'cascade' }),
+    role: text('role').notNull(),
+    content: text('content').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    metaAgentMessagesSessionCreatedIdx: index('meta_agent_messages_session_created_idx').on(
+      table.sessionId,
+      table.createdAt,
+    ),
+  }),
+);

--- a/packages/proxy/src/openclaw/meta-history.ts
+++ b/packages/proxy/src/openclaw/meta-history.ts
@@ -1,0 +1,128 @@
+import { and, asc, eq } from 'drizzle-orm';
+import type { Database } from '../db/client.js';
+import { customers, metaAgentMessages, metaAgentSessions } from '../db/schema.js';
+import { buildAgentSessionKey } from './sessions.js';
+
+export type MetaMessageRole = 'user' | 'assistant';
+
+export interface MetaHistoryMessage {
+  role: MetaMessageRole;
+  content: string;
+  createdAt: Date;
+}
+
+export interface MetaHistory {
+  sessionId: string;
+  openclawSessionKey: string;
+  messages: MetaHistoryMessage[];
+}
+
+const EMBED_CODE_RE = /<script\s[^>]*data-agent-token="[^"]*"[^>]*><\/script>/i;
+
+async function ensureCustomer(db: Database, customerId: string): Promise<void> {
+  await db
+    .insert(customers)
+    .values({
+      id: customerId,
+      email: `customer-${customerId}@webagent.local`,
+    })
+    .onConflictDoNothing();
+}
+
+async function getOrCreateMetaSession(db: Database, customerId: string) {
+  const openclawSessionKey = buildAgentSessionKey('meta', `admin-${customerId}`);
+  await db
+    .insert(metaAgentSessions)
+    .values({
+      customerId,
+      openclawSessionKey,
+      lastActiveAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: [metaAgentSessions.customerId],
+      set: {
+        openclawSessionKey,
+        lastActiveAt: new Date(),
+      },
+    });
+
+  const [session] = await db
+    .select()
+    .from(metaAgentSessions)
+    .where(eq(metaAgentSessions.customerId, customerId))
+    .limit(1);
+
+  if (!session) {
+    throw new Error('Failed to create meta-agent session');
+  }
+
+  return session;
+}
+
+export async function getMetaHistory(db: Database, customerId: string): Promise<MetaHistory> {
+  await ensureCustomer(db, customerId);
+  const session = await getOrCreateMetaSession(db, customerId);
+
+  const rows = await db
+    .select({
+      role: metaAgentMessages.role,
+      content: metaAgentMessages.content,
+      createdAt: metaAgentMessages.createdAt,
+    })
+    .from(metaAgentMessages)
+    .where(eq(metaAgentMessages.sessionId, session.id))
+    .orderBy(asc(metaAgentMessages.createdAt));
+
+  const messages = rows
+    .filter((row): row is { role: MetaMessageRole; content: string; createdAt: Date } =>
+      (row.role === 'user' || row.role === 'assistant')
+      && typeof row.content === 'string'
+      && row.content.length > 0,
+    )
+    .map((row) => ({
+      role: row.role,
+      content: row.content,
+      createdAt: row.createdAt,
+    }));
+
+  return {
+    sessionId: session.id,
+    openclawSessionKey: session.openclawSessionKey,
+    messages,
+  };
+}
+
+export async function appendMetaHistoryMessage(
+  db: Database,
+  customerId: string,
+  role: MetaMessageRole,
+  content: string,
+): Promise<void> {
+  const trimmed = content.trim();
+  if (!trimmed) return;
+
+  await ensureCustomer(db, customerId);
+  const session = await getOrCreateMetaSession(db, customerId);
+  const now = new Date();
+  await db.insert(metaAgentMessages).values({
+    sessionId: session.id,
+    role,
+    content: trimmed,
+    createdAt: now,
+  });
+  await db
+    .update(metaAgentSessions)
+    .set({ lastActiveAt: now })
+    .where(and(eq(metaAgentSessions.id, session.id), eq(metaAgentSessions.customerId, customerId)));
+}
+
+export function extractEmbedCodeFromMessages(messages: Array<{ content: string }>): string {
+  for (let idx = messages.length - 1; idx >= 0; idx -= 1) {
+    const content = messages[idx]?.content ?? '';
+    const match = content.match(EMBED_CODE_RE)?.[0];
+    if (match) {
+      return match;
+    }
+  }
+  return '';
+}

--- a/packages/proxy/src/routes/api.ts
+++ b/packages/proxy/src/routes/api.ts
@@ -8,7 +8,11 @@ import { and, count, eq, ne } from 'drizzle-orm';
 import { z } from 'zod';
 import JSON5 from 'json5';
 import { OpenClawClient } from '../openclaw/client.js';
-import { buildAgentSessionKey } from '../openclaw/sessions.js';
+import {
+  appendMetaHistoryMessage,
+  extractEmbedCodeFromMessages,
+  getMetaHistory,
+} from '../openclaw/meta-history.js';
 import { agents, auditLog, customers, widgetEmbeds, widgetSessions } from '../db/schema.js';
 import { invalidateEmbedTokenCache } from '../ws/handler.js';
 
@@ -218,6 +222,7 @@ async function registerAgentInOpenClaw(
   slug: string,
   name: string,
   app: FastifyInstance,
+  skills?: string[],
 ): Promise<void> {
   // Resolve config path: OPENCLAW_CONFIG_PATH > /opt/webagent/openclaw/config/openclaw.json5 > ~/.openclaw/openclaw.json
   const configPath =
@@ -258,7 +263,7 @@ async function registerAgentInOpenClaw(
         id: slug,
         name,
         workspace: join(workspacesDir, slug),
-        skills: ['website-api'],
+        skills: skills?.length ? skills : ['website-api'],
         heartbeat: { every: '30m' },
       });
 
@@ -346,6 +351,7 @@ export async function detectAgentCreation(
     websiteUrl: string;
     apiDescription: string;
     apiBaseUrl: string;
+    skills?: string[];
     createdAt: string;
   };
 
@@ -471,7 +477,7 @@ export async function detectAgentCreation(
   }
 
   // Register agent in OpenClaw gateway config and restart gateway
-  await registerAgentInOpenClaw(config.agentSlug, config.agentName, app);
+  await registerAgentInOpenClaw(config.agentSlug, config.agentName, app, config.skills);
 
   const existingEmbedRows = await app.db
     .select()
@@ -581,33 +587,35 @@ export function registerApiRoutes(app: FastifyInstance) {
     );
     if (!body) return;
 
-    const sessionId = body.sessionId?.trim() || randomUUID();
-    const isNewSession = !body.sessionId?.trim();
     const latestUserMessage = body.messages
       .filter((message) => message.role.toLowerCase() === 'user')
       .map((message) => message.content.trim())
       .filter((message) => message.length > 0)
       .at(-1) ?? '';
+    const normalizedLatestMessage = latestUserMessage || 'I want to create a chat agent for my website.';
 
-    const domain = (process.env.AUTH_URL || 'https://dev.lamoom.com').replace(/\/+$/, '');
-    const messageForAgent = isNewSession
-      ? `[Lamoom Platform — Agent Creation Session]
-Customer ID: ${customerId}
-Platform domain: ${domain}
-
-Customer: ${latestUserMessage || 'I want to create a chat agent for my website.'}`
-      : latestUserMessage;
-
-    if (!messageForAgent.trim()) {
+    if (!normalizedLatestMessage.trim()) {
       return sendError(reply, 400, 'empty_message', 'Message content is required');
     }
 
     try {
+      const history = await getMetaHistory(app.db, customerId);
+      const isNewSession = history.messages.length === 0;
+      const sessionId = history.sessionId;
+      const domain = (process.env.AUTH_URL || 'https://dev.lamoom.com').replace(/\/+$/, '');
+      const messageForAgent = isNewSession
+        ? `[Lamoom Platform — Agent Creation Session]
+Customer ID: ${customerId}
+Platform domain: ${domain}
+
+Customer: ${normalizedLatestMessage}`
+        : normalizedLatestMessage;
+
       const openclawClient = new OpenClawClient();
       const agentResponse = await openclawClient.sendMessage({
         message: messageForAgent,
         agentId: 'meta',
-        sessionKey: buildAgentSessionKey('meta', `admin-${customerId}-${sessionId}`),
+        sessionKey: history.openclawSessionKey,
         name: 'agent-builder',
         timeoutSeconds: 240,
       });
@@ -623,6 +631,8 @@ Customer: ${latestUserMessage || 'I want to create a chat agent for my website.'
       }
 
       const responseText = agentResponse.response ?? '';
+      await appendMetaHistoryMessage(app.db, customerId, 'user', normalizedLatestMessage);
+      await appendMetaHistoryMessage(app.db, customerId, 'assistant', responseText);
       const existingEmbedCode
         = responseText.match(/<script\s[^>]*data-agent-token="[^"]*"[^>]*><\/script>/i)?.[0] ?? '';
       const createdAgentData = await detectAgentCreation(responseText, customerId, app, domain);
@@ -654,6 +664,29 @@ Customer: ${latestUserMessage || 'I want to create a chat agent for my website.'
         'meta_unavailable',
         'Agent builder service is temporarily unavailable. Please try again.',
       );
+    }
+  });
+
+  app.get('/api/agents/meta-history', async (request, reply) => {
+    const customerId = requireCustomerAuth(request, reply);
+    if (!customerId) return;
+
+    try {
+      const history = await getMetaHistory(app.db, customerId);
+      return reply.send({
+        data: {
+          sessionId: history.sessionId,
+          messages: history.messages.map(({ role, content, createdAt }) => ({
+            role,
+            content,
+            createdAt,
+          })),
+          embedCode: extractEmbedCodeFromMessages(history.messages),
+        },
+      });
+    } catch (error) {
+      request.log.error({ error }, 'failed to fetch meta-agent history');
+      return sendError(reply, 500, 'internal_error', 'Failed to fetch meta-agent history');
     }
   });
 

--- a/packages/proxy/src/ws/handler.ts
+++ b/packages/proxy/src/ws/handler.ts
@@ -7,7 +7,12 @@ import { and, eq } from 'drizzle-orm';
 import type { Database } from '../db/client.js';
 import { agents, widgetEmbeds } from '../db/schema.js';
 import { OpenClawClient } from '../openclaw/client.js';
-import { buildAgentSessionKey, getOrCreateSession, touchSessionLastActiveAt } from '../openclaw/sessions.js';
+import {
+  appendMetaHistoryMessage,
+  extractEmbedCodeFromMessages,
+  getMetaHistory,
+} from '../openclaw/meta-history.js';
+import { getOrCreateSession, touchSessionLastActiveAt } from '../openclaw/sessions.js';
 import { detectAgentCreation } from '../routes/api.js';
 
 interface WebSocket {
@@ -422,12 +427,19 @@ export function handleConnection(
             state.userId = ticketCustomerId ?? msg.userId;
             state.agentId = 'meta';
             state.openclawAgentId = 'meta';
-            state.sessionKey = buildAgentSessionKey('meta', `admin-${state.userId}-${crypto.randomUUID()}`);
+            const history = await getMetaHistory(ctx.db, state.userId);
+            state.sessionKey = history.openclawSessionKey;
             state.authenticated = true;
             state.isAdmin = true;
-            state.firstMessage = true;
+            state.firstMessage = history.messages.length === 0;
             clearTimeout(authTimeout);
             send(ws, { type: 'auth_ok', sessionId: state.sessionKey });
+            send(ws, {
+              type: 'history',
+              sessionId: history.sessionId,
+              messages: history.messages.map(({ role, content }) => ({ role, content })),
+              embedCode: extractEmbedCodeFromMessages(history.messages),
+            });
             return;
           }
 
@@ -560,35 +572,43 @@ export function handleConnection(
               message: outboundMessage,
               agentId: state.openclawAgentId,
               sessionKey: state.sessionKey,
-              onDelta: state.isAdmin
-                ? undefined
-                : (delta) => {
-                    if (!delta) {
-                      return;
-                    }
-                    streamed = true;
-                    send(ws, { type: 'message', content: delta, done: false });
-                  },
+              onDelta: (delta) => {
+                if (!delta) {
+                  return;
+                }
+                streamed = true;
+                send(ws, { type: 'message', content: delta, done: false });
+              },
             });
 
             if (result.success) {
               let responseText = result.response || '';
+              let embedSuffix = '';
               if (state.isAdmin && responseText) {
                 const created = await detectAgentCreation(responseText, state.userId, ctx.app, domain);
                 if (created?.status === 'created') {
-                  responseText = `${responseText}\n\n${created.embedCode}`;
+                  embedSuffix = `\n\n${created.embedCode}`;
+                  responseText = `${responseText}${embedSuffix}`;
                 } else if (created?.status === 'conflict') {
                   const conflictMessage
                     = `${created.message} Please retry with a more unique website or agent name.`;
                   send(ws, { type: 'error', message: conflictMessage });
-                  responseText = `${responseText}\n\n⚠️ ${conflictMessage}`;
+                  embedSuffix = `\n\n⚠️ ${conflictMessage}`;
+                  responseText = `${responseText}${embedSuffix}`;
                 }
               }
 
-              if (streamed && !state.isAdmin) {
-                send(ws, { type: 'message', content: '', done: true });
+              if (streamed) {
+                // Streaming chunks already delivered the main response text.
+                // Send any extra suffix (e.g. embed code for admin) as the
+                // final done message; widget gets an empty done signal.
+                send(ws, { type: 'message', content: embedSuffix, done: true });
               } else {
                 send(ws, { type: 'message', content: responseText, done: true });
+              }
+              if (state.isAdmin) {
+                await appendMetaHistoryMessage(ctx.db, state.userId, 'user', customerContent);
+                await appendMetaHistoryMessage(ctx.db, state.userId, 'assistant', responseText);
               }
               state.firstMessage = false;
             } else {

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -40,6 +40,12 @@ export type ClientMessage =
 export type ServerMessage =
   | { type: 'auth_ok'; sessionId: string }
   | { type: 'auth_error'; reason: string }
+  | {
+    type: 'history';
+    sessionId: string;
+    messages: Array<{ role: 'user' | 'assistant'; content: string }>;
+    embedCode?: string;
+  }
   | { type: 'message'; content: string; done: boolean }
   | { type: 'error'; message: string }
   | { type: 'pong' };

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -1,3 +1,5 @@
+import { renderMarkdownToSafeHtml } from './markdown.js';
+
 interface WidgetConfig {
   agentToken: string;
   userId: string;
@@ -579,13 +581,13 @@ class WebAgentWidget {
 
     this.messagesList.innerHTML = this.messages
       .map((message) => {
-        const escaped = this.escapeHtml(message.content).replace(/\n/g, '<br>');
+        const rendered = renderMarkdownToSafeHtml(message.content);
 
         if (message.role === 'visitor' && message.failed) {
-          return `<div class="wa-message wa-visitor"><button type="button" class="wa-msg wa-failed" data-retry-id="${message.id}" aria-label="Retry sending message">${escaped}<span class="wa-failed-note">Failed to send. Click to retry.</span></button></div>`;
+          return `<div class="wa-message wa-visitor"><button type="button" class="wa-msg wa-failed" data-retry-id="${message.id}" aria-label="Retry sending message">${rendered}<span class="wa-failed-note">Failed to send. Click to retry.</span></button></div>`;
         }
 
-        return `<div class="wa-message ${message.role === 'visitor' ? 'wa-visitor' : 'wa-agent'}"><div class="wa-msg">${escaped}</div></div>`;
+        return `<div class="wa-message ${message.role === 'visitor' ? 'wa-visitor' : 'wa-agent'}"><div class="wa-msg">${rendered}</div></div>`;
       })
       .join('');
 
@@ -774,6 +776,48 @@ class WebAgentWidget {
           color: #0f172a;
         }
 
+        .wa-msg p {
+          margin: 0;
+        }
+
+        .wa-msg p + p,
+        .wa-msg ul,
+        .wa-msg ol,
+        .wa-msg pre {
+          margin-top: 8px;
+        }
+
+        .wa-msg ul,
+        .wa-msg ol {
+          padding-left: 18px;
+        }
+
+        .wa-msg pre {
+          overflow-x: auto;
+          border-radius: 10px;
+          padding: 8px 10px;
+          background: rgba(15, 23, 42, 0.08);
+        }
+
+        .wa-msg code {
+          font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+          font-size: 12px;
+          background: rgba(15, 23, 42, 0.08);
+          padding: 1px 4px;
+          border-radius: 5px;
+        }
+
+        .wa-msg pre code {
+          padding: 0;
+          background: transparent;
+        }
+
+        .wa-msg a {
+          color: inherit;
+          text-decoration: underline;
+          text-underline-offset: 2px;
+        }
+
         .wa-visitor .wa-msg {
           background: #2563eb;
           color: #fff;
@@ -945,6 +989,14 @@ class WebAgentWidget {
           .wa-msg {
             background: #1e293b;
             color: #e2e8f0;
+          }
+
+          .wa-msg code {
+            background: rgba(148, 163, 184, 0.22);
+          }
+
+          .wa-msg pre {
+            background: rgba(15, 23, 42, 0.65);
           }
 
           .wa-visitor .wa-msg {

--- a/packages/widget/src/markdown.ts
+++ b/packages/widget/src/markdown.ts
@@ -1,0 +1,158 @@
+type InlineToken =
+  | { type: 'text'; value: string }
+  | { type: 'code'; value: string }
+  | { type: 'link'; value: string; href: string };
+
+type MarkdownBlock =
+  | { type: 'paragraph'; lines: InlineToken[][] }
+  | { type: 'code'; language?: string; value: string }
+  | { type: 'list'; ordered: boolean; items: InlineToken[][] };
+
+const INLINE_TOKEN_RE = /`([^`\n]+)`|\[([^\]]+)\]\(([^)\s]+)\)/g;
+const ORDERED_LIST_RE = /^(\d+)\.\s+(.*)$/;
+const UNORDERED_LIST_RE = /^[-*+]\s+(.*)$/;
+
+const escapeHtml = (input: string): string =>
+  input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const isSafeHref = (href: string): boolean => {
+  if (!href) return false;
+  if (href.startsWith('#') || href.startsWith('/') || href.startsWith('./') || href.startsWith('../')) {
+    return true;
+  }
+
+  try {
+    const parsed = new URL(href, 'https://example.com');
+    return ['http:', 'https:', 'mailto:', 'tel:'].includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+};
+
+const parseInlineTokens = (input: string): InlineToken[] => {
+  const tokens: InlineToken[] = [];
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+
+  INLINE_TOKEN_RE.lastIndex = 0;
+  while ((match = INLINE_TOKEN_RE.exec(input)) !== null) {
+    const [fullMatch, code, label, href] = match;
+    const start = match.index;
+    if (start > cursor) {
+      tokens.push({ type: 'text', value: input.slice(cursor, start) });
+    }
+
+    if (code !== undefined) {
+      tokens.push({ type: 'code', value: code });
+    } else if (label !== undefined && href !== undefined && isSafeHref(href.trim())) {
+      tokens.push({ type: 'link', value: label, href: href.trim() });
+    } else {
+      tokens.push({ type: 'text', value: fullMatch });
+    }
+
+    cursor = start + fullMatch.length;
+  }
+
+  if (cursor < input.length) {
+    tokens.push({ type: 'text', value: input.slice(cursor) });
+  }
+
+  return tokens;
+};
+
+const parseMarkdown = (input: string): MarkdownBlock[] => {
+  const lines = input.replace(/\r\n/g, '\n').split('\n');
+  const blocks: MarkdownBlock[] = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index] ?? '';
+    if (!line.trim()) {
+      index += 1;
+      continue;
+    }
+
+    const codeStart = line.match(/^```(\w+)?\s*$/);
+    if (codeStart) {
+      const language = codeStart[1];
+      const codeLines: string[] = [];
+      index += 1;
+      while (index < lines.length && !(lines[index] ?? '').startsWith('```')) {
+        codeLines.push(lines[index] ?? '');
+        index += 1;
+      }
+      if (index < lines.length) {
+        index += 1;
+      }
+      blocks.push({ type: 'code', language, value: codeLines.join('\n') });
+      continue;
+    }
+
+    const listMatch = line.match(ORDERED_LIST_RE) ?? line.match(UNORDERED_LIST_RE);
+    if (listMatch) {
+      const ordered = ORDERED_LIST_RE.test(line);
+      const items: InlineToken[][] = [];
+      while (index < lines.length) {
+        const current = lines[index] ?? '';
+        const currentMatch = ordered ? current.match(ORDERED_LIST_RE) : current.match(UNORDERED_LIST_RE);
+        if (!currentMatch) break;
+        items.push(parseInlineTokens((currentMatch[2] ?? currentMatch[1] ?? '').trim()));
+        index += 1;
+      }
+      blocks.push({ type: 'list', ordered, items });
+      continue;
+    }
+
+    const paragraphLines: InlineToken[][] = [];
+    while (index < lines.length) {
+      const current = lines[index] ?? '';
+      if (!current.trim()) break;
+      if (current.startsWith('```')) break;
+      if (current.match(ORDERED_LIST_RE) || current.match(UNORDERED_LIST_RE)) break;
+      paragraphLines.push(parseInlineTokens(current));
+      index += 1;
+    }
+    blocks.push({ type: 'paragraph', lines: paragraphLines });
+  }
+
+  return blocks;
+};
+
+const renderInlineTokens = (tokens: InlineToken[]): string =>
+  tokens
+    .map((token) => {
+      if (token.type === 'code') {
+        return `<code>${escapeHtml(token.value)}</code>`;
+      }
+
+      if (token.type === 'link') {
+        return `<a href="${escapeHtml(token.href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(token.value)}</a>`;
+      }
+
+      return escapeHtml(token.value);
+    })
+    .join('');
+
+export const renderMarkdownToSafeHtml = (input: string): string =>
+  parseMarkdown(input)
+    .map((block) => {
+      if (block.type === 'code') {
+        const languageClass = block.language ? ` class="language-${escapeHtml(block.language)}"` : '';
+        return `<pre><code${languageClass}>${escapeHtml(block.value)}</code></pre>`;
+      }
+
+      if (block.type === 'list') {
+        const tag = block.ordered ? 'ol' : 'ul';
+        const items = block.items.map((item) => `<li>${renderInlineTokens(item)}</li>`).join('');
+        return `<${tag}>${items}</${tag}>`;
+      }
+
+      const lines = block.lines.map((line) => renderInlineTokens(line)).join('<br>');
+      return `<p>${lines}</p>`;
+    })
+    .join('');


### PR DESCRIPTION
## Summary
- add durable meta-agent history persistence (DB tables, WS/API retrieval, admin hydration)
- harden history persistence ordering and add history read-path index
- fix meta-agent generation pipeline so created agents can execute API calls via `fetch`
- enable streaming end-to-end for admin/meta chat and widget path
- render markdown safely in admin chat and widget chat
- replace simulated agent-detail preview with real widget embed execution
- update `docs/design.md` with architecture/flow updates

## Validation
- `pnpm -w typecheck`
- `pnpm -w build`

Closes #164