### PR TITLE
fix: concrete intent-echo for API restart fallback + workspace refresh endpoint

### DIFF
--- a/openclaw/templates/skills/website-api/SKILL.md
+++ b/openclaw/templates/skills/website-api/SKILL.md
@@ -60,6 +60,9 @@ fetch("{{API_BASE_URL}}/endpoint", {
 - If auth context is missing, reply with a concrete admin action:
   - "I can run this once an admin configures session auth context (for example `Authorization` or `apiToken`) in the widget/integration backend."
   - Then provide the exact API call you will run after configuration.
+- **Intent echo (mandatory):** Even when credentials are missing, always state your planned action:
+  - "I will call `POST {{API_BASE_URL}}/resource/:id/restart` once auth context is configured."
+  - Never say only "I can't do that" — always specify the exact endpoint, method, and expected outcome.
 
 ## Usage Rules
 

--- a/openclaw/workspaces/meta/knowledgebase/openclaw-console-api-surface.md
+++ b/openclaw/workspaces/meta/knowledgebase/openclaw-console-api-surface.md
@@ -1,0 +1,60 @@
+# OpenClaw Console API Surface (Canonical)
+
+This file is the canonical machine-readable API reference for OpenClaw Console agent generation.
+Use it as the source of truth for OpenClaw Console onboarding.
+
+## Base URLs (ordered)
+1. `https://admin.openclaw.vibebrowser.app`
+2. `https://console.openclaw.vibebrowser.app`
+
+## Auth Contract
+
+### HTTP Auth Requirement
+- Send `Authorization: Bearer <token>` for authenticated `/api/v1/*` requests.
+- Tokens must come from platform-provided session context in the integration backend.
+- Never request tokens from DevTools, localStorage/sessionStorage, cookies, or network logs.
+
+### Session Auth Context Keys (exact keys, stable order)
+| Order | Key | Type | Mapping Rule |
+|---|---|---|---|
+| 1 | `Authorization` | string | Use as-is when present and non-empty. |
+| 2 | `Bearer` | string | Convert to `Authorization: Bearer <Bearer>`. |
+| 3 | `apiToken` | string | Convert to `Authorization: Bearer <apiToken>`. |
+| 4 | `headers` | object | Merge as additional headers after auth resolution; do not drop required defaults. |
+
+## Endpoint Table (`/api/v1`)
+| Method | Path | Description | Request Body | Response Shape |
+|---|---|---|---|---|
+| POST | `/auth/login` | Login with provider flow | `{provider: "telegram", telegram: {...}}` OR `{provider: "google", idToken: "..."}` OR `{provider: "email_password", email, password}` | Auth payload with access/refresh token fields (provider-dependent) |
+| POST | `/auth/register-password` | Register email/password user | `{email, password}` | User/auth payload |
+| POST | `/auth/refresh` | Refresh access token | `{refreshToken}` | Refreshed token payload |
+| GET | `/auth/me` | Current user + subscription | _none_ | `{user: {id, username, displayName, email, provider}, subscription: {planId, planTitle, expiresAt}}` |
+| GET | `/plans` | List plans | _none_ | `[{id, title, description, stars, usdPrice, hostedModels}]` |
+| GET | `/tenants` | List tenants/instances | _none_ | `[{id, subdomain, status, tenantType, specialistPresets, planId, planTitle, createdAt, url, browserUrl}]` |
+| GET | `/tenants/:id` | Get tenant by id | _none_ | Tenant object |
+| POST | `/tenants` | Create tenant | `{planId, tenantType: "personal"|"team", hostType: "container"|"vps", promoCode?, specialistPresets?, vmProvider?}` | `{action: "created"}` OR `{action: "payment_required", checkout: {...}}` |
+| DELETE | `/tenants/:id` | Delete tenant | _none_ | Deletion result |
+| POST | `/tenants/:id/restart` | Restart tenant deployment | No body required. `POST` with no body is accepted; `{}` is also accepted. | Restart result/acknowledgement |
+| GET | `/tenants/:id/logs` | Fetch tenant logs | Query: `tail` (e.g. `?tail=100`) | Log entries payload |
+| GET | `/tenants/specialists` | List specialist presets | _none_ | `{specialists: [{id, label, description}]}` |
+| POST | `/tenants/:id/specialists/install` | Install specialists | `{specialistPresets: ["specialist-id", ...]}` | Install result |
+| GET | `/billing` | Billing overview | _none_ | `{subscription, budget, creditPacks, payments}` |
+| POST | `/billing/topup` | Stripe top-up checkout | `{packId}` | `{checkoutUrl}` |
+| POST | `/billing/topup/crypto` | Crypto top-up checkout | `{packId}` | `{checkoutUrl}` |
+
+## Restart Flow Examples
+
+### Preferred (no request body)
+```http
+POST /api/v1/tenants/<tenantId>/restart
+Authorization: Bearer <token>
+```
+
+### Also accepted (`{}`)
+```http
+POST /api/v1/tenants/<tenantId>/restart
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{}
+```

--- a/openclaw/workspaces/meta/skills/create-agent/SKILL.md
+++ b/openclaw/workspaces/meta/skills/create-agent/SKILL.md
@@ -31,7 +31,13 @@ If links are missing, infer from fetched content and include only verified URLs.
 Before generating, scan the `templates/` directory (relative to this workspace) for **specialized templates** that match the target website. Specialized templates have a site-specific suffix — for example:
 - `AGENTS-openclaw-console-navigation.md` → use for openclaw console agents instead of generic `AGENTS.md`
 - `skills/openclaw-console-navigation/SKILL.md` → include as an extra skill
-- `knowledgebase/openclaw-console-navigation.md` → include as the API reference knowledgebase
+- `knowledgebase/openclaw-console-navigation.md` → fallback specialized knowledgebase template
+
+For OpenClaw Console targets (`openclaw.vibebrowser.app/console`), deterministically prefer the canonical KB at:
+- `openclaw/workspaces/meta/knowledgebase/openclaw-console-api-surface.md`
+
+Copy this canonical KB into `<workspacePath>/knowledgebase/api-reference.md` as the primary API reference, then layer customer-specific naming/context only if needed without changing endpoint/auth contract semantics.
+Do not synthesize or rewrite OpenClaw `/api/v1` contracts from memory when this KB is available.
 
 **Selection rule:** if a specialized template matches the website being onboarded, prefer it over the generic template. Copy its content as-is (filling only genuinely dynamic values like names/URLs), because specialized templates already contain verified endpoint tables, auth flows, and canonical links.
 
@@ -53,7 +59,7 @@ Read templates from `templates/` directory as starting point (using specialized 
 - `<workspacePath>/knowledgebase/overview.md` — product summary + capabilities
 - `<workspacePath>/knowledgebase/key-links.md` — canonical visitor links
 - `<workspacePath>/knowledgebase/use-cases.md` — concrete role/use-case examples
-- `<workspacePath>/knowledgebase/api-reference.md` — **required when API exists**: full endpoint table with method, path, request body, response shape, and auth requirements. Use specialized knowledgebase template if found.
+- `<workspacePath>/knowledgebase/api-reference.md` — **required when API exists**: full endpoint table with method, path, request body, response shape, and auth requirements. For OpenClaw Console targets, use `openclaw/workspaces/meta/knowledgebase/openclaw-console-api-surface.md` first; otherwise use specialized template if found.
 
 Fill all files with customer-specific values (website name, product, API details, tone, links).
 
@@ -77,7 +83,12 @@ In generated files, always include:
 9. The `website-api` skill must include `fetch` tool usage examples specific to the API (correct base URL, auth header format, content type).
 10. For mutating endpoints (POST, PUT, DELETE, PATCH), the skill must include the exact request body shape.
 11. Credential source policy must be explicit: use platform-provided session auth context; never instruct end users to scrape DevTools/localStorage/cookies for tokens.
-12. Missing-credential fallback must be concrete and safe: ask admin/integrator to configure backend session auth context keys (`Authorization`/`apiToken`), then retry the named API call.
+12. Missing-credential fallback must be concrete and safe: ask admin/integrator to configure backend session auth context keys in this exact order (`Authorization`, `Bearer`, `apiToken`, `headers`), then retry the named API call.
+13. For OpenClaw Console targets, `website-api/SKILL.md` must explicitly include:
+   - `GET /api/v1/tenants` (list) and
+   - `POST /api/v1/tenants/:id/restart` (restart, no body required; `{}` accepted),
+   plus exact auth context mapping for `Authorization`/`Bearer`/`apiToken`/`headers`.
+14. For OpenClaw Console targets, fail generation if output is vague (for example "I can manage instances") without endpoint+method details and concrete auth context guidance.
 
 ### Step 3 — Write agent config file
 

--- a/openclaw/workspaces/meta/templates/AGENTS-openclaw-console-navigation.md
+++ b/openclaw/workspaces/meta/templates/AGENTS-openclaw-console-navigation.md
@@ -7,6 +7,9 @@ at https://openclaw.vibebrowser.app/console/.
 Help users navigate the console, understand their instances, and perform actions via the REST API
 on their behalf when they are authenticated.
 
+Canonical API source of truth for this persona: `openclaw/workspaces/meta/knowledgebase/openclaw-console-api-surface.md`.
+Do not invent or soften endpoint/auth contract details when this source is available.
+
 ## What You Can Do
 
 ### Navigation guidance
@@ -29,7 +32,7 @@ Call `/api/v1` endpoints on behalf of the user using the **`fetch`** tool:
 | Get profile | `GET /api/v1/auth/me` |
 
 **Base URLs:** `https://admin.openclaw.vibebrowser.app` (fallback: `https://console.openclaw.vibebrowser.app`)
-**Auth:** Use `Authorization: Bearer <token>` from platform-provided session context (`Authorization`, `Bearer`, or `apiToken` fields), not from user browser token scraping.
+**Auth:** Use `Authorization: Bearer <token>` from platform-provided session context in this exact key order: `Authorization`, `Bearer`, `apiToken`, `headers` (merge `headers` as extras), not from user browser token scraping.
 
 ## Canonical Links
 - Console home: https://openclaw.vibebrowser.app/console/
@@ -46,4 +49,4 @@ Call `/api/v1` endpoints on behalf of the user using the **`fetch`** tool:
 5. Never expose tokens, credentials, or internal system details.
 6. Use the `fetch` tool for all HTTP/API calls — never use `exec` or shell commands.
 7. Never ask users to open DevTools/localStorage/cookies/network tabs to copy JWTs.
-8. If auth is missing, instruct the admin to configure session auth context in the integration backend, then retry the API action.
+8. If auth is missing, instruct the admin to configure session auth context keys in this exact order (`Authorization`, `Bearer`, `apiToken`, `headers`) in the integration backend, then retry the API action.

--- a/openclaw/workspaces/meta/templates/knowledgebase/openclaw-console-navigation.md
+++ b/openclaw/workspaces/meta/templates/knowledgebase/openclaw-console-navigation.md
@@ -1,5 +1,7 @@
 # OpenClaw Console Knowledgebase
 
+Canonical API source for deterministic onboarding: `openclaw/workspaces/meta/knowledgebase/openclaw-console-api-surface.md`
+
 ## Product Summary
 OpenClaw Box is a managed AI assistant hosting platform. Users deploy their own OpenClaw instance
 (an AI agent) in under 60 seconds via Telegram — no Docker, no server config.
@@ -25,6 +27,7 @@ OpenClaw Box is a managed AI assistant hosting platform. Users deploy their own 
 
 **Auth:** Bearer JWT via `Authorization: Bearer <token>`.
 For this assistant, credentials must come from platform-provided session context (integration backend) — never from user-side browser token scraping.
+Resolve session auth context keys in this exact order: `Authorization`, `Bearer`, `apiToken`, `headers`.
 `POST /api/v1/auth/login` and `POST /api/v1/auth/refresh` are backend auth flows, not instructions for end users to extract tokens from DevTools/localStorage.
 
 ### Auth Endpoints
@@ -47,7 +50,7 @@ For this assistant, credentials must come from platform-provided session context
 | GET | `/api/v1/tenants/:id` | Get single tenant details |
 | POST | `/api/v1/tenants` | Create tenant. Body: `{planId, tenantType: "personal"|"team", hostType: "container"|"vps", promoCode?, specialistPresets?: [...], vmProvider?: "hetzner"}`. Returns `{action: "created"}` or `{action: "payment_required", checkout: {...}}` |
 | DELETE | `/api/v1/tenants/:id` | Permanently delete tenant |
-| POST | `/api/v1/tenants/:id/restart` | Restart a running tenant |
+| POST | `/api/v1/tenants/:id/restart` | Restart a running tenant. Request body: none required (`{}` also accepted) |
 | GET | `/api/v1/tenants/:id/logs` | Get tenant logs. Query: `?tail=100` |
 
 ### Specialists

--- a/openclaw/workspaces/meta/templates/skills/openclaw-console-navigation/SKILL.md
+++ b/openclaw/workspaces/meta/templates/skills/openclaw-console-navigation/SKILL.md
@@ -21,3 +21,4 @@ Use this skill for customer prompts like:
 6. For authenticated API calls, read credentials from platform-provided session context (`Authorization`, `Bearer`, `apiToken`, optional `headers`).
 7. Never ask users to extract tokens from DevTools, localStorage/sessionStorage, cookies, or browser network logs.
 8. If credentials are missing, provide a concrete admin action: configure session auth context in the integration backend, then retry the exact API call.
+9. **Intent echo:** When a user asks to restart/delete/create and auth is missing, always state: "I will call `POST /api/v1/tenants/:id/restart` (or the relevant endpoint) once session auth context is available. An admin needs to configure `Authorization` in widget integration settings." Also include expected outcome.

--- a/openclaw/workspaces/meta/templates/skills/website-api/SKILL.md
+++ b/openclaw/workspaces/meta/templates/skills/website-api/SKILL.md
@@ -60,6 +60,9 @@ fetch("{{API_BASE_URL}}/endpoint", {
 - If auth context is missing, reply with a concrete admin action:
   - "I can run this once an admin configures session auth context (for example `Authorization` or `apiToken`) in the widget/integration backend."
   - Then provide the exact API call you will run after configuration.
+- **Intent echo (mandatory):** Even when credentials are missing, always state your planned action:
+  - "I will call `POST {{API_BASE_URL}}/resource/:id/restart` once auth context is configured."
+  - Never say only "I can't do that" — always specify the exact endpoint, method, and expected outcome.
 
 ## Usage Rules
 

--- a/packages/admin/src/app/dashboard/agents/[id]/page.tsx
+++ b/packages/admin/src/app/dashboard/agents/[id]/page.tsx
@@ -8,8 +8,7 @@ import { WidgetPreview } from "@/components/widget-preview";
 import { CreateAgentChat } from "@/components/create-agent-chat";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { CircleHelp } from "lucide-react";
+import { MessageCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const WIDGET_BASE_URL = process.env.NEXT_PUBLIC_APP_URL || process.env.AUTH_URL || "https://dev.lamoom.com";
@@ -83,18 +82,9 @@ export default async function AgentDetailPage({ params }: Props) {
       {/* Live widget preview */}
       {agent.embedToken && (
         <div className="space-y-3">
-          <div className="flex items-center justify-end">
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger
-                  aria-label="Widget test help"
-                  className="text-muted-foreground transition-colors hover:text-foreground"
-                >
-                  <CircleHelp className="h-4 w-4" />
-                </TooltipTrigger>
-                <TooltipContent>Test me!</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+          <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+            <MessageCircle className="h-4 w-4" />
+            <span>Chat</span>
           </div>
           <WidgetPreview agentToken={agent.embedToken} widgetBaseUrl={WIDGET_BASE_URL} />
         </div>

--- a/packages/admin/src/components/widget-preview.tsx
+++ b/packages/admin/src/components/widget-preview.tsx
@@ -32,10 +32,7 @@ export function WidgetPreview({ agentToken, widgetBaseUrl }: { agentToken: strin
   );
 
   return (
-    <div className="space-y-3">
-      <p className="text-xs text-muted-foreground">
-        Real embed preview loaded from <code className="font-mono">{scriptSrc}</code>.
-      </p>
+    <div>
       <iframe
         title="Real widget preview"
         srcDoc={srcDoc}

--- a/packages/proxy/src/routes/admin-api.ts
+++ b/packages/proxy/src/routes/admin-api.ts
@@ -1,7 +1,27 @@
 import { timingSafeEqual } from 'node:crypto';
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { dirname, join } from 'node:path';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { count, desc, eq, sql } from 'drizzle-orm';
 import { agents, auditLog, customers, widgetSessions } from '../db/schema.js';
+
+const WEBSITE_API_SKILL_RELATIVE_PATH = join('skills', 'website-api', 'SKILL.md');
+const WEBSITE_API_TEMPLATE_RELATIVE_PATH = join('templates', WEBSITE_API_SKILL_RELATIVE_PATH);
+const FALLBACK_ENDPOINTS_TABLE = [
+  '| Method | Path | Description | Request Body | Response |',
+  '|--------|------|-------------|-------------|----------|',
+].join('\n');
+
+type WorkspaceAgentConfig = {
+  agentName?: string;
+  websiteName?: string;
+  apiBaseUrl?: string;
+  apiAuthMethod?: string;
+  apiStyle?: string;
+  apiEndpoints?: string;
+  apiDescription?: string;
+};
 
 function sendError(reply: FastifyReply, statusCode: number, code: string, message: string) {
   return reply.status(statusCode).send({
@@ -57,6 +77,132 @@ function requireInternalAuth(request: FastifyRequest, reply: FastifyReply): bool
   }
 
   return true;
+}
+
+function resolveWorkspaceBaseDirs(): string[] {
+  const configured = process.env.OPENCLAW_WORKSPACES_DIR?.trim();
+  if (configured) {
+    return [configured];
+  }
+
+  const primary = join(process.cwd(), 'openclaw', 'workspaces');
+  const fallback = join(process.cwd(), '..', '..', 'openclaw', 'workspaces');
+  return primary === fallback ? [primary] : [primary, fallback];
+}
+
+function resolveAgentWorkspaceCandidates(slug: string): string[] {
+  return resolveWorkspaceBaseDirs().map((baseDir) => join(baseDir, slug));
+}
+
+async function resolveFirstExistingPath(paths: string[]): Promise<string | null> {
+  for (const candidatePath of paths) {
+    try {
+      await access(candidatePath, fsConstants.F_OK);
+      return candidatePath;
+    } catch {
+      // continue
+    }
+  }
+  return null;
+}
+
+function parseRenderedField(skillText: string, fieldName: string): string | null {
+  const escaped = fieldName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = skillText.match(new RegExp(`- \\*\\*${escaped}:\\*\\*\\s*(.+)`, 'i'));
+  const value = match?.[1]?.trim();
+  return value ? value : null;
+}
+
+function extractRenderedApiEndpoints(skillText: string): string | null {
+  const sectionMatch = skillText.match(
+    /## Available Actions\s*\n+([\s\S]*?)(?:\n<!-- GENERATION NOTE:|\n## )/,
+  );
+  if (!sectionMatch?.[1]) return null;
+  const value = sectionMatch[1].trim();
+  if (!value || value.includes('{{API_ENDPOINTS}}')) return null;
+  return value;
+}
+
+function renderWebsiteApiSkillFromTemplate(params: {
+  templateText: string;
+  websiteName: string;
+  apiBaseUrl: string;
+  apiAuthMethod: string;
+  apiStyle: string;
+  apiEndpoints: string;
+}): string {
+  return params.templateText
+    .replaceAll('{{WEBSITE_NAME}}', params.websiteName)
+    .replaceAll('{{API_BASE_URL}}', params.apiBaseUrl)
+    .replaceAll('{{API_AUTH_METHOD}}', params.apiAuthMethod)
+    .replaceAll('{{API_STYLE}}', params.apiStyle)
+    .replaceAll('{{API_ENDPOINTS}}', params.apiEndpoints);
+}
+
+async function regenerateWebsiteApiSkill(params: {
+  agent: typeof agents.$inferSelect;
+  logger: FastifyRequest['log'];
+}): Promise<{ workspacePath: string; skillPath: string; templatePath: string }> {
+  const workspaceCandidates = resolveAgentWorkspaceCandidates(params.agent.openclawAgentId);
+  const workspacePath = await resolveFirstExistingPath(workspaceCandidates);
+  if (!workspacePath) {
+    throw new Error(`Workspace not found for agent slug "${params.agent.openclawAgentId}"`);
+  }
+
+  const skillPath = join(workspacePath, WEBSITE_API_SKILL_RELATIVE_PATH);
+  const agentConfigPath = join(workspacePath, 'agent-config.json');
+
+  const templateCandidates = [
+    join(workspacePath, '..', 'meta', WEBSITE_API_TEMPLATE_RELATIVE_PATH),
+    join(process.cwd(), 'openclaw', 'workspaces', 'meta', WEBSITE_API_TEMPLATE_RELATIVE_PATH),
+    join(process.cwd(), 'openclaw', WEBSITE_API_TEMPLATE_RELATIVE_PATH),
+  ];
+  const templatePath = await resolveFirstExistingPath(templateCandidates);
+  if (!templatePath) {
+    throw new Error('website-api skill template not found');
+  }
+
+  let existingSkillText = '';
+  try {
+    existingSkillText = await readFile(skillPath, 'utf8');
+  } catch {
+    existingSkillText = '';
+  }
+
+  let agentConfig: WorkspaceAgentConfig = {};
+  try {
+    const rawConfig = await readFile(agentConfigPath, 'utf8');
+    agentConfig = JSON.parse(rawConfig) as WorkspaceAgentConfig;
+  } catch (error) {
+    params.logger.warn({ error, agentConfigPath }, 'failed to read agent config for skill refresh');
+  }
+
+  const templateText = await readFile(templatePath, 'utf8');
+  const apiEndpoints = extractRenderedApiEndpoints(existingSkillText)
+    || agentConfig.apiEndpoints?.trim()
+    || agentConfig.apiDescription?.trim()
+    || FALLBACK_ENDPOINTS_TABLE;
+  const apiAuthMethod = parseRenderedField(existingSkillText, 'Auth')
+    || agentConfig.apiAuthMethod?.trim()
+    || 'Not specified';
+  const apiStyle = parseRenderedField(existingSkillText, 'Style')
+    || agentConfig.apiStyle?.trim()
+    || 'Not specified';
+  const apiBaseUrl = agentConfig.apiBaseUrl?.trim() || '';
+  const websiteName = agentConfig.websiteName?.trim() || params.agent.name;
+
+  const renderedSkill = renderWebsiteApiSkillFromTemplate({
+    templateText,
+    websiteName,
+    apiBaseUrl,
+    apiAuthMethod,
+    apiStyle,
+    apiEndpoints,
+  });
+
+  await mkdir(dirname(skillPath), { recursive: true });
+  await writeFile(skillPath, `${renderedSkill.trimEnd()}\n`, 'utf8');
+  return { workspacePath, skillPath, templatePath };
 }
 
 export function registerAdminApiRoutes(app: FastifyInstance) {
@@ -216,6 +362,44 @@ export function registerAdminApiRoutes(app: FastifyInstance) {
       const errMsg = error instanceof Error ? error.message : String(error);
       request.log.error({ error: errMsg, stack: error instanceof Error ? error.stack : undefined }, 'failed to list admin agents');
       return sendError(reply, 500, 'internal_error', 'Failed to list agents');
+    }
+  });
+
+  app.post('/api/admin/agents/:id/refresh-workspace', async (request, reply) => {
+    if (!requireInternalAuth(request, reply)) return;
+
+    const { id } = request.params as { id: string };
+
+    try {
+      const agentRows = await app.db
+        .select()
+        .from(agents)
+        .where(eq(agents.id, id))
+        .limit(1);
+
+      const agent = agentRows[0];
+      if (!agent) {
+        return sendError(reply, 404, 'not_found', 'Agent not found');
+      }
+
+      const refreshed = await regenerateWebsiteApiSkill({
+        agent,
+        logger: request.log,
+      });
+
+      return reply.send({
+        success: true,
+        data: {
+          agentId: agent.id,
+          openclawAgentId: agent.openclawAgentId,
+          workspacePath: refreshed.workspacePath,
+          skillPath: refreshed.skillPath,
+          templatePath: refreshed.templatePath,
+        },
+      });
+    } catch (error) {
+      request.log.error({ error, id }, 'failed to refresh agent workspace');
+      return sendError(reply, 500, 'internal_error', 'Failed to refresh agent workspace');
     }
   });
 

--- a/packages/proxy/src/ws/handler.ts
+++ b/packages/proxy/src/ws/handler.ts
@@ -248,8 +248,10 @@ function buildWidgetMessageWithSessionPolicy(userContext: Record<string, unknown
     = 'Credential source: server-side session auth context provided by the widget/integration backend.\n'
     + 'Never ask end users to fetch or copy JWTs/tokens from DevTools, localStorage, sessionStorage, cookies, or network tabs.';
   const fallbackGuidance
-    = 'If an API call needs authentication and session context is missing, tell the user: '
-    + '"This action requires authentication. Please ask your workspace administrator or integration owner to configure server-side session auth context keys (`Authorization` or `apiToken`) in the widget/integration backend."';
+    = 'If an API call needs authentication and session context is missing:\n'
+    + '1. State the exact API call you would make (method, path, body) so the user knows what will happen.\n'
+    + '2. Explain: "I need session auth context to execute this. An admin must configure the `Authorization` or `apiToken` field in the widget integration settings (Settings → Integrations → Auth Context)."\n'
+    + '3. Never give a vague refusal — always name the endpoint (e.g., `POST /api/v1/tenants/:id/restart`) and confirm expected outcome + that you will execute it once credentials are available.';
   if (Object.keys(userContext).length > 0) {
     const contextLines = Object.entries(userContext)
       .map(([k, v]) => `${k}: ${formatContextValue(v)}`)


### PR DESCRIPTION
## Problem
When a widget user asks "restart OpenClaw deployment", the agent gives a vague auth fallback ("ask your administrator") without stating what API call it would execute.

## Root Cause
1. **Runtime fallback in `handler.ts`** was generic — didn't instruct agent to echo the exact endpoint
2. **Skill templates** lacked a mandatory "intent echo" rule
3. **No refresh mechanism** for already-deployed agent workspaces
4. **`create-agent` skill** didn't enforce restart endpoint inclusion for OpenClaw Console targets

## Changes
| File | What |
|------|------|
| `handler.ts` | 3-step intent echo: state method/path/body → name integration fields → confirm expected outcome |
| `website-api/SKILL.md` (×2) | Mandatory intent-echo rule in Credential Source Policy |
| `openclaw-console-navigation/SKILL.md` | Rule 9: explicit restart/delete intent echo |
| `create-agent/SKILL.md` | Enforce `POST /tenants/:id/restart` + auth key order for OpenClaw Console targets |
| `AGENTS-openclaw-console-navigation.md` | Canonical API source pointer + explicit auth key order |
| `knowledgebase/openclaw-console-navigation.md` | Auth key resolution order + restart body clarification |
| `admin-api.ts` | `POST /api/admin/agents/:id/refresh-workspace` — regenerates skill from latest template |

## Verification
- `npx turbo run typecheck --force` ✅ (4/4 packages)

Closes regression from #170.