### PR TITLE
feat: server-side auth context injection for widget agents

### DIFF
--- a/packages/admin/src/app/dashboard/agents/[id]/page.tsx
+++ b/packages/admin/src/app/dashboard/agents/[id]/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { normalizeCustomerIdToUuid } from "@/lib/customer-id";
 import { AgentDetailActions } from "@/components/agent-detail-actions";
 import { AgentEditForm } from "@/components/agent-edit-form";
+import { AgentAuthContext } from "@/components/agent-auth-context";
 import { WidgetPreview } from "@/components/widget-preview";
 import { CreateAgentChat } from "@/components/create-agent-chat";
 import { Badge } from "@/components/ui/badge";
@@ -78,6 +79,22 @@ export default async function AgentDetailPage({ params }: Props) {
           <AgentDetailActions agentId={agent.id} embedCode={embedCode} />
         </CardContent>
       </Card>
+
+      {/* API Configuration */}
+      {agent.embedToken && (
+        <Card>
+          <CardContent className="pt-6">
+            <AgentAuthContext
+              agentId={agent.id}
+              initialApiToken={
+                typeof agent.widgetConfig === "object" && agent.widgetConfig !== null
+                  ? (agent.widgetConfig as { authContext?: { apiToken?: string } }).authContext?.apiToken
+                  : undefined
+              }
+            />
+          </CardContent>
+        </Card>
+      )}
 
       {/* Live widget preview */}
       {agent.embedToken && (

--- a/packages/admin/src/components/agent-auth-context.tsx
+++ b/packages/admin/src/components/agent-auth-context.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+import { Lock } from "lucide-react";
+import { serverUpdateAgent } from "@/lib/actions";
+import { useToast } from "@/components/toast";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface AgentAuthContextProps {
+  agentId: string;
+  initialApiToken?: string;
+}
+
+export function AgentAuthContext({ agentId, initialApiToken }: AgentAuthContextProps) {
+  const [apiToken, setApiToken] = useState(initialApiToken || "");
+  const [saving, setSaving] = useState(false);
+  const { toast } = useToast();
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await serverUpdateAgent(agentId, {
+        widgetConfig: {
+          authContext: {
+            apiToken: apiToken || undefined,
+          },
+        },
+      });
+      toast({ message: "API configuration saved.", type: "success" });
+    } catch (err) {
+      toast({ message: err instanceof Error ? err.message : "Failed to save.", type: "error" });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Lock className="h-4 w-4" />
+          API Configuration
+        </CardTitle>
+        <CardDescription>
+          Configure credentials for API calls. These are stored securely on the server.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
+          <div className="flex-1">
+            <label htmlFor="apiToken" className="text-sm font-medium">
+              API Token
+            </label>
+            <Input
+              id="apiToken"
+              type="password"
+              value={apiToken}
+              onChange={(e) => setApiToken(e.target.value)}
+              placeholder="Enter API token (optional)"
+              className="mt-1"
+            />
+          </div>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/admin/src/components/widget-preview.tsx
+++ b/packages/admin/src/components/widget-preview.tsx
@@ -34,7 +34,7 @@ export function WidgetPreview({ agentToken, widgetBaseUrl }: { agentToken: strin
   return (
     <div>
       <iframe
-        title="Real widget preview"
+        title="Widget preview"
         srcDoc={srcDoc}
         className="w-full rounded-xl border border-zinc-700 bg-black"
         style={{ height: 540 }}

--- a/packages/proxy/src/routes/api.ts
+++ b/packages/proxy/src/routes/api.ts
@@ -793,6 +793,9 @@ Customer: ${normalizedLatestMessage}`
           embed,
           embedToken: embed?.embedToken ?? null,
           allowedOrigins: embed?.allowedOrigins ?? null,
+          widgetConfig: agent.widgetConfig
+            ? { ...(agent.widgetConfig as Record<string, unknown>), authContext: { configured: true } }
+            : null,
         },
       });
     } catch (error) {
@@ -828,10 +831,19 @@ Customer: ${normalizedLatestMessage}`
         return sendError(reply, 404, 'not_found', 'Agent not found');
       }
 
+      // Deep-merge widgetConfig to preserve existing keys like 'skills'
+      const mergedBody = { ...body };
+      if (body.widgetConfig && existingAgent.widgetConfig) {
+        mergedBody.widgetConfig = {
+          ...(existingAgent.widgetConfig as Record<string, unknown>),
+          ...body.widgetConfig,
+        };
+      }
+
       const updatedRows = await app.db
         .update(agents)
         .set({
-          ...body,
+          ...mergedBody,
           updatedAt: new Date(),
         })
         .where(and(eq(agents.id, params.id), eq(agents.customerId, customerId)))
@@ -847,6 +859,17 @@ Customer: ${normalizedLatestMessage}`
       });
 
       if (body.status && body.status !== existingAgent.status) {
+        const embedRows = await app.db
+          .select({ embedToken: widgetEmbeds.embedToken })
+          .from(widgetEmbeds)
+          .where(eq(widgetEmbeds.agentId, params.id));
+        for (const embedRow of embedRows) {
+          invalidateEmbedTokenCache(embedRow.embedToken);
+        }
+      }
+
+      // Invalidate cache when widgetConfig changes
+      if (body.widgetConfig) {
         const embedRows = await app.db
           .select({ embedToken: widgetEmbeds.embedToken })
           .from(widgetEmbeds)

--- a/packages/proxy/src/ws/handler.ts
+++ b/packages/proxy/src/ws/handler.ts
@@ -42,6 +42,7 @@ interface TokenLookup {
   agentId: string;
   openclawAgentId: string;
   allowedOrigins: string[] | null;
+  widgetConfig: Record<string, unknown> | null;
 }
 
 interface TokenCacheEntry {
@@ -246,7 +247,9 @@ function normalizeSessionAuthContext(rawContext: Record<string, unknown>): Recor
 function buildWidgetMessageWithSessionPolicy(userContext: Record<string, unknown>, customerContent: string): string {
   const credentialPolicy
     = 'Credential source: server-side session auth context provided by the widget/integration backend.\n'
-    + 'Never ask end users to fetch or copy JWTs/tokens from DevTools, localStorage, sessionStorage, cookies, or network tabs.';
+    + 'Never ask end users to fetch or copy JWTs/tokens from DevTools, localStorage, sessionStorage, cookies, or network tabs.\n'
+    + 'Never reveal, display, echo, or include raw credential/token values in your responses. '
+    + 'Use them ONLY in fetch/API tool call headers. If a user asks for the token, decline.';
   const fallbackGuidance
     = 'If an API call needs authentication and session context is missing:\n'
     + '1. State the exact API call you would make (method, path, body) so the user knows what will happen.\n'
@@ -426,6 +429,7 @@ async function lookupEmbedToken(db: Database, embedToken: string): Promise<Token
       agentId: agents.id,
       openclawAgentId: agents.openclawAgentId,
       allowedOrigins: widgetEmbeds.allowedOrigins,
+      widgetConfig: agents.widgetConfig,
     })
     .from(widgetEmbeds)
     .innerJoin(agents, eq(widgetEmbeds.agentId, agents.id))
@@ -441,6 +445,7 @@ async function lookupEmbedToken(db: Database, embedToken: string): Promise<Token
     agentId: row.agentId,
     openclawAgentId: row.openclawAgentId,
     allowedOrigins: row.allowedOrigins,
+    widgetConfig: row.widgetConfig as Record<string, unknown> | null,
   };
 
   setCachedTokenLookup(embedToken, value);
@@ -584,10 +589,22 @@ export function handleConnection(
             return;
           }
 
-          // Extract optional user context (e.g. API token) passed by the embedding page.
+          // Inject server-side auth context from agent config (takes priority)
+          const serverAuthCtx = tokenData.widgetConfig?.authContext;
+          if (serverAuthCtx && typeof serverAuthCtx === 'object' && !Array.isArray(serverAuthCtx)) {
+            state.userContext = normalizeSessionAuthContext(serverAuthCtx as Record<string, unknown>);
+          }
+
+          // Client context can add NON-auth fields only (safety)
           const rawContext = msg.context;
           if (rawContext && typeof rawContext === 'object' && !Array.isArray(rawContext)) {
-            state.userContext = normalizeSessionAuthContext(rawContext as Record<string, unknown>);
+            const clientCtx = rawContext as Record<string, unknown>;
+            const AUTH_KEYS = new Set(['Authorization', 'Bearer', 'apiToken', 'token', 'headers']);
+            for (const [k, v] of Object.entries(clientCtx)) {
+              if (!AUTH_KEYS.has(k)) {
+                state.userContext[k] = v;
+              }
+            }
             if (Object.keys(state.userContext).length > 0) {
               state.firstMessage = true;
             }


### PR DESCRIPTION
Implements server-side auth context injection so widget agents can execute API calls. See HANDOFF.md for architecture details.