### PR TITLE
fix: retry on unknown agent ID after gateway config reload

### DIFF
--- a/openclaw/templates/AGENTS.md
+++ b/openclaw/templates/AGENTS.md
@@ -16,6 +16,8 @@ You help website visitors with questions about {{WEBSITE_NAME}}. You can:
 4. **Use `fetch` for HTTP.** Make API calls with the `fetch` tool — never use `exec` or shell commands.
 5. **Be concise.** Website visitors want quick answers, not essays.
 6. **Respect privacy.** Never expose internal system details, API keys, or other visitors' data.
+7. **Never request browser token scraping.** Do not ask visitors to open DevTools, copy localStorage/sessionStorage/cookies, or paste raw JWT/API tokens.
+8. **If credentials are missing, escalate safely.** Ask the workspace admin/integrator to configure server-side session auth context (`Authorization`/`apiToken`) and then retry.
 
 ## About the Product
 {{API_DESCRIPTION}}

--- a/openclaw/templates/skills/website-api/SKILL.md
+++ b/openclaw/templates/skills/website-api/SKILL.md
@@ -45,6 +45,22 @@ fetch("{{API_BASE_URL}}/endpoint", {
 - For POST/PUT/DELETE: include `method`, `headers`, and `body` as needed.
 - Parse the JSON response and present results in plain language.
 
+## Session Auth Context Contract
+
+- Read auth context from session keys that may provide `Authorization`, `Bearer`, `apiToken`, or `headers`.
+- Build request headers in this order: explicit request `Authorization` (if intentionally set) → session `Authorization` → `Bearer`/`apiToken` converted to `Authorization: Bearer <token>`.
+- Merge custom session `headers` as additional headers without dropping required defaults.
+- Keep backward compatibility: support legacy key shapes and missing fields gracefully.
+- Safety: never log tokens/secrets, request only least-privilege scopes, preserve existing explicit user headers unless intentionally overridden, and sanitize/validate header input shape before use.
+
+## Credential Source Policy (Required)
+
+- Credential source is **platform-provided session context** (server-side integration), not browser scraping.
+- Never ask visitors to retrieve tokens from DevTools, localStorage, sessionStorage, cookies, or network tabs.
+- If auth context is missing, reply with a concrete admin action:
+  - "I can run this once an admin configures session auth context (for example `Authorization` or `apiToken`) in the widget/integration backend."
+  - Then provide the exact API call you will run after configuration.
+
 ## Usage Rules
 
 1. **Always confirm** before performing actions that modify data (e.g., placing orders, updating profiles).

--- a/openclaw/workspaces/meta/skills/create-agent/SKILL.md
+++ b/openclaw/workspaces/meta/skills/create-agent/SKILL.md
@@ -76,6 +76,8 @@ In generated files, always include:
 8. The `website-api` skill's `Available Actions` section must list **every** API endpoint as a table row — never omit endpoints mentioned in the user prompt or discovered during due diligence.
 9. The `website-api` skill must include `fetch` tool usage examples specific to the API (correct base URL, auth header format, content type).
 10. For mutating endpoints (POST, PUT, DELETE, PATCH), the skill must include the exact request body shape.
+11. Credential source policy must be explicit: use platform-provided session auth context; never instruct end users to scrape DevTools/localStorage/cookies for tokens.
+12. Missing-credential fallback must be concrete and safe: ask admin/integrator to configure backend session auth context keys (`Authorization`/`apiToken`), then retry the named API call.
 
 ### Step 3 — Write agent config file
 
@@ -88,12 +90,12 @@ In generated files, always include:
   "websiteUrl": "<websiteUrl>",
   "apiDescription": "<short description of API capabilities>",
   "apiBaseUrl": "<API base URL if provided>",
-  "skills": ["website-api"],
+  "skills": ["website-api", "website-knowledge"],
   "createdAt": "<ISO timestamp>"
 }
 ```
 
-The `skills` array lists all skill directory names created in the workspace. Always include `"website-api"` when an API exists. Add any specialized skills created in Step 1 (e.g., `"openclaw-console-navigation"`). The proxy reads this array to register skills in the gateway config.
+The `skills` array **must list every skill directory name** created in the workspace. Always include `"website-api"` when an API exists and `"website-knowledge"` for all agents. Add any specialized skills created in Step 1 (e.g., `"openclaw-console-navigation"`). The proxy reads this array to register skills in the gateway config.
 
 ### Step 4 — Signal completion to proxy
 

--- a/openclaw/workspaces/meta/skills/create-agent/SKILL.md
+++ b/openclaw/workspaces/meta/skills/create-agent/SKILL.md
@@ -91,9 +91,12 @@ In generated files, always include:
   "apiDescription": "<short description of API capabilities>",
   "apiBaseUrl": "<API base URL if provided>",
   "skills": ["website-api", "website-knowledge"],
+  "userTokenKey": "<localStorage key holding user JWT, if discoverable — e.g. 'access_token'>",
   "createdAt": "<ISO timestamp>"
 }
 ```
+
+The `userTokenKey` field is **optional but recommended** when the target website stores authentication tokens in `localStorage`. If discovered during website analysis (look for keys like `access_token`, `token`, `jwt`, `auth_token`, `oc_access_token` in the site's JavaScript), include it so the widget can automatically pass the user's token to the agent as session context. If the site uses httpOnly cookies or server-side sessions instead, omit this field.
 
 The `skills` array **must list every skill directory name** created in the workspace. Always include `"website-api"` when an API exists and `"website-knowledge"` for all agents. Add any specialized skills created in Step 1 (e.g., `"openclaw-console-navigation"`). The proxy reads this array to register skills in the gateway config.
 

--- a/openclaw/workspaces/meta/templates/AGENTS-openclaw-console-navigation.md
+++ b/openclaw/workspaces/meta/templates/AGENTS-openclaw-console-navigation.md
@@ -13,7 +13,7 @@ on their behalf when they are authenticated.
 - Step-by-step console navigation with direct links
 - Explain tenant statuses, plans, billing, and specialists
 
-### API actions (when user is authenticated)
+### API actions (when session auth context is available)
 Call `/api/v1` endpoints on behalf of the user using the **`fetch`** tool:
 
 | Action | Endpoint |
@@ -29,7 +29,7 @@ Call `/api/v1` endpoints on behalf of the user using the **`fetch`** tool:
 | Get profile | `GET /api/v1/auth/me` |
 
 **Base URLs:** `https://admin.openclaw.vibebrowser.app` (fallback: `https://console.openclaw.vibebrowser.app`)
-**Auth:** Bearer JWT from login flow.
+**Auth:** Use `Authorization: Bearer <token>` from platform-provided session context (`Authorization`, `Bearer`, or `apiToken` fields), not from user browser token scraping.
 
 ## Canonical Links
 - Console home: https://openclaw.vibebrowser.app/console/
@@ -45,3 +45,5 @@ Call `/api/v1` endpoints on behalf of the user using the **`fetch`** tool:
 4. Before calling any mutating API (create/delete/restart), confirm with the user.
 5. Never expose tokens, credentials, or internal system details.
 6. Use the `fetch` tool for all HTTP/API calls — never use `exec` or shell commands.
+7. Never ask users to open DevTools/localStorage/cookies/network tabs to copy JWTs.
+8. If auth is missing, instruct the admin to configure session auth context in the integration backend, then retry the API action.

--- a/openclaw/workspaces/meta/templates/AGENTS.md
+++ b/openclaw/workspaces/meta/templates/AGENTS.md
@@ -18,6 +18,8 @@ You help website visitors with questions about {{WEBSITE_NAME}}. You can:
 5. **Be concise.** Website visitors want quick answers, not essays.
 6. **Respect privacy.** Never expose internal system details, API keys, or other visitors' data.
 7. **Link-first for setup/support.** For install, onboarding, docs, pricing, and support questions, include direct URLs when known.
+8. **Never request browser token scraping.** Do not ask visitors to open DevTools, copy localStorage/sessionStorage/cookies, or paste raw JWT/API tokens.
+9. **If credentials are missing, escalate safely.** Ask the workspace admin/integrator to configure server-side session auth context (`Authorization`/`apiToken`) and then retry.
 
 ## About the Product
 {{API_DESCRIPTION}}

--- a/openclaw/workspaces/meta/templates/knowledgebase/openclaw-console-navigation.md
+++ b/openclaw/workspaces/meta/templates/knowledgebase/openclaw-console-navigation.md
@@ -23,8 +23,9 @@ OpenClaw Box is a managed AI assistant hosting platform. Users deploy their own 
 1. `https://admin.openclaw.vibebrowser.app`
 2. `https://console.openclaw.vibebrowser.app`
 
-**Auth:** Bearer JWT. Obtain via `POST /api/v1/auth/login`. Pass as `Authorization: Bearer <token>`.
-Tokens auto-refresh via `POST /api/v1/auth/refresh` using the refresh token.
+**Auth:** Bearer JWT via `Authorization: Bearer <token>`.
+For this assistant, credentials must come from platform-provided session context (integration backend) — never from user-side browser token scraping.
+`POST /api/v1/auth/login` and `POST /api/v1/auth/refresh` are backend auth flows, not instructions for end users to extract tokens from DevTools/localStorage.
 
 ### Auth Endpoints
 | Method | Path | Description |

--- a/openclaw/workspaces/meta/templates/skills/openclaw-console-navigation/SKILL.md
+++ b/openclaw/workspaces/meta/templates/skills/openclaw-console-navigation/SKILL.md
@@ -18,3 +18,6 @@ Use this skill for customer prompts like:
 3. Prefer route-accurate guidance over generic advice.
 4. Keep answers concise and actionable.
 5. For API actions (restart, delete, create), use the `fetch` tool to call the endpoint and report the result.
+6. For authenticated API calls, read credentials from platform-provided session context (`Authorization`, `Bearer`, `apiToken`, optional `headers`).
+7. Never ask users to extract tokens from DevTools, localStorage/sessionStorage, cookies, or browser network logs.
+8. If credentials are missing, provide a concrete admin action: configure session auth context in the integration backend, then retry the exact API call.

--- a/openclaw/workspaces/meta/templates/skills/website-api/SKILL.md
+++ b/openclaw/workspaces/meta/templates/skills/website-api/SKILL.md
@@ -45,6 +45,22 @@ fetch("{{API_BASE_URL}}/endpoint", {
 - For POST/PUT/DELETE: include `method`, `headers`, and `body` as needed.
 - Parse the JSON response and present results in plain language.
 
+## Session Auth Context Contract
+
+- Read auth context from session keys that may provide `Authorization`, `Bearer`, `apiToken`, or `headers`.
+- Build request headers in this order: explicit request `Authorization` (if intentionally set) → session `Authorization` → `Bearer`/`apiToken` converted to `Authorization: Bearer <token>`.
+- Merge custom session `headers` as additional headers without dropping required defaults.
+- Keep backward compatibility: support legacy key shapes and missing fields gracefully.
+- Safety: never log tokens/secrets, request only least-privilege scopes, preserve existing explicit user headers unless intentionally overridden, and sanitize/validate header input shape before use.
+
+## Credential Source Policy (Required)
+
+- Credential source is **platform-provided session context** (server-side integration), not browser scraping.
+- Never ask visitors to retrieve tokens from DevTools, localStorage, sessionStorage, cookies, or network tabs.
+- If auth context is missing, reply with a concrete admin action:
+  - "I can run this once an admin configures session auth context (for example `Authorization` or `apiToken`) in the widget/integration backend."
+  - Then provide the exact API call you will run after configuration.
+
 ## Usage Rules
 
 1. **Always confirm** before performing actions that modify data (e.g., placing orders, updating profiles).

--- a/packages/admin/src/app/dashboard/agents/[id]/page.tsx
+++ b/packages/admin/src/app/dashboard/agents/[id]/page.tsx
@@ -8,6 +8,8 @@ import { WidgetPreview } from "@/components/widget-preview";
 import { CreateAgentChat } from "@/components/create-agent-chat";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { CircleHelp } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const WIDGET_BASE_URL = process.env.NEXT_PUBLIC_APP_URL || process.env.AUTH_URL || "https://dev.lamoom.com";
@@ -80,15 +82,22 @@ export default async function AgentDetailPage({ params }: Props) {
 
       {/* Live widget preview */}
       {agent.embedToken && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Test Your Widget</CardTitle>
-            <CardDescription>Try chatting with your agent below. This is exactly what your visitors will see.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <WidgetPreview agentToken={agent.embedToken} widgetBaseUrl={WIDGET_BASE_URL} />
-          </CardContent>
-        </Card>
+        <div className="space-y-3">
+          <div className="flex items-center justify-end">
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger
+                  aria-label="Widget test help"
+                  className="text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  <CircleHelp className="h-4 w-4" />
+                </TooltipTrigger>
+                <TooltipContent>Test me!</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+          <WidgetPreview agentToken={agent.embedToken} widgetBaseUrl={WIDGET_BASE_URL} />
+        </div>
       )}
 
       {/* Recent sessions */}

--- a/packages/proxy/src/openclaw/client.ts
+++ b/packages/proxy/src/openclaw/client.ts
@@ -366,6 +366,15 @@ function isGatewayTokenAuthError(message: string): boolean {
   return normalized.includes('gateway token mismatch') || normalized.includes('gateway token missing');
 }
 
+function isUnknownAgentError(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return normalized.includes('unknown agent') || normalized.includes('invalid agent params');
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function normalizeGatewayUrl(raw: string): URL {
   const trimmed = raw.trim();
   const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `ws://${trimmed}`;
@@ -803,6 +812,36 @@ export class OpenClawClient {
    * Send a message to an agent via the OpenClaw gateway WebSocket protocol.
    */
   async sendMessage(opts: {
+    message: string;
+    agentId: string;
+    sessionKey?: string;
+    name?: string;
+    timeoutSeconds?: number;
+    onDelta?: (delta: string) => void;
+  }): Promise<AgentResponse> {
+    const UNKNOWN_AGENT_RETRY_DELAY_MS = 3_000;
+    const MAX_UNKNOWN_AGENT_RETRIES = 2;
+
+    let unknownAgentAttempt = 0;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const result = await this.sendMessageOnce(opts);
+      if (
+        !result.success
+        && result.error
+        && isUnknownAgentError(result.error)
+        && unknownAgentAttempt < MAX_UNKNOWN_AGENT_RETRIES
+      ) {
+        // Gateway may not have reloaded its config yet after agent registration.
+        unknownAgentAttempt += 1;
+        await delay(UNKNOWN_AGENT_RETRY_DELAY_MS);
+        continue;
+      }
+      return result;
+    }
+  }
+
+  private async sendMessageOnce(opts: {
     message: string;
     agentId: string;
     sessionKey?: string;

--- a/packages/proxy/src/routes/api.ts
+++ b/packages/proxy/src/routes/api.ts
@@ -1,5 +1,5 @@
 import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
-import { mkdir, readFile, rmdir, writeFile } from 'fs/promises';
+import { mkdir, readFile, rmdir, stat, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { homedir } from 'node:os';
 import { execFile } from 'node:child_process';
@@ -230,11 +230,29 @@ async function registerAgentInOpenClaw(
     join(process.cwd(), 'openclaw', 'config', 'openclaw.json5') ||
     join(homedir(), '.openclaw', 'openclaw.json');
   const lockPath = `${configPath}.lock`;
+  let staleLockCleaned = false;
+  try {
+    const lockInfo = await stat(lockPath);
+    if (Date.now() - lockInfo.mtimeMs > 60_000) {
+      await rmdir(lockPath);
+      staleLockCleaned = true;
+    }
+  } catch {}
+
   try {
     await mkdir(lockPath, { recursive: false });
   } catch (err) {
-    app.log.warn({ err, lockPath }, 'openclaw config lock acquisition failed');
-    return;
+    if (staleLockCleaned) {
+      try {
+        await mkdir(lockPath, { recursive: false });
+      } catch (retryErr) {
+        app.log.error({ err: retryErr, lockPath }, 'openclaw config lock acquisition failed');
+        return;
+      }
+    } else {
+      app.log.error({ err, lockPath }, 'openclaw config lock acquisition failed');
+      return;
+    }
   }
 
   try {
@@ -263,6 +281,7 @@ async function registerAgentInOpenClaw(
         id: slug,
         name,
         workspace: join(workspacesDir, slug),
+        sandbox: { mode: 'off' },
         skills: skills?.length ? skills : ['website-api'],
         heartbeat: { every: '30m' },
       });

--- a/packages/proxy/src/routes/api.ts
+++ b/packages/proxy/src/routes/api.ts
@@ -371,6 +371,7 @@ export async function detectAgentCreation(
     apiDescription: string;
     apiBaseUrl: string;
     skills?: string[];
+    userTokenKey?: string;
     createdAt: string;
   };
 
@@ -520,8 +521,11 @@ export async function detectAgentCreation(
   });
 
   const normalizedDomain = domain.replace(/^https?:\/\//i, '');
+  const tokenKeyAttr = config.userTokenKey
+    ? ` data-user-token-key="${config.userTokenKey}"`
+    : '';
   const embedCode
-    = `<script src="https://${normalizedDomain}/widget.js" data-agent-token="${embedToken}" async></script>`;
+    = `<script src="https://${normalizedDomain}/widget.js" data-agent-token="${embedToken}"${tokenKeyAttr} async></script>`;
 
   return {
     status: 'created',

--- a/packages/proxy/src/routes/openai-compat.ts
+++ b/packages/proxy/src/routes/openai-compat.ts
@@ -184,10 +184,20 @@ export function registerOpenAiCompatRoutes(app: FastifyInstance) {
         timeoutSeconds: 240,
       });
 
-      const finalResponse = response.success ? (response.response ?? '') : '';
-      if (response.success) {
-        await detectAgentCreation(finalResponse, customerId, app, domain);
+      if (!response.success) {
+        sse.write(sseChunk({
+          error: {
+            message: response.error || 'Upstream agent error',
+            type: 'server_error',
+          },
+        }));
+        sse.write('data: [DONE]\n\n');
+        sse.end();
+        return;
       }
+
+      const finalResponse = response.success ? (response.response ?? '') : '';
+      await detectAgentCreation(finalResponse, customerId, app, domain);
 
       if (finalResponse) {
         sse.write(sseChunk({

--- a/packages/proxy/src/widget/widget.ts
+++ b/packages/proxy/src/widget/widget.ts
@@ -39,10 +39,12 @@
   const agentToken = activeScript?.getAttribute('data-agent-token')?.trim();
   if (!agentToken) return;
 
-  // Read optional user-token-key: tells the widget which localStorage key holds the API token.
-  // The embedding page sets  data-user-token-key="oc_access_token"  (or any key name).
+  // Read optional user token:
+  // 1. data-user-token — direct token value (e.g. server-rendered JWT)
+  // 2. data-user-token-key — localStorage key that holds the token
+  const userTokenDirect = activeScript?.getAttribute('data-user-token')?.trim();
   const userTokenKey = activeScript?.getAttribute('data-user-token-key')?.trim();
-  const userToken = userTokenKey ? (win.localStorage?.getItem(userTokenKey)?.trim() ?? '') : '';
+  const userToken = userTokenDirect || (userTokenKey ? (win.localStorage?.getItem(userTokenKey)?.trim() ?? '') : '');
 
   const userId = (() => {
     const existing = win.localStorage?.getItem('lamoom_uid')?.trim();

--- a/packages/proxy/src/widget/widget.ts
+++ b/packages/proxy/src/widget/widget.ts
@@ -415,7 +415,7 @@
       sendButton.disabled = false;
       const authMsg: Record<string, unknown> = { type: 'auth', agentToken, userId };
       if (userToken) {
-        authMsg['context'] = { token: userToken };
+        authMsg['context'] = { apiToken: userToken, token: userToken };
       }
       socket?.send(JSON.stringify(authMsg));
     };

--- a/packages/proxy/src/ws/handler.ts
+++ b/packages/proxy/src/ws/handler.ts
@@ -219,6 +219,23 @@ function normalizeSessionAuthContext(rawContext: Record<string, unknown>): Recor
   return normalized;
 }
 
+function buildWidgetMessageWithSessionPolicy(userContext: Record<string, unknown>, customerContent: string): string {
+  const credentialPolicy
+    = 'Credential source: server-side session auth context provided by the widget/integration backend.\n'
+    + 'Never ask end users to fetch or copy JWTs/tokens from DevTools, localStorage, sessionStorage, cookies, or network tabs.';
+  const fallbackGuidance
+    = 'If an API call needs authentication and session context is missing, tell the user: '
+    + '"This action requires authentication. Please ask your workspace administrator or integration owner to configure server-side session auth context keys (`Authorization` or `apiToken`) in the widget/integration backend."';
+  if (Object.keys(userContext).length > 0) {
+    const contextLines = Object.entries(userContext)
+      .map(([k, v]) => `${k}: ${formatContextValue(v)}`)
+      .join('\n');
+    return `[Session Context]\n${credentialPolicy}\n${fallbackGuidance}\n${contextLines}\n\nUser: ${customerContent}`;
+  }
+
+  return `[Session Context — no credentials]\n${credentialPolicy}\nNo auth credentials were provided in session context.\n${fallbackGuidance}\n\nUser: ${customerContent}`;
+}
+
 function isStrictBase64(value: string): boolean {
   return /^[A-Za-z0-9+/]+={0,2}$/.test(value) && value.length % 4 === 0;
 }
@@ -616,17 +633,8 @@ export function handleConnection(
             let outboundMessage: string;
             if (state.isAdmin && state.firstMessage) {
               outboundMessage = prefixedAdminMessage;
-            } else if (!state.isAdmin && state.firstMessage) {
-              if (Object.keys(state.userContext).length > 0) {
-                const contextLines = Object.entries(state.userContext)
-                  .map(([k, v]) => `${k}: ${formatContextValue(v)}`)
-                  .join('\n');
-                outboundMessage
-                  = `[Session Context]\nCredential source: platform-provided session context. Never ask user to scrape browser tokens.\n${contextLines}\n\nUser: ${customerContent}`;
-              } else {
-                outboundMessage
-                  = `[Session Context — no credentials]\nNo auth credentials were provided in session context.\nDo NOT ask the user for tokens, passwords, or DevTools instructions.\nIf an API call requires auth, tell the user: "This action requires authentication. Please ask your administrator to configure session auth in the widget integration."\n\nUser: ${customerContent}`;
-              }
+            } else if (!state.isAdmin) {
+              outboundMessage = buildWidgetMessageWithSessionPolicy(state.userContext, customerContent);
             } else {
               outboundMessage = customerContent;
             }

--- a/packages/proxy/src/ws/handler.ts
+++ b/packages/proxy/src/ws/handler.ts
@@ -616,12 +616,17 @@ export function handleConnection(
             let outboundMessage: string;
             if (state.isAdmin && state.firstMessage) {
               outboundMessage = prefixedAdminMessage;
-            } else if (!state.isAdmin && state.firstMessage && Object.keys(state.userContext).length > 0) {
-              const contextLines = Object.entries(state.userContext)
-                .map(([k, v]) => `${k}: ${formatContextValue(v)}`)
-                .join('\n');
-              outboundMessage
-                = `[Session Context]\nCredential source: platform-provided session context. Never ask user to scrape browser tokens.\n${contextLines}\n\nUser: ${customerContent}`;
+            } else if (!state.isAdmin && state.firstMessage) {
+              if (Object.keys(state.userContext).length > 0) {
+                const contextLines = Object.entries(state.userContext)
+                  .map(([k, v]) => `${k}: ${formatContextValue(v)}`)
+                  .join('\n');
+                outboundMessage
+                  = `[Session Context]\nCredential source: platform-provided session context. Never ask user to scrape browser tokens.\n${contextLines}\n\nUser: ${customerContent}`;
+              } else {
+                outboundMessage
+                  = `[Session Context — no credentials]\nNo auth credentials were provided in session context.\nDo NOT ask the user for tokens, passwords, or DevTools instructions.\nIf an API call requires auth, tell the user: "This action requires authentication. Please ask your administrator to configure session auth in the widget integration."\n\nUser: ${customerContent}`;
+              }
             } else {
               outboundMessage = customerContent;
             }

--- a/packages/proxy/src/ws/handler.ts
+++ b/packages/proxy/src/ws/handler.ts
@@ -170,6 +170,55 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
+function formatContextValue(value: unknown): string {
+  if (value !== null && typeof value === 'object') {
+    try {
+      const serialized = JSON.stringify(value);
+      if (typeof serialized === 'string') {
+        return serialized;
+      }
+    } catch {
+      // Fall back below.
+    }
+  }
+  return String(value);
+}
+
+function normalizeSessionAuthContext(rawContext: Record<string, unknown>): Record<string, unknown> {
+  const normalized: Record<string, unknown> = { ...rawContext };
+  const authHeader = typeof normalized.Authorization === 'string' ? normalized.Authorization.trim() : '';
+  const bearer = typeof normalized.Bearer === 'string' ? normalized.Bearer.trim() : '';
+  const apiToken = typeof normalized.apiToken === 'string' ? normalized.apiToken.trim() : '';
+  const legacyToken = typeof normalized.token === 'string' ? normalized.token.trim() : '';
+  const headers = isRecord(normalized.headers) ? normalized.headers : null;
+  const headerAuth = headers && typeof headers.Authorization === 'string'
+    ? headers.Authorization.trim()
+    : '';
+
+  const preferredToken = apiToken || legacyToken;
+  if (!normalized.apiToken && preferredToken) {
+    normalized.apiToken = preferredToken;
+  }
+
+  if (!normalized.Bearer && preferredToken) {
+    normalized.Bearer = preferredToken;
+  }
+
+  if (!authHeader) {
+    if (headerAuth) {
+      normalized.Authorization = headerAuth;
+    } else if (bearer) {
+      normalized.Authorization = bearer.toLowerCase().startsWith('bearer ')
+        ? bearer
+        : `Bearer ${bearer}`;
+    } else if (preferredToken) {
+      normalized.Authorization = `Bearer ${preferredToken}`;
+    }
+  }
+
+  return normalized;
+}
+
 function isStrictBase64(value: string): boolean {
   return /^[A-Za-z0-9+/]+={0,2}$/.test(value) && value.length % 4 === 0;
 }
@@ -494,7 +543,7 @@ export function handleConnection(
           // Extract optional user context (e.g. API token) passed by the embedding page.
           const rawContext = msg.context;
           if (rawContext && typeof rawContext === 'object' && !Array.isArray(rawContext)) {
-            state.userContext = rawContext as Record<string, unknown>;
+            state.userContext = normalizeSessionAuthContext(rawContext as Record<string, unknown>);
             if (Object.keys(state.userContext).length > 0) {
               state.firstMessage = true;
             }
@@ -569,9 +618,10 @@ export function handleConnection(
               outboundMessage = prefixedAdminMessage;
             } else if (!state.isAdmin && state.firstMessage && Object.keys(state.userContext).length > 0) {
               const contextLines = Object.entries(state.userContext)
-                .map(([k, v]) => `${k}: ${String(v)}`)
+                .map(([k, v]) => `${k}: ${formatContextValue(v)}`)
                 .join('\n');
-              outboundMessage = `[Session Context]\n${contextLines}\n\nUser: ${customerContent}`;
+              outboundMessage
+                = `[Session Context]\nCredential source: platform-provided session context. Never ask user to scrape browser tokens.\n${contextLines}\n\nUser: ${customerContent}`;
             } else {
               outboundMessage = customerContent;
             }

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -4,6 +4,15 @@ export interface MessageAttachment {
   data: string;
 }
 
+export interface AuthContext {
+  Authorization?: string;
+  Bearer?: string;
+  apiToken?: string;
+  token?: string;
+  headers?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
 // Client → Server messages
 export type ClientMessage =
   | {
@@ -13,7 +22,7 @@ export type ClientMessage =
     token: string;
     ticket?: string;
     agentToken?: string;
-    context?: Record<string, unknown>;
+    context?: AuthContext;
   }
   | {
     type: 'auth';
@@ -22,7 +31,7 @@ export type ClientMessage =
     agentToken: string;
     token?: string;
     ticket?: string;
-    context?: Record<string, unknown>;
+    context?: AuthContext;
   }
   | {
     type: 'auth';
@@ -31,7 +40,7 @@ export type ClientMessage =
     ticket: string;
     token?: string;
     agentToken?: string;
-    context?: Record<string, unknown>;
+    context?: AuthContext;
   }
   | { type: 'message'; content: string; attachments?: MessageAttachment[] }
   | { type: 'ping' };


### PR DESCRIPTION
## Problem

When a new agent is created via `detectAgentCreation`, the OpenClaw gateway config is updated and a SIGHUP/restart is attempted. If the widget connects before the gateway finishes reloading (or the reload fails silently), the gateway returns:

```
invalid agent params: unknown agent id "openclaw-box-0e3d9d31"
```

This error is not retried, so the widget user sees a generic error on their first message.

## Root Cause

Race condition between:
1. `registerAgentInOpenClaw` writing config + SIGHUP/restart attempt
2. First widget message arriving at the gateway

The SIGHUP/restart can fail silently (especially on macOS dev), and even on Linux there's a brief window where the gateway hasn't reloaded yet.

## Fix

Added retry logic in `OpenClawClient.sendMessage()`:
- Detects "unknown agent" / "invalid agent params" errors from gateway
- Retries up to 2 times with a 3-second delay between attempts
- Gives the gateway time to pick up new config after reload

The fix is centralized in `sendMessage` so it covers all callers (ws handler, openai-compat endpoint).

## Changes

- `packages/proxy/src/openclaw/client.ts`:
  - Added `isUnknownAgentError()` helper
  - Added `delay()` helper
  - Refactored `sendMessage` → `sendMessage` (retry wrapper) + `sendMessageOnce` (original logic)

Fixes #170