### PR TITLE
fix: generated agent API calls unreliable — stale lock, sandbox, auth context, skill propagation

### DIFF
--- a/packages/proxy/src/routes/api.test.ts
+++ b/packages/proxy/src/routes/api.test.ts
@@ -1,0 +1,28 @@
+// Test-only env stubs — must be set BEFORE importing api.ts (which transitively
+// pulls in client/config that validates these at module load).
+process.env.OPENCLAW_GATEWAY_TOKEN ??= 'test-token';
+process.env.OPENCLAW_GATEWAY_URL ??= 'http://127.0.0.1:0';
+process.env.DATABASE_URL ??= 'postgres://test:test@127.0.0.1:5432/test';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { buildWidgetEmbedCode } = await import('./api.js');
+
+test('buildWidgetEmbedCode escapes user token key attribute', () => {
+  const embedCode = buildWidgetEmbedCode('https://dev.lamoom.com', 'embed-token', 'auth" onload="alert(1)&<x>');
+
+  assert.equal(
+    embedCode,
+    '<script src="https://dev.lamoom.com/widget.js" data-agent-token="embed-token" data-user-token-key="auth&quot; onload=&quot;alert(1)&amp;&lt;x&gt;" async></script>',
+  );
+});
+
+test('buildWidgetEmbedCode omits blank user token key attribute', () => {
+  const embedCode = buildWidgetEmbedCode('dev.lamoom.com', 'embed-token', '   ');
+
+  assert.equal(
+    embedCode,
+    '<script src="https://dev.lamoom.com/widget.js" data-agent-token="embed-token" async></script>',
+  );
+});

--- a/packages/proxy/src/routes/api.ts
+++ b/packages/proxy/src/routes/api.ts
@@ -216,6 +216,22 @@ async function insertAuditLog(
   await app.db.insert(auditLog).values({ customerId, action, details: details ?? null });
 }
 
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+export function buildWidgetEmbedCode(domain: string, embedToken: string, userTokenKey?: string): string {
+  const normalizedDomain = domain.replace(/^https?:\/\//i, '');
+  const tokenKeyAttr = userTokenKey?.trim()
+    ? ` data-user-token-key="${escapeHtmlAttribute(userTokenKey.trim())}"`
+    : '';
+  return `<script src="https://${normalizedDomain}/widget.js" data-agent-token="${embedToken}"${tokenKeyAttr} async></script>`;
+}
+
 /**
  * Resolve the OpenClaw gateway config path (shared with reconciler).
  *
@@ -657,12 +673,7 @@ export async function detectAgentCreation(
     slug,
   });
 
-  const normalizedDomain = domain.replace(/^https?:\/\//i, '');
-  const tokenKeyAttr = config.userTokenKey
-    ? ` data-user-token-key="${config.userTokenKey}"`
-    : '';
-  const embedCode
-    = `<script src="https://${normalizedDomain}/widget.js" data-agent-token="${embedToken}"${tokenKeyAttr} async></script>`;
+  const embedCode = buildWidgetEmbedCode(domain, embedToken, config.userTokenKey);
 
   return {
     status: 'created',

--- a/packages/proxy/src/ws/handler.ts
+++ b/packages/proxy/src/ws/handler.ts
@@ -244,7 +244,7 @@ function normalizeSessionAuthContext(rawContext: Record<string, unknown>): Recor
   return normalized;
 }
 
-function buildWidgetMessageWithSessionPolicy(userContext: Record<string, unknown>, customerContent: string): string {
+export function buildWidgetMessageWithSessionPolicy(userContext: Record<string, unknown>, customerContent: string): string {
   const credentialPolicy
     = 'Credential source: server-side session auth context provided by the widget/integration backend.\n'
     + 'Never ask end users to fetch or copy JWTs/tokens from DevTools, localStorage, sessionStorage, cookies, or network tabs.\n'

--- a/packages/proxy/src/ws/session-context.test.ts
+++ b/packages/proxy/src/ws/session-context.test.ts
@@ -1,0 +1,28 @@
+// Test-only env stubs — must be set BEFORE importing handler.ts (which
+// transitively pulls in client/config that validates these at module load).
+process.env.OPENCLAW_GATEWAY_TOKEN ??= 'test-token';
+process.env.OPENCLAW_GATEWAY_URL ??= 'http://127.0.0.1:0';
+process.env.DATABASE_URL ??= 'postgres://test:test@127.0.0.1:5432/test';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { buildWidgetMessageWithSessionPolicy } = await import('./handler.js');
+
+test('buildWidgetMessageWithSessionPolicy includes no-credentials session context', () => {
+  const outbound = buildWidgetMessageWithSessionPolicy({}, 'List my tenants');
+
+  assert.match(outbound, /^\[Session Context — no credentials\]/);
+  assert.match(outbound, /No API credentials are configured/);
+  assert.match(outbound, /Never ask end users to fetch or copy JWTs\/tokens/);
+  assert.match(outbound, /User: List my tenants$/);
+});
+
+test('buildWidgetMessageWithSessionPolicy includes configured credentials guidance without dropping user text', () => {
+  const outbound = buildWidgetMessageWithSessionPolicy({ Authorization: 'Bearer secret' }, 'Restart tenant alpha');
+
+  assert.match(outbound, /^\[Session Context\]/);
+  assert.match(outbound, /Authentication credentials are configured/);
+  assert.match(outbound, /Authorization: Bearer secret/);
+  assert.match(outbound, /User: Restart tenant alpha$/);
+});


### PR DESCRIPTION
## Fix: Agent API Call Reliability (#176)

### Problem
Generated widget agents don't reliably make API calls. Instead of executing API requests, agents hallucinate token collection — asking users to open DevTools/localStorage to copy JWT tokens.

**Concrete repro:** User asks "list all tenants I have right now" → Agent responds with instructions to scrape Bearer JWT from DevTools localStorage instead of calling `GET /api/v1/tenants`.

### Root Cause Chain
1. Embed code `<script data-agent-token="TOKEN">` is missing `data-user-token-key` attribute
2. Widget never reads user's JWT from localStorage → no auth context sent via WS
3. WS handler only sends `[Session Context]` prefix when context is non-empty → agent receives bare message with NO session context signal
4. Agent has no credentials AND no awareness that session context exists → hallucinates token-scraping instructions

### Fix (3 commits)

#### Commit 1: Stale config lock + sandbox mode
- Stale lock detection (>60s → auto-cleanup)
- Explicit `sandbox: { mode: "off" }` for new agent entries

#### Commit 2: Auth context normalization + credential safety templates
- `normalizeSessionAuthContext()` in WS handler
- `AuthContext` interface in shared protocol
- Credential safety rules in all agent/skill templates
- "Session Auth Context Contract" in website-api skill

#### Commit 3: Always-send session context + token passthrough ⭐
**The key fix for the repro case:**

| Layer | Change | Impact |
|---|---|---|
| **WS Handler** | Always send `[Session Context]` block — explicit "no credentials" message when empty | Fixes ALL existing agents immediately |
| **Embed code** | `userTokenKey` in AgentConfig → `data-user-token-key` attr in generated embed | Enables token passthrough for new agents |
| **Widget** | `data-user-token` attribute (direct value) + existing `data-user-token-key` | Enables server-rendered token embedding |
| **Create-agent skill** | `userTokenKey` in agent-config.json schema | Meta agent discovers localStorage auth keys |

### Files Changed
- `packages/proxy/src/ws/handler.ts` — always-send context block + auth normalization
- `packages/proxy/src/routes/api.ts` — stale lock, sandbox, AgentConfig type, embed code
- `packages/proxy/src/widget/widget.ts` — `data-user-token` + `data-user-token-key` support
- `packages/shared/src/protocol.ts` — AuthContext interface
- `openclaw/workspaces/meta/skills/create-agent/SKILL.md` — config schema + credential rules
- `openclaw/templates/AGENTS.md` + `openclaw/workspaces/meta/templates/*` — credential safety rules

### Testing
- ✅ All 4 packages typecheck (`npx turbo typecheck --force`)
- ✅ All 4 packages build (`npx turbo build --force`)

Closes #176