### PR TITLE
feat: MVP auth context architecture + QA hardening + handoff

### DIFF
--- a/.agents/skills/e2e-playwright-test/SKILL.md
+++ b/.agents/skills/e2e-playwright-test/SKILL.md
@@ -26,6 +26,18 @@ Run these checks IN ORDER using vibebrowser tools. Take a screenshot after each 
 
 **Protocol of record:** This QA skill is browser-tool driven. Do **not** rely on `test-e2e-full.sh` (or other shell scripts) as the primary end-to-end verdict.
 
+### Verdict Rules (MUST follow)
+
+1. **Any phase marked BLOCKING that fails → STOP immediately, verdict = NOT READY.**
+2. **Any phase marked RELEASE-CRITICAL that fails → verdict = NOT READY** (continue remaining phases for full report, but the final verdict is already decided).
+3. **Timeouts are failures.** If a wait exceeds its stated maximum (e.g., 180 s), the check is FAIL — do NOT extend the wait or retry silently.
+4. **"Non-empty" is not "correct."** A response that is non-empty but irrelevant, generic, or contains only an error/apology MUST be scored as FAIL.
+5. **Screenshots MUST be taken and visually inspected.** A phase without its screenshot is incomplete and MUST be re-run.
+6. **Blocker precedence is absolute:** if any blocker appears anywhere, final verdict MUST be NOT READY.
+7. **READY requires all hard-release-gate criteria and complete evidence.** Any failed/missing gate item or evidence gap = NOT READY.
+
+**Architecture baseline:** Native chat (`/create` + LibreChat iframe) is the source-of-truth flow. Legacy/custom chat fallback is not valid release-gate evidence.
+
 ### Phase 0: Infrastructure (curl, not browser)
 ```
 curl -sk https://dev.lamoom.com/health → 200 {"status":"ok"}
@@ -73,7 +85,7 @@ Verify NextAuth providers are correctly configured and the DrizzleAdapter connec
 **If providers endpoint returns an error or is missing `google` → STOP. Report BLOCKING failure.**
 Common cause: DrizzleAdapter table name mismatch (adapter expects singular `account`/`user`, DB has plural `accounts`/`users`). Fix: pass custom table schemas to `DrizzleAdapter()` in `packages/admin/src/lib/auth.ts`.
 
-### Phase 1: Login & Dashboard
+### Phase 1: Login & Dashboard — RELEASE-CRITICAL
 
 1. **Navigate** to `https://dev.lamoom.com`
 2. **CHECK**: Redirects to `/login` or `/dashboard` (if already logged in)
@@ -87,7 +99,7 @@ Common cause: DrizzleAdapter table name mismatch (adapter expects singular `acco
    - **CHECK**: Agent list visible (may be empty or have existing agents)
    - **SCREENSHOT**: Take screenshot, verify professional dark theme
 
-### Phase 2: Create Agent Chat — Native Chat Integration
+### Phase 2: Create Agent Chat — Native Chat Integration — BLOCKING
 
 1. **Navigate** to `https://dev.lamoom.com/create`
 2. **CHECK**: Page loads with dark background (#171717), header bar shows "Create Agent"
@@ -101,9 +113,10 @@ Common cause: DrizzleAdapter table name mismatch (adapter expects singular `acco
    - ❌ FAIL if: White/light background (theme mismatch)
    - ❌ FAIL if: "Unable to open AI Chat" error (SSO endpoint failed)
 6. **SCREENSHOT**: Full page with LibreChat loaded in iframe
-7. **Bonus**: Toggle "Legacy chat" button visible — clicking it switches to the old custom chat UI
 
-### Phase 3: Agent Creation Conversation (via native chat)
+**If the iframe does not load or shows a login/error page → STOP. Verdict = NOT READY.** The /create page is the core product surface; a broken iframe means zero user value.
+
+### Phase 3: Agent Creation Conversation (via native chat) — RELEASE-CRITICAL
 
 1. **Click** into the LibreChat message input inside the iframe
 2. **Type** a real website description:
@@ -114,14 +127,21 @@ Common cause: DrizzleAdapter table name mismatch (adapter expects singular `acco
 6. **CHECK — CRITICAL (Website Discovery)**: The response MUST prove the meta-agent fetched openclaw.vibebrowser.app/console:
    - Mentions specific details about the product (console, tenant management, admin, agent creation)
    - NOT just generic "I'll help you create an agent" without site-specific info
+   - NOT an apology ("I couldn't access…") followed by generic advice
    - This is the core product promise — if the agent doesn't proactively discover, it FAILS
+   - **FAIL rule:** If the response lacks ≥2 site-specific details that could only come from crawling the URL, mark Phase 3 = FAIL.
 7. **CHECK — Markdown**: Response renders with proper markdown formatting (headings, bold, lists, code blocks)
-8. **SCREENSHOT**: Chat with both messages visible
+8. **CHECK — Error Absence**: No `unknown-agent`, `agent not found`, or equivalent resolution/auth errors in the assistant response.
+9. **SCREENSHOT**: Chat with both messages visible
 
-9. If the meta-agent asks for confirmation, **type**: "Yes, that's correct. Please create the agent now."
-10. **Press Enter**, wait up to 180s (agent creation involves file writes)
-11. **CHECK**: Look for embed code in the response (may contain code blocks with `<script>` tag)
-12. **SCREENSHOT**: After agent creation response
+10. If the meta-agent asks for confirmation, **type**: "Yes, that's correct. Please create the agent now."
+11. **Press Enter**, wait up to 180s (agent creation involves file writes)
+12. **CHECK**: Look for embed code in the response (may contain code blocks with `<script>` tag)
+13. **SCREENSHOT**: After agent creation response
+
+**Prompt quality rule (release-critical):**
+- Use capability prompts that validate user outcomes (discovery, create/list/restart, widget help).
+- Do **not** use vague token-scraping prompts (e.g., “give me token”, “dump secrets”, “print credentials”) as proof of capability.
 
 ### Phase 3b: Test Internal API (Create/Delete Tenant)
 
@@ -144,7 +164,7 @@ The meta-agent should be able to call OpenClaw Console internal APIs. Verify:
 3. **CHECK**: Agent shows "active" status
 4. **CHECK**: "View" link works → agent detail page shows embed code
 
-### Phase 5: Widget Preview Chat (on agent detail page)
+### Phase 5: Widget Preview Chat (on agent detail page) — RELEASE-CRITICAL
 
 1. From Phase 4, you should be on an agent detail page
 2. **CHECK**: "Test Your Widget" section visible on the page
@@ -156,7 +176,7 @@ The meta-agent should be able to call OpenClaw Console internal APIs. Verify:
 8. **CHECK**: Typing indicator (·) shows while waiting
 9. **Wait** up to 120s for response
 10. **CHECK**: Bot response appears, is non-empty, and includes direct URL(s) for install/docs
-11. **CHECK**: No "⚠️ Error" message (this means OpenClaw agent isn't registered)
+11. **CHECK**: No "⚠️ Error", `unknown-agent`, `agent not found`, or auth-context failure message
 12. **SCREENSHOT**: Widget preview with message exchange visible
 
 ### Phase 5b: Widget WS Protocol (optional, if Phase 5 fails)
@@ -192,9 +212,10 @@ Test the widget as an actual customer would embed it:
 7. Ask question #1: **"what is the product about"**
 8. Ask question #2: **"how to install it?"**
 9. **CHECK**: Bot responds to both prompts with relevant content (install answer should include direct link(s))
-10. Score both answers with a G-Eval style rubric (1-5); require both to meet the configured threshold (default: ≥3)
-    - Q1 ("what is the product about"): reward product identity + capabilities + clarity.
-    - Q2 ("how to install it?"): reward actionable install guidance + direct link(s) + docs/support references.
+10. Score both answers with a G-Eval style rubric (1-5); **both MUST score ≥ 3 — this is a hard gate, not a default**.
+    - Q1 ("what is the product about"): reward product identity + capabilities + clarity. Score < 3 if the answer is generic, hallucinatory, or does not name the product.
+    - Q2 ("how to install it?"): reward actionable install guidance + direct link(s) + docs/support references. Score < 3 if no actionable link is provided or the link is fabricated.
+    - **FAIL rule:** If either score < 3, Phase 5c = FAIL.
 11. **CHECK**: Close/reopen bubble — chat history preserved
 12. **SCREENSHOT**: Widget demo working on standalone page
 
@@ -243,6 +264,18 @@ Test the widget as an actual customer would embed it:
 6. **CHECK**: Audit Log table visible with recent entries
 7. **SCREENSHOT**: Admin dashboard
 
+### Phase 10: Restart/List Automation Critical Path — RELEASE-CRITICAL
+
+1. In native chat, ask: **"List my agents and show status for the one we just created."**
+2. **CHECK**: Response contains concrete list/status output and no `unknown-agent` style errors.
+3. In native chat, ask: **"Restart the created agent and confirm it is healthy again."**
+4. **CHECK**: Restart action succeeds (or explicit equivalent operation) and returns post-action health/status confirmation.
+5. Repeat list/status check in widget preview chat for parity.
+6. **CHECK**: Widget list/restart context has no resolution/auth failures and returns concrete status.
+7. **SCREENSHOT**: Native chat + widget evidence for list/restart path.
+
+If auth context is missing (cannot authorize list/restart operations), you **cannot** declare READY for restart automation capability.
+
 ## UI/UX Quality Checklist (check on EVERY page)
 
 Run these checks on every page you visit. Any failure = QA FAIL.
@@ -258,6 +291,32 @@ Run these checks on every page you visit. Any failure = QA FAIL.
 | 7 | Error handling | If SSO or API fails, error message + retry button shown |
 | 8 | Professional typography | Consistent font sizes, proper spacing, readable text |
 
+## Hard Release Gate (Non-Negotiable)
+
+Return **READY** only if all are true:
+1. **unknown-agent errors absent** in native chat, widget preview, and restart/list critical path.
+2. **widget restart/list critical path passes** (Phase 10, both native chat + widget).
+3. **no vague token-scraping prompts** used as validation evidence.
+4. **streaming is visible where expected** (native chat + widget typing/stream indicators observed).
+5. **deployment parity check passes** (tested build is confirmed as merged and deployed).
+
+If any item fails or lacks evidence, final verdict is **NOT READY**.
+
+## Blocker Precedence Rule
+
+- Any blocker in any phase overrides all other passes.
+- If a blocker appears, final verdict **MUST** be **NOT READY**.
+
+## Evidence Requirements (Mandatory)
+
+For release-critical phases, provide:
+1. **Exact prompt/response snippets** (verbatim excerpts) for Phase 3, Phase 5, and Phase 10 checks.
+2. **Endpoint/status evidence** for infra/auth/deploy checks: endpoint URL, HTTP status, key assertion/result.
+3. **Deployment parity evidence**: merged commit/PR reference plus deployed revision/build evidence from the tested environment.
+4. **Screenshots + one-line interpretation** per critical phase.
+
+Missing critical evidence means verdict = **NOT READY**.
+
 ## Reporting
 
 After running all phases, report a summary table:
@@ -268,23 +327,30 @@ After running all phases, report a summary table:
 | Phase | Status | Notes |
 |-------|--------|-------|
 | 0. Infrastructure | ✅/❌ | health, openclaw health, widget.js, /v1/models, LibreChat docker |
-| 0b. Static Assets | ✅/❌ | CSS 200+size>1KB, JS chunks 200 — BLOCKING |
-| 0c. OAuth Providers | ✅/❌ | /api/auth/providers returns google+credentials — BLOCKING |
-| 1. Login & Dashboard | ✅/❌ | auth works, dark theme |
-| 2. LibreChat Integration | ✅/❌ | SSO works, iframe loads, dark theme, no login page |
-| 3. Agent Creation | ✅/❌ | full conversation via LibreChat, markdown rendered, embed code |
+| 0b. Static Assets | ✅/❌ | CSS 200+size>1KB, JS chunks 200 — **BLOCKING** |
+| 0c. OAuth Providers | ✅/❌ | /api/auth/providers returns google+credentials — **BLOCKING** |
+| 1. Login & Dashboard | ✅/❌ | auth works, dark theme — **RELEASE-CRITICAL** |
+| 2. LibreChat Integration | ✅/❌ | SSO works, iframe loads, dark theme, no login page — **BLOCKING** |
+| 3. Agent Creation | ✅/❌ | site-specific discovery, markdown rendered, embed code — **RELEASE-CRITICAL** |
 | 4. Agent Verification | ✅/❌ | appears in dashboard |
-| 5. Widget Preview | ✅/❌ | live chat on dashboard works |
+| 5. Widget Preview | ✅/❌ | live chat on dashboard works — **RELEASE-CRITICAL** |
+| 5c. Widget Demo | ✅/❌ | G-Eval ≥ 3 on both questions — **RELEASE-CRITICAL** |
 | 6. Sign Out Flow    | ✅/❌ | logout + session cleared |
 | 7. Agent Delete      | ✅/❌ | delete + confirmation |
 | 8. Agent Detail      | ✅/❌ | embed code, copy, regenerate |
 | 9. Admin CRM        | ✅/❌ | stats, users, agents, audit |
+| 10. Restart Gate     | ✅/❌/N/A | post-restart health (deploy only) — **RELEASE-CRITICAL** |
+| 10. Restart/List Critical Path | ✅/❌ | native chat + widget list/restart, no unknown-agent/auth-context failures |
 
 UI/UX Issues Found:
 - [list any visual/interaction problems]
 
 Blockers:
 - [list anything that prevents the product from working]
+
+Final Verdict:
+- READY (only if every hard gate passed and no blockers), or
+- NOT READY (required if any blocker, gate failure, or missing evidence exists)
 ```
 
 ## Deploy Verification Checklist
@@ -301,3 +367,50 @@ After any deploy, verify these common failure modes:
 9. SSO bridge "no token" → user not created in LibreChat (email verification issue), check `ALLOW_UNVERIFIED_EMAIL_LOGIN=true` in `/opt/librechat/.env`
 10. LibreChat iframe shows login page → SSO flow failed, check proxy logs: `journalctl -u webagent-proxy -n 20 --output=cat | grep sso`
 11. tsbuildinfo stale on VM → `find /opt/webagent/packages -name 'tsconfig.tsbuildinfo' -delete` then rebuild
+
+### Phase 10: Restart-Deployment Gate — RELEASE-CRITICAL (when deploy is in scope)
+
+When QA is running as part of a deployment (not a standalone spot-check), this phase is MANDATORY.
+
+1. **SSH** to the VM and restart the primary services:
+   ```
+   ssh root@78.47.152.177 "systemctl restart webagent-proxy && systemctl restart webagent-admin"
+   ```
+2. **Wait** 15 s for services to stabilize.
+3. **Re-run Phase 0** (all health endpoints). Every check MUST return the expected result.
+4. **Re-run Phase 0b** (static assets). CSS and JS MUST still resolve to 200.
+5. **Navigate** to `https://dev.lamoom.com/dashboard` in the browser.
+6. **CHECK**: Dashboard loads within 10 s with no errors.
+7. **CHECK**: An existing agent is still visible (data persistence across restart).
+
+**FAIL rule:** If any check in steps 3-7 fails after restart, the deployment is NOT survivable and the verdict is NOT READY regardless of all other phases.
+
+---
+
+## Verdict Decision Matrix
+
+Use this matrix after all phases complete. The verdict is the **worst matching row**.
+
+| Condition | Verdict | Action |
+|-----------|---------|--------|
+| All phases PASS | **READY** | Ship it |
+| Any BLOCKING phase FAIL (0b, 0c, 2) | **NOT READY** | Fix blocker before any further testing |
+| Any RELEASE-CRITICAL phase FAIL (1, 3, 5, 10) | **NOT READY** | Fix critical path; re-run full QA |
+| ≥ 3 non-optional phases FAIL or SKIPPED | **NOT READY** | Systemic issues; investigate root cause |
+| 1–2 non-critical phases FAIL (6, 7, 8, 9) | **READY WITH CAVEATS** | Ship, but file issues for failures |
+| G-Eval score < 3 on any widget question (5c) | **NOT READY** | Agent quality insufficient for demo |
+| Phase 3 meta-agent response lacks site-specific detail | **NOT READY** | Core product promise broken |
+| Phase 10 post-restart health fails (deploy in scope) | **NOT READY** | Deployment does not survive restart |
+| Timeout exceeded on any wait | **FAIL for that phase** | Treat as phase failure; apply rules above |
+
+### Reporting the Verdict
+
+The QA summary MUST end with exactly one of these lines:
+
+```
+**VERDICT: READY**
+**VERDICT: READY WITH CAVEATS** — [list caveats]
+**VERDICT: NOT READY** — [list blocking reasons]
+```
+
+Any report missing an explicit verdict line is incomplete and MUST be amended.

--- a/.agents/skills/e2e-playwright-test/SKILL.md
+++ b/.agents/skills/e2e-playwright-test/SKILL.md
@@ -339,8 +339,7 @@ After running all phases, report a summary table:
 | 7. Agent Delete      | ✅/❌ | delete + confirmation |
 | 8. Agent Detail      | ✅/❌ | embed code, copy, regenerate |
 | 9. Admin CRM        | ✅/❌ | stats, users, agents, audit |
-| 10. Restart Gate     | ✅/❌/N/A | post-restart health (deploy only) — **RELEASE-CRITICAL** |
-| 10. Restart/List Critical Path | ✅/❌ | native chat + widget list/restart, no unknown-agent/auth-context failures |
+| 10. Restart/List Critical Path | ✅/❌ | native chat + widget list/restart, no unknown-agent/auth-context failures — **RELEASE-CRITICAL** |
 
 UI/UX Issues Found:
 - [list any visual/interaction problems]

--- a/.agents/skills/e2e-playwright-test/scripts/test-ai-liveness.sh
+++ b/.agents/skills/e2e-playwright-test/scripts/test-ai-liveness.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # E2E AI Liveness Test Suite
+# Supplemental liveness signal only — not a release-readiness verdict source.
 # Verifies the system talks to a real, flexible AI — not hardcoded responses.
 # Run against the live proxy endpoint.
 #

--- a/.agents/skills/e2e-playwright-test/scripts/test-e2e-full.sh
+++ b/.agents/skills/e2e-playwright-test/scripts/test-e2e-full.sh
@@ -2,6 +2,11 @@
 # =============================================================================
 # Lamoom Platform — Full E2E Flow Test
 #
+# IMPORTANT:
+# - Supplemental protocol checker only.
+# - MUST NOT be used as sole MVP/READY release verdict.
+# - Browser protocol in ../SKILL.md remains source of record for pass/fail readiness.
+#
 # Tests the COMPLETE product flow at the protocol level:
 #   Health → Agent Creation via Meta-Agent → Agent Verification → Widget Chat (WS)
 #

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,254 @@
+# MVP Handoff — Auth Context Fix + Deploy + QA
+
+> **Created**: 2025-07-21
+> **Branch**: `fix/regression-api-restart-intent` (2 commits ahead of main)
+> **Target**: Make widget agents capable of executing API calls (restart, list tenants, etc.)
+
+---
+
+## Current State
+
+### What's Done (committed on branch)
+- **QA skill hardened** — strict verdict matrix, evidence requirements, false-positive gates
+- **Intent-echo rules** — agent states exact API call before executing
+- **Refresh-workspace endpoint** — `POST /api/admin/agents/:id/refresh-workspace`
+- **Agent detail page UX** — simplified "Chat" label with MessageCircle icon (no more "Test Your Widget" framing)
+- **API surface KB** — `openclaw/workspaces/meta/knowledgebase/openclaw-console-api-surface.md`
+- **Meta templates updated** — never-request-browser-token rule, concrete endpoint guidance
+- **Unknown-agent self-heal** — WS handler retries after registering agent with gateway
+
+### What's Uncommitted (local only)
+- Minor QA skill script tweaks (3 files, 7 lines changed)
+
+### What's NOT Done (the remaining MVP gap)
+These items are the **sole blockers** preventing MVP readiness:
+
+---
+
+## Task 1: Server-Side Auth Context Injection (CRITICAL)
+
+**Problem**: Widget agents have no auth credentials. When asked to "restart deployment" or "list tenants," the agent hallucinates about finding tokens in DevTools.
+
+**Root Cause**: `buildWidgetMessageWithSessionPolicy()` in `packages/proxy/src/ws/handler.ts` injects session context into messages, but `state.userContext` is always empty because nobody configures it.
+
+**Solution**: Store auth context in `agents.widgetConfig.authContext` (JSONB). On widget WS auth, read it and inject into session.
+
+### Implementation Details
+
+#### 1a. Modify `lookupEmbedToken()` (handler.ts ~line 418)
+Add `widgetConfig` to the SELECT:
+```typescript
+// Current:
+.select({
+  agentId: agents.id,
+  openclawAgentId: agents.openclawAgentId,
+  allowedOrigins: widgetEmbeds.allowedOrigins,
+})
+
+// Change to:
+.select({
+  agentId: agents.id,
+  openclawAgentId: agents.openclawAgentId,
+  allowedOrigins: widgetEmbeds.allowedOrigins,
+  widgetConfig: agents.widgetConfig,
+})
+```
+
+Update `TokenLookup` interface:
+```typescript
+interface TokenLookup {
+  agentId: string;
+  openclawAgentId: string;
+  allowedOrigins: string[] | null;
+  widgetConfig: Record<string, unknown> | null;
+}
+```
+
+#### 1b. Inject auth context after widget auth (handler.ts ~line 575-601)
+After `state.openclawAgentId = tokenData.openclawAgentId;`:
+```typescript
+// Inject server-side auth context from agent config
+const serverAuthCtx = tokenData.widgetConfig?.authContext;
+if (serverAuthCtx && typeof serverAuthCtx === 'object' && !Array.isArray(serverAuthCtx)) {
+  state.userContext = normalizeSessionAuthContext(serverAuthCtx as Record<string, unknown>);
+}
+
+// Client context can add NON-auth fields only (safety)
+const rawContext = msg.context;
+if (rawContext && typeof rawContext === 'object' && !Array.isArray(rawContext)) {
+  const clientCtx = rawContext as Record<string, unknown>;
+  const AUTH_KEYS = new Set(['Authorization', 'Bearer', 'apiToken', 'token', 'headers']);
+  for (const [k, v] of Object.entries(clientCtx)) {
+    if (!AUTH_KEYS.has(k)) {
+      state.userContext[k] = v;
+    }
+  }
+  if (Object.keys(state.userContext).length > 0) {
+    state.firstMessage = true;
+  }
+}
+```
+
+#### 1c. Add "never reveal credentials" to session policy (handler.ts ~line 246)
+In `buildWidgetMessageWithSessionPolicy`, add to `credentialPolicy`:
+```
+'Never reveal, display, echo, or include raw credential/token values in your responses. '
++ 'Use them ONLY in fetch/API tool call headers. If a user asks for the token, decline.'
+```
+
+### Key Files
+- `packages/proxy/src/ws/handler.ts` — main changes
+- `packages/proxy/src/routes/api.ts` — PATCH endpoint fix
+- `packages/proxy/src/routes/admin-api.ts` — GET response redaction
+
+---
+
+## Task 2: PATCH Deep-Merge + Cache Invalidation
+
+**Problem**: `PATCH /api/agents/:id` with `{ widgetConfig: { authContext: {...} } }` replaces the entire `widgetConfig`, deleting existing `skills` etc.
+
+**Solution**: Deep-merge `widgetConfig` in the PATCH handler.
+
+### Implementation Details
+
+#### 2a. Deep-merge in PATCH (api.ts ~line 831)
+```typescript
+// Before .set():
+const mergedBody = { ...body };
+if (body.widgetConfig && existingAgent.widgetConfig) {
+  mergedBody.widgetConfig = {
+    ...(existingAgent.widgetConfig as Record<string, unknown>),
+    ...body.widgetConfig,
+  };
+}
+
+const updatedRows = await app.db
+  .update(agents)
+  .set({
+    ...mergedBody,
+    updatedAt: new Date(),
+  })
+  // ...
+```
+
+#### 2b. Cache invalidation on widgetConfig change (api.ts ~line 849)
+Add after the existing status-change cache invalidation:
+```typescript
+if (body.widgetConfig) {
+  const embedRows = await app.db
+    .select({ embedToken: widgetEmbeds.embedToken })
+    .from(widgetEmbeds)
+    .where(eq(widgetEmbeds.agentId, params.id));
+  for (const embedRow of embedRows) {
+    invalidateEmbedTokenCache(embedRow.embedToken);
+  }
+}
+```
+
+#### 2c. Redact authContext from GET responses
+In admin-api.ts GET endpoints that return agents, strip `widgetConfig.authContext` before sending.
+
+### Key Files
+- `packages/proxy/src/routes/api.ts` — PATCH fix + cache invalidation
+- `packages/proxy/src/routes/admin-api.ts` — response redaction
+
+---
+
+## Task 3: Auth Context Config UI
+
+**Problem**: No way for admins to configure the API token for an agent.
+
+**Solution**: Add a simple card to the agent detail page.
+
+### Implementation Details
+
+Create `packages/admin/src/components/agent-auth-context.tsx`:
+- Client component ("use client")
+- Simple card with:
+  - "API Configuration" title
+  - "API Token" password input field
+  - "Save" button
+- Reads current value from agent's `widgetConfig.authContext.apiToken`
+- Saves via `PATCH /api/agents/:id` with `{ widgetConfig: { authContext: { apiToken: value } } }`
+- Uses existing auth/API infrastructure in the admin app
+
+Add to `packages/admin/src/app/dashboard/agents/[id]/page.tsx`:
+- Insert between Embed Code card and Chat section
+- Only show if agent is active
+
+---
+
+## Task 4: Widget Preview Cleanup (Minor)
+
+- `packages/admin/src/components/widget-preview.tsx` line 36: change `title="Real widget preview"` → `title="Widget preview"`
+
+---
+
+## Task 5: Deploy + QA
+
+### Deploy Steps
+```bash
+ssh root@78.47.152.177
+cd /opt/webagent
+git pull origin main
+pnpm install --frozen-lockfile
+npx turbo run build
+set -a; source .env; set +a
+npx drizzle-kit migrate
+cp -r packages/admin/.next/static packages/admin/.next/standalone/packages/admin/.next/static
+systemctl restart webagent-proxy webagent-admin
+# Verify:
+curl -sk https://dev.lamoom.com/health
+curl -sk https://dev.lamoom.com/health/openclaw
+```
+
+### Post-Deploy: Configure Auth Context
+1. Find an existing agent in the dashboard
+2. Set the API token for the OpenClaw Console API
+3. Test widget chat: ask "list my tenants" or "restart deployment"
+
+### QA
+Run the full E2E QA skill (`.agents/skills/e2e-playwright-test/SKILL.md`).
+Key phases to verify:
+- Phase 5: Widget chat works with auth context
+- Phase 10: Restart/list critical path passes
+
+---
+
+## Architecture Notes
+
+### Why Token in Prompt?
+OpenClaw agents use `fetch` tool to make HTTP calls. The LLM generates the full `fetch` call including headers. There's no server-side credential injection in OpenClaw's tool runtime. The token MUST be visible to the LLM to generate correct API calls. Mitigated by:
+- Strong "never reveal credentials" instruction in session policy
+- Redacting from API GET responses
+- Server-side auth context takes priority (untrusted client can't override)
+
+### Data Model
+```
+agents.widgetConfig (JSONB):
+{
+  "skills": ["website-api"],
+  "authContext": {
+    "apiToken": "actual-token-value",
+    "Authorization": "Bearer actual-token-value"  // auto-normalized
+  }
+}
+```
+
+### WS Auth Flow (after fix)
+1. Widget connects → sends `{type:"auth", token:"embed-token", userId:"..."}`
+2. Proxy looks up embed token → gets agent + widgetConfig
+3. Extracts `widgetConfig.authContext` → injects into `state.userContext`
+4. On message, `buildWidgetMessageWithSessionPolicy()` prepends auth context to prompt
+5. Agent sees credentials → can use in `fetch` tool calls
+
+### Relevant PRs/Branches
+- Current branch: `fix/regression-api-restart-intent` (2 ahead of main)
+- Unmerged: PR #184 (`fix/regression-chat-ui-section`) — agent detail UX
+- These should be merged to main before starting new work
+
+### VM Access
+- `root@78.47.152.177`
+- Services: webagent-proxy, webagent-admin, openclaw-gateway
+- Docker: lamoom-librechat
+- Workspace: `/opt/webagent/`

--- a/openclaw/templates/skills/website-api/SKILL.md
+++ b/openclaw/templates/skills/website-api/SKILL.md
@@ -60,6 +60,9 @@ fetch("{{API_BASE_URL}}/endpoint", {
 - If auth context is missing, reply with a concrete admin action:
   - "I can run this once an admin configures session auth context (for example `Authorization` or `apiToken`) in the widget/integration backend."
   - Then provide the exact API call you will run after configuration.
+- **Intent echo (mandatory):** Even when credentials are missing, always state your planned action:
+  - "I will call `POST {{API_BASE_URL}}/resource/:id/restart` once auth context is configured."
+  - Never say only "I can't do that" — always specify the exact endpoint, method, and expected outcome.
 
 ## Usage Rules
 

--- a/openclaw/workspaces/meta/knowledgebase/openclaw-console-api-surface.md
+++ b/openclaw/workspaces/meta/knowledgebase/openclaw-console-api-surface.md
@@ -1,0 +1,60 @@
+# OpenClaw Console API Surface (Canonical)
+
+This file is the canonical machine-readable API reference for OpenClaw Console agent generation.
+Use it as the source of truth for OpenClaw Console onboarding.
+
+## Base URLs (ordered)
+1. `https://admin.openclaw.vibebrowser.app`
+2. `https://console.openclaw.vibebrowser.app`
+
+## Auth Contract
+
+### HTTP Auth Requirement
+- Send `Authorization: Bearer <token>` for authenticated `/api/v1/*` requests.
+- Tokens must come from platform-provided session context in the integration backend.
+- Never request tokens from DevTools, localStorage/sessionStorage, cookies, or network logs.
+
+### Session Auth Context Keys (exact keys, stable order)
+| Order | Key | Type | Mapping Rule |
+|---|---|---|---|
+| 1 | `Authorization` | string | Use as-is when present and non-empty. |
+| 2 | `Bearer` | string | Convert to `Authorization: Bearer <Bearer>`. |
+| 3 | `apiToken` | string | Convert to `Authorization: Bearer <apiToken>`. |
+| 4 | `headers` | object | Merge as additional headers after auth resolution; do not drop required defaults. |
+
+## Endpoint Table (`/api/v1`)
+| Method | Path | Description | Request Body | Response Shape |
+|---|---|---|---|---|
+| POST | `/auth/login` | Login with provider flow | `{provider: "telegram", telegram: {...}}` OR `{provider: "google", idToken: "..."}` OR `{provider: "email_password", email, password}` | Auth payload with access/refresh token fields (provider-dependent) |
+| POST | `/auth/register-password` | Register email/password user | `{email, password}` | User/auth payload |
+| POST | `/auth/refresh` | Refresh access token | `{refreshToken}` | Refreshed token payload |
+| GET | `/auth/me` | Current user + subscription | _none_ | `{user: {id, username, displayName, email, provider}, subscription: {planId, planTitle, expiresAt}}` |
+| GET | `/plans` | List plans | _none_ | `[{id, title, description, stars, usdPrice, hostedModels}]` |
+| GET | `/tenants` | List tenants/instances | _none_ | `[{id, subdomain, status, tenantType, specialistPresets, planId, planTitle, createdAt, url, browserUrl}]` |
+| GET | `/tenants/:id` | Get tenant by id | _none_ | Tenant object |
+| POST | `/tenants` | Create tenant | `{planId, tenantType: "personal"|"team", hostType: "container"|"vps", promoCode?, specialistPresets?, vmProvider?}` | `{action: "created"}` OR `{action: "payment_required", checkout: {...}}` |
+| DELETE | `/tenants/:id` | Delete tenant | _none_ | Deletion result |
+| POST | `/tenants/:id/restart` | Restart tenant deployment | No body required. `POST` with no body is accepted; `{}` is also accepted. | Restart result/acknowledgement |
+| GET | `/tenants/:id/logs` | Fetch tenant logs | Query: `tail` (e.g. `?tail=100`) | Log entries payload |
+| GET | `/tenants/specialists` | List specialist presets | _none_ | `{specialists: [{id, label, description}]}` |
+| POST | `/tenants/:id/specialists/install` | Install specialists | `{specialistPresets: ["specialist-id", ...]}` | Install result |
+| GET | `/billing` | Billing overview | _none_ | `{subscription, budget, creditPacks, payments}` |
+| POST | `/billing/topup` | Stripe top-up checkout | `{packId}` | `{checkoutUrl}` |
+| POST | `/billing/topup/crypto` | Crypto top-up checkout | `{packId}` | `{checkoutUrl}` |
+
+## Restart Flow Examples
+
+### Preferred (no request body)
+```http
+POST /api/v1/tenants/<tenantId>/restart
+Authorization: Bearer <token>
+```
+
+### Also accepted (`{}`)
+```http
+POST /api/v1/tenants/<tenantId>/restart
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{}
+```

--- a/openclaw/workspaces/meta/skills/create-agent/SKILL.md
+++ b/openclaw/workspaces/meta/skills/create-agent/SKILL.md
@@ -31,7 +31,13 @@ If links are missing, infer from fetched content and include only verified URLs.
 Before generating, scan the `templates/` directory (relative to this workspace) for **specialized templates** that match the target website. Specialized templates have a site-specific suffix — for example:
 - `AGENTS-openclaw-console-navigation.md` → use for openclaw console agents instead of generic `AGENTS.md`
 - `skills/openclaw-console-navigation/SKILL.md` → include as an extra skill
-- `knowledgebase/openclaw-console-navigation.md` → include as the API reference knowledgebase
+- `knowledgebase/openclaw-console-navigation.md` → fallback specialized knowledgebase template
+
+For OpenClaw Console targets (`openclaw.vibebrowser.app/console`), deterministically prefer the canonical KB at:
+- `openclaw/workspaces/meta/knowledgebase/openclaw-console-api-surface.md`
+
+Copy this canonical KB into `<workspacePath>/knowledgebase/api-reference.md` as the primary API reference, then layer customer-specific naming/context only if needed without changing endpoint/auth contract semantics.
+Do not synthesize or rewrite OpenClaw `/api/v1` contracts from memory when this KB is available.
 
 **Selection rule:** if a specialized template matches the website being onboarded, prefer it over the generic template. Copy its content as-is (filling only genuinely dynamic values like names/URLs), because specialized templates already contain verified endpoint tables, auth flows, and canonical links.
 
@@ -53,7 +59,7 @@ Read templates from `templates/` directory as starting point (using specialized 
 - `<workspacePath>/knowledgebase/overview.md` — product summary + capabilities
 - `<workspacePath>/knowledgebase/key-links.md` — canonical visitor links
 - `<workspacePath>/knowledgebase/use-cases.md` — concrete role/use-case examples
-- `<workspacePath>/knowledgebase/api-reference.md` — **required when API exists**: full endpoint table with method, path, request body, response shape, and auth requirements. Use specialized knowledgebase template if found.
+- `<workspacePath>/knowledgebase/api-reference.md` — **required when API exists**: full endpoint table with method, path, request body, response shape, and auth requirements. For OpenClaw Console targets, use `openclaw/workspaces/meta/knowledgebase/openclaw-console-api-surface.md` first; otherwise use specialized template if found.
 
 Fill all files with customer-specific values (website name, product, API details, tone, links).
 
@@ -77,7 +83,12 @@ In generated files, always include:
 9. The `website-api` skill must include `fetch` tool usage examples specific to the API (correct base URL, auth header format, content type).
 10. For mutating endpoints (POST, PUT, DELETE, PATCH), the skill must include the exact request body shape.
 11. Credential source policy must be explicit: use platform-provided session auth context; never instruct end users to scrape DevTools/localStorage/cookies for tokens.
-12. Missing-credential fallback must be concrete and safe: ask admin/integrator to configure backend session auth context keys (`Authorization`/`apiToken`), then retry the named API call.
+12. Missing-credential fallback must be concrete and safe: ask admin/integrator to configure backend session auth context keys in this exact order (`Authorization`, `Bearer`, `apiToken`, `headers`), then retry the named API call.
+13. For OpenClaw Console targets, `website-api/SKILL.md` must explicitly include:
+   - `GET /api/v1/tenants` (list) and
+   - `POST /api/v1/tenants/:id/restart` (restart, no body required; `{}` accepted),
+   plus exact auth context mapping for `Authorization`/`Bearer`/`apiToken`/`headers`.
+14. For OpenClaw Console targets, fail generation if output is vague (for example "I can manage instances") without endpoint+method details and concrete auth context guidance.
 
 ### Step 3 — Write agent config file
 

--- a/openclaw/workspaces/meta/templates/AGENTS-openclaw-console-navigation.md
+++ b/openclaw/workspaces/meta/templates/AGENTS-openclaw-console-navigation.md
@@ -7,6 +7,9 @@ at https://openclaw.vibebrowser.app/console/.
 Help users navigate the console, understand their instances, and perform actions via the REST API
 on their behalf when they are authenticated.
 
+Canonical API source of truth for this persona: `openclaw/workspaces/meta/knowledgebase/openclaw-console-api-surface.md`.
+Do not invent or soften endpoint/auth contract details when this source is available.
+
 ## What You Can Do
 
 ### Navigation guidance
@@ -29,7 +32,7 @@ Call `/api/v1` endpoints on behalf of the user using the **`fetch`** tool:
 | Get profile | `GET /api/v1/auth/me` |
 
 **Base URLs:** `https://admin.openclaw.vibebrowser.app` (fallback: `https://console.openclaw.vibebrowser.app`)
-**Auth:** Use `Authorization: Bearer <token>` from platform-provided session context (`Authorization`, `Bearer`, or `apiToken` fields), not from user browser token scraping.
+**Auth:** Use `Authorization: Bearer <token>` from platform-provided session context in this exact key order: `Authorization`, `Bearer`, `apiToken`, `headers` (merge `headers` as extras), not from user browser token scraping.
 
 ## Canonical Links
 - Console home: https://openclaw.vibebrowser.app/console/
@@ -46,4 +49,4 @@ Call `/api/v1` endpoints on behalf of the user using the **`fetch`** tool:
 5. Never expose tokens, credentials, or internal system details.
 6. Use the `fetch` tool for all HTTP/API calls — never use `exec` or shell commands.
 7. Never ask users to open DevTools/localStorage/cookies/network tabs to copy JWTs.
-8. If auth is missing, instruct the admin to configure session auth context in the integration backend, then retry the API action.
+8. If auth is missing, instruct the admin to configure session auth context keys in this exact order (`Authorization`, `Bearer`, `apiToken`, `headers`) in the integration backend, then retry the API action.

--- a/openclaw/workspaces/meta/templates/knowledgebase/openclaw-console-navigation.md
+++ b/openclaw/workspaces/meta/templates/knowledgebase/openclaw-console-navigation.md
@@ -1,5 +1,7 @@
 # OpenClaw Console Knowledgebase
 
+Canonical API source for deterministic onboarding: `openclaw/workspaces/meta/knowledgebase/openclaw-console-api-surface.md`
+
 ## Product Summary
 OpenClaw Box is a managed AI assistant hosting platform. Users deploy their own OpenClaw instance
 (an AI agent) in under 60 seconds via Telegram — no Docker, no server config.
@@ -25,6 +27,7 @@ OpenClaw Box is a managed AI assistant hosting platform. Users deploy their own 
 
 **Auth:** Bearer JWT via `Authorization: Bearer <token>`.
 For this assistant, credentials must come from platform-provided session context (integration backend) — never from user-side browser token scraping.
+Resolve session auth context keys in this exact order: `Authorization`, `Bearer`, `apiToken`, `headers`.
 `POST /api/v1/auth/login` and `POST /api/v1/auth/refresh` are backend auth flows, not instructions for end users to extract tokens from DevTools/localStorage.
 
 ### Auth Endpoints
@@ -47,7 +50,7 @@ For this assistant, credentials must come from platform-provided session context
 | GET | `/api/v1/tenants/:id` | Get single tenant details |
 | POST | `/api/v1/tenants` | Create tenant. Body: `{planId, tenantType: "personal"|"team", hostType: "container"|"vps", promoCode?, specialistPresets?: [...], vmProvider?: "hetzner"}`. Returns `{action: "created"}` or `{action: "payment_required", checkout: {...}}` |
 | DELETE | `/api/v1/tenants/:id` | Permanently delete tenant |
-| POST | `/api/v1/tenants/:id/restart` | Restart a running tenant |
+| POST | `/api/v1/tenants/:id/restart` | Restart a running tenant. Request body: none required (`{}` also accepted) |
 | GET | `/api/v1/tenants/:id/logs` | Get tenant logs. Query: `?tail=100` |
 
 ### Specialists

--- a/openclaw/workspaces/meta/templates/skills/openclaw-console-navigation/SKILL.md
+++ b/openclaw/workspaces/meta/templates/skills/openclaw-console-navigation/SKILL.md
@@ -21,3 +21,4 @@ Use this skill for customer prompts like:
 6. For authenticated API calls, read credentials from platform-provided session context (`Authorization`, `Bearer`, `apiToken`, optional `headers`).
 7. Never ask users to extract tokens from DevTools, localStorage/sessionStorage, cookies, or browser network logs.
 8. If credentials are missing, provide a concrete admin action: configure session auth context in the integration backend, then retry the exact API call.
+9. **Intent echo:** When a user asks to restart/delete/create and auth is missing, always state: "I will call `POST /api/v1/tenants/:id/restart` (or the relevant endpoint) once session auth context is available. An admin needs to configure `Authorization` in widget integration settings." Also include expected outcome.

--- a/openclaw/workspaces/meta/templates/skills/website-api/SKILL.md
+++ b/openclaw/workspaces/meta/templates/skills/website-api/SKILL.md
@@ -60,6 +60,9 @@ fetch("{{API_BASE_URL}}/endpoint", {
 - If auth context is missing, reply with a concrete admin action:
   - "I can run this once an admin configures session auth context (for example `Authorization` or `apiToken`) in the widget/integration backend."
   - Then provide the exact API call you will run after configuration.
+- **Intent echo (mandatory):** Even when credentials are missing, always state your planned action:
+  - "I will call `POST {{API_BASE_URL}}/resource/:id/restart` once auth context is configured."
+  - Never say only "I can't do that" — always specify the exact endpoint, method, and expected outcome.
 
 ## Usage Rules
 

--- a/packages/admin/src/app/dashboard/agents/[id]/page.tsx
+++ b/packages/admin/src/app/dashboard/agents/[id]/page.tsx
@@ -8,8 +8,7 @@ import { WidgetPreview } from "@/components/widget-preview";
 import { CreateAgentChat } from "@/components/create-agent-chat";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { CircleHelp } from "lucide-react";
+import { MessageCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const WIDGET_BASE_URL = process.env.NEXT_PUBLIC_APP_URL || process.env.AUTH_URL || "https://dev.lamoom.com";
@@ -83,18 +82,9 @@ export default async function AgentDetailPage({ params }: Props) {
       {/* Live widget preview */}
       {agent.embedToken && (
         <div className="space-y-3">
-          <div className="flex items-center justify-end">
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger
-                  aria-label="Widget test help"
-                  className="text-muted-foreground transition-colors hover:text-foreground"
-                >
-                  <CircleHelp className="h-4 w-4" />
-                </TooltipTrigger>
-                <TooltipContent>Test me!</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+          <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+            <MessageCircle className="h-4 w-4" />
+            <span>Chat</span>
           </div>
           <WidgetPreview agentToken={agent.embedToken} widgetBaseUrl={WIDGET_BASE_URL} />
         </div>

--- a/packages/admin/src/components/widget-preview.tsx
+++ b/packages/admin/src/components/widget-preview.tsx
@@ -32,10 +32,7 @@ export function WidgetPreview({ agentToken, widgetBaseUrl }: { agentToken: strin
   );
 
   return (
-    <div className="space-y-3">
-      <p className="text-xs text-muted-foreground">
-        Real embed preview loaded from <code className="font-mono">{scriptSrc}</code>.
-      </p>
+    <div>
       <iframe
         title="Real widget preview"
         srcDoc={srcDoc}

--- a/packages/proxy/src/routes/admin-api.ts
+++ b/packages/proxy/src/routes/admin-api.ts
@@ -1,7 +1,27 @@
 import { timingSafeEqual } from 'node:crypto';
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { dirname, join } from 'node:path';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { count, desc, eq, sql } from 'drizzle-orm';
 import { agents, auditLog, customers, widgetSessions } from '../db/schema.js';
+
+const WEBSITE_API_SKILL_RELATIVE_PATH = join('skills', 'website-api', 'SKILL.md');
+const WEBSITE_API_TEMPLATE_RELATIVE_PATH = join('templates', WEBSITE_API_SKILL_RELATIVE_PATH);
+const FALLBACK_ENDPOINTS_TABLE = [
+  '| Method | Path | Description | Request Body | Response |',
+  '|--------|------|-------------|-------------|----------|',
+].join('\n');
+
+type WorkspaceAgentConfig = {
+  agentName?: string;
+  websiteName?: string;
+  apiBaseUrl?: string;
+  apiAuthMethod?: string;
+  apiStyle?: string;
+  apiEndpoints?: string;
+  apiDescription?: string;
+};
 
 function sendError(reply: FastifyReply, statusCode: number, code: string, message: string) {
   return reply.status(statusCode).send({
@@ -57,6 +77,132 @@ function requireInternalAuth(request: FastifyRequest, reply: FastifyReply): bool
   }
 
   return true;
+}
+
+function resolveWorkspaceBaseDirs(): string[] {
+  const configured = process.env.OPENCLAW_WORKSPACES_DIR?.trim();
+  if (configured) {
+    return [configured];
+  }
+
+  const primary = join(process.cwd(), 'openclaw', 'workspaces');
+  const fallback = join(process.cwd(), '..', '..', 'openclaw', 'workspaces');
+  return primary === fallback ? [primary] : [primary, fallback];
+}
+
+function resolveAgentWorkspaceCandidates(slug: string): string[] {
+  return resolveWorkspaceBaseDirs().map((baseDir) => join(baseDir, slug));
+}
+
+async function resolveFirstExistingPath(paths: string[]): Promise<string | null> {
+  for (const candidatePath of paths) {
+    try {
+      await access(candidatePath, fsConstants.F_OK);
+      return candidatePath;
+    } catch {
+      // continue
+    }
+  }
+  return null;
+}
+
+function parseRenderedField(skillText: string, fieldName: string): string | null {
+  const escaped = fieldName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = skillText.match(new RegExp(`- \\*\\*${escaped}:\\*\\*\\s*(.+)`, 'i'));
+  const value = match?.[1]?.trim();
+  return value ? value : null;
+}
+
+function extractRenderedApiEndpoints(skillText: string): string | null {
+  const sectionMatch = skillText.match(
+    /## Available Actions\s*\n+([\s\S]*?)(?:\n<!-- GENERATION NOTE:|\n## )/,
+  );
+  if (!sectionMatch?.[1]) return null;
+  const value = sectionMatch[1].trim();
+  if (!value || value.includes('{{API_ENDPOINTS}}')) return null;
+  return value;
+}
+
+function renderWebsiteApiSkillFromTemplate(params: {
+  templateText: string;
+  websiteName: string;
+  apiBaseUrl: string;
+  apiAuthMethod: string;
+  apiStyle: string;
+  apiEndpoints: string;
+}): string {
+  return params.templateText
+    .replaceAll('{{WEBSITE_NAME}}', params.websiteName)
+    .replaceAll('{{API_BASE_URL}}', params.apiBaseUrl)
+    .replaceAll('{{API_AUTH_METHOD}}', params.apiAuthMethod)
+    .replaceAll('{{API_STYLE}}', params.apiStyle)
+    .replaceAll('{{API_ENDPOINTS}}', params.apiEndpoints);
+}
+
+async function regenerateWebsiteApiSkill(params: {
+  agent: typeof agents.$inferSelect;
+  logger: FastifyRequest['log'];
+}): Promise<{ workspacePath: string; skillPath: string; templatePath: string }> {
+  const workspaceCandidates = resolveAgentWorkspaceCandidates(params.agent.openclawAgentId);
+  const workspacePath = await resolveFirstExistingPath(workspaceCandidates);
+  if (!workspacePath) {
+    throw new Error(`Workspace not found for agent slug "${params.agent.openclawAgentId}"`);
+  }
+
+  const skillPath = join(workspacePath, WEBSITE_API_SKILL_RELATIVE_PATH);
+  const agentConfigPath = join(workspacePath, 'agent-config.json');
+
+  const templateCandidates = [
+    join(workspacePath, '..', 'meta', WEBSITE_API_TEMPLATE_RELATIVE_PATH),
+    join(process.cwd(), 'openclaw', 'workspaces', 'meta', WEBSITE_API_TEMPLATE_RELATIVE_PATH),
+    join(process.cwd(), 'openclaw', WEBSITE_API_TEMPLATE_RELATIVE_PATH),
+  ];
+  const templatePath = await resolveFirstExistingPath(templateCandidates);
+  if (!templatePath) {
+    throw new Error('website-api skill template not found');
+  }
+
+  let existingSkillText = '';
+  try {
+    existingSkillText = await readFile(skillPath, 'utf8');
+  } catch {
+    existingSkillText = '';
+  }
+
+  let agentConfig: WorkspaceAgentConfig = {};
+  try {
+    const rawConfig = await readFile(agentConfigPath, 'utf8');
+    agentConfig = JSON.parse(rawConfig) as WorkspaceAgentConfig;
+  } catch (error) {
+    params.logger.warn({ error, agentConfigPath }, 'failed to read agent config for skill refresh');
+  }
+
+  const templateText = await readFile(templatePath, 'utf8');
+  const apiEndpoints = extractRenderedApiEndpoints(existingSkillText)
+    || agentConfig.apiEndpoints?.trim()
+    || agentConfig.apiDescription?.trim()
+    || FALLBACK_ENDPOINTS_TABLE;
+  const apiAuthMethod = parseRenderedField(existingSkillText, 'Auth')
+    || agentConfig.apiAuthMethod?.trim()
+    || 'Not specified';
+  const apiStyle = parseRenderedField(existingSkillText, 'Style')
+    || agentConfig.apiStyle?.trim()
+    || 'Not specified';
+  const apiBaseUrl = agentConfig.apiBaseUrl?.trim() || '';
+  const websiteName = agentConfig.websiteName?.trim() || params.agent.name;
+
+  const renderedSkill = renderWebsiteApiSkillFromTemplate({
+    templateText,
+    websiteName,
+    apiBaseUrl,
+    apiAuthMethod,
+    apiStyle,
+    apiEndpoints,
+  });
+
+  await mkdir(dirname(skillPath), { recursive: true });
+  await writeFile(skillPath, `${renderedSkill.trimEnd()}\n`, 'utf8');
+  return { workspacePath, skillPath, templatePath };
 }
 
 export function registerAdminApiRoutes(app: FastifyInstance) {
@@ -216,6 +362,44 @@ export function registerAdminApiRoutes(app: FastifyInstance) {
       const errMsg = error instanceof Error ? error.message : String(error);
       request.log.error({ error: errMsg, stack: error instanceof Error ? error.stack : undefined }, 'failed to list admin agents');
       return sendError(reply, 500, 'internal_error', 'Failed to list agents');
+    }
+  });
+
+  app.post('/api/admin/agents/:id/refresh-workspace', async (request, reply) => {
+    if (!requireInternalAuth(request, reply)) return;
+
+    const { id } = request.params as { id: string };
+
+    try {
+      const agentRows = await app.db
+        .select()
+        .from(agents)
+        .where(eq(agents.id, id))
+        .limit(1);
+
+      const agent = agentRows[0];
+      if (!agent) {
+        return sendError(reply, 404, 'not_found', 'Agent not found');
+      }
+
+      const refreshed = await regenerateWebsiteApiSkill({
+        agent,
+        logger: request.log,
+      });
+
+      return reply.send({
+        success: true,
+        data: {
+          agentId: agent.id,
+          openclawAgentId: agent.openclawAgentId,
+          workspacePath: refreshed.workspacePath,
+          skillPath: refreshed.skillPath,
+          templatePath: refreshed.templatePath,
+        },
+      });
+    } catch (error) {
+      request.log.error({ error, id }, 'failed to refresh agent workspace');
+      return sendError(reply, 500, 'internal_error', 'Failed to refresh agent workspace');
     }
   });
 

--- a/packages/proxy/src/ws/handler.ts
+++ b/packages/proxy/src/ws/handler.ts
@@ -248,8 +248,10 @@ function buildWidgetMessageWithSessionPolicy(userContext: Record<string, unknown
     = 'Credential source: server-side session auth context provided by the widget/integration backend.\n'
     + 'Never ask end users to fetch or copy JWTs/tokens from DevTools, localStorage, sessionStorage, cookies, or network tabs.';
   const fallbackGuidance
-    = 'If an API call needs authentication and session context is missing, tell the user: '
-    + '"This action requires authentication. Please ask your workspace administrator or integration owner to configure server-side session auth context keys (`Authorization` or `apiToken`) in the widget/integration backend."';
+    = 'If an API call needs authentication and session context is missing:\n'
+    + '1. State the exact API call you would make (method, path, body) so the user knows what will happen.\n'
+    + '2. Explain: "I need session auth context to execute this. An admin must configure the `Authorization` or `apiToken` field in the widget integration settings (Settings → Integrations → Auth Context)."\n'
+    + '3. Never give a vague refusal — always name the endpoint (e.g., `POST /api/v1/tenants/:id/restart`) and confirm expected outcome + that you will execute it once credentials are available.';
   if (Object.keys(userContext).length > 0) {
     const contextLines = Object.entries(userContext)
       .map(([k, v]) => `${k}: ${formatContextValue(v)}`)


### PR DESCRIPTION
## Summary

Consolidates all pending MVP work into a single merge:

### Already implemented (this PR)
- **QA skill hardened** — strict verdict matrix, evidence requirements, blocker precedence, false-positive gates
- **Intent-echo rules** — agent states exact API call before executing  
- **Refresh-workspace endpoint** — `POST /api/admin/agents/:id/refresh-workspace`
- **Agent detail UX** — simplified "Chat" label (MessageCircle icon, no "Test Your Widget" framing)
- **API surface KB** — canonical OpenClaw Console API reference for meta-agent
- **Meta templates updated** — never-request-browser-token rule, concrete endpoint guidance
- **Unknown-agent self-heal** — WS handler retries after registering agent with gateway

### Handoff for remaining work (HANDOFF.md)
Full implementation spec for the critical MVP blocker — server-side auth context injection:
1. WS handler reads `widgetConfig.authContext` and injects into widget sessions
2. PATCH deep-merge for widgetConfig (preserves existing `skills`)
3. Auth context config UI on agent detail page
4. Cache invalidation on widgetConfig changes
5. Credential redaction from GET API responses

See `HANDOFF.md` for complete architecture notes and implementation details.

### Files changed
- `.agents/skills/e2e-playwright-test/SKILL.md` — hardened QA protocol
- `openclaw/workspaces/meta/` — KB, templates, skills updates
- `packages/admin/src/` — agent detail UX simplification
- `packages/proxy/src/` — refresh-workspace, WS handler, intent-echo
- `HANDOFF.md` — full implementation spec for auth context fix
