### PR TITLE
fix(openclaw): reconcile registration & skills on startup (#193)

### DIFF
--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -10,6 +10,7 @@
     "build": "tsc -p tsconfig.json && pnpm run build:widget",
     "build:widget": "cd ../.. && node --import tsx packages/proxy/src/widget/build-widget.ts",
     "start": "node dist/index.js",
+    "test": "OPENCLAW_GATEWAY_TOKEN=test-token DATABASE_URL=postgres://stub/stub node --import tsx --test src/**/__tests__/*.test.ts",
     "lint": "tsc -p tsconfig.json --noEmit",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "db:generate": "drizzle-kit generate",

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -11,6 +11,7 @@ import { registerOpenAiCompatRoutes } from './routes/openai-compat.js';
 import { registerSsoRoutes } from './routes/sso.js';
 import { registerWidgetRoutes } from './routes/widget.js';
 import { handleConnection } from './ws/handler.js';
+import { reconcileOpenClawConfig } from './openclaw/reconciler.js';
 import { DEFAULT_WS_PATH } from '@webagent/shared/constants';
 
 interface ManagedSocket {
@@ -93,6 +94,19 @@ process.once('SIGINT', () => {
 
 const start = async (): Promise<void> => {
   try {
+    // Reconcile openclaw.json5 against on-disk agent workspaces. Non-fatal:
+    // a broken workspace must not block the server from coming up.
+    try {
+      const summary = await reconcileOpenClawConfig(app);
+      if (summary.errors.length > 0) {
+        app.log.warn({ summary }, 'openclaw reconciler completed with errors');
+      } else {
+        app.log.info({ summary }, 'openclaw reconciler completed');
+      }
+    } catch (err) {
+      app.log.error({ err }, 'openclaw reconciler crashed (continuing startup)');
+    }
+
     await app.listen({ host: '0.0.0.0', port: config.port });
     app.log.info(
       { port: config.port, openClawGatewayUrl: config.openClawGatewayUrl },

--- a/packages/proxy/src/openclaw/__tests__/atomic-write.test.ts
+++ b/packages/proxy/src/openclaw/__tests__/atomic-write.test.ts
@@ -1,0 +1,68 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, readdir, writeFile, chmod } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { atomicWriteFile } from '../atomic-write.js';
+
+async function makeTmp(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), 'atomic-write-'));
+}
+
+test('atomicWriteFile creates a new file with the given contents', async () => {
+  const dir = await makeTmp();
+  const target = join(dir, 'out.txt');
+  await atomicWriteFile(target, 'hello world\n');
+  const got = await readFile(target, 'utf8');
+  assert.equal(got, 'hello world\n');
+});
+
+test('atomicWriteFile overwrites an existing file', async () => {
+  const dir = await makeTmp();
+  const target = join(dir, 'out.txt');
+  await writeFile(target, 'old');
+  await atomicWriteFile(target, 'new contents');
+  assert.equal(await readFile(target, 'utf8'), 'new contents');
+});
+
+test('atomicWriteFile leaves no .tmp sibling on success', async () => {
+  const dir = await makeTmp();
+  const target = join(dir, 'config.json5');
+  await atomicWriteFile(target, '{ ok: true }');
+  const entries = await readdir(dir);
+  assert.deepEqual(
+    entries.filter((e) => e.includes('.tmp')),
+    [],
+    'no .tmp file should remain after success',
+  );
+  assert.deepEqual(entries, ['config.json5']);
+});
+
+test('atomicWriteFile throws and cleans up tmp on rename failure', async () => {
+  // Simulate rename failure by making the target directory read-only AFTER
+  // the temp file is created. The temp file is created inside the dir, so
+  // we can't lock writes ahead of time. Instead, point at a path whose
+  // directory does not exist — open() will fail before the rename, but
+  // that exercises the throw path. We then assert no junk leaks.
+  const dir = await makeTmp();
+  const target = join(dir, 'does-not-exist-subdir', 'file.txt');
+  await assert.rejects(() => atomicWriteFile(target, 'x'));
+  const entries = await readdir(dir);
+  assert.deepEqual(entries, []);
+});
+
+test('atomicWriteFile is concurrent-safe: last writer wins, no corruption', async () => {
+  const dir = await makeTmp();
+  const target = join(dir, 'race.txt');
+  const writers: Promise<void>[] = [];
+  for (let i = 0; i < 20; i++) {
+    writers.push(atomicWriteFile(target, `payload-${i}`));
+  }
+  await Promise.all(writers);
+  const got = await readFile(target, 'utf8');
+  assert.match(got, /^payload-\d+$/);
+  // Ensure no orphaned .tmp files leaked.
+  const entries = await readdir(dir);
+  assert.deepEqual(entries, ['race.txt']);
+});

--- a/packages/proxy/src/openclaw/__tests__/reconciler.test.ts
+++ b/packages/proxy/src/openclaw/__tests__/reconciler.test.ts
@@ -1,0 +1,239 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import JSON5 from 'json5';
+
+import { reconcileOpenClawConfig } from '../reconciler.js';
+
+/**
+ * Minimal Fastify-shaped stub. The reconciler only uses `app.log.{info,warn,error}`.
+ */
+function makeApp() {
+  const events: { level: string; obj: unknown; msg?: string }[] = [];
+  const mk = (level: string) =>
+    (objOrMsg: unknown, msg?: string) => {
+      events.push({ level, obj: objOrMsg, msg });
+    };
+  return {
+    log: { info: mk('info'), warn: mk('warn'), error: mk('error') },
+    events,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+interface Fixture {
+  root: string;
+  configPath: string;
+  workspacesDir: string;
+  cleanup: () => void;
+}
+
+async function setupFixture(initialConfig: unknown): Promise<Fixture> {
+  const root = await mkdtemp(join(tmpdir(), 'reconciler-'));
+  const configDir = join(root, 'openclaw', 'config');
+  const workspacesDir = join(root, 'openclaw', 'workspaces');
+  await mkdir(configDir, { recursive: true });
+  await mkdir(workspacesDir, { recursive: true });
+  const configPath = join(configDir, 'openclaw.json5');
+  await writeFile(configPath, JSON5.stringify(initialConfig, null, 2));
+
+  const prevConfig = process.env.OPENCLAW_CONFIG_PATH;
+  const prevWorkspaces = process.env.OPENCLAW_WORKSPACES_DIR;
+  const prevRemove = process.env.OPENCLAW_RECONCILE_REMOVE_ORPHANS;
+  process.env.OPENCLAW_CONFIG_PATH = configPath;
+  process.env.OPENCLAW_WORKSPACES_DIR = workspacesDir;
+
+  return {
+    root,
+    configPath,
+    workspacesDir,
+    cleanup: () => {
+      if (prevConfig === undefined) delete process.env.OPENCLAW_CONFIG_PATH;
+      else process.env.OPENCLAW_CONFIG_PATH = prevConfig;
+      if (prevWorkspaces === undefined) delete process.env.OPENCLAW_WORKSPACES_DIR;
+      else process.env.OPENCLAW_WORKSPACES_DIR = prevWorkspaces;
+      if (prevRemove === undefined) delete process.env.OPENCLAW_RECONCILE_REMOVE_ORPHANS;
+      else process.env.OPENCLAW_RECONCILE_REMOVE_ORPHANS = prevRemove;
+    },
+  };
+}
+
+async function writeWorkspace(
+  workspacesDir: string,
+  slug: string,
+  cfg: Record<string, unknown> | null,
+): Promise<void> {
+  const dir = join(workspacesDir, slug);
+  await mkdir(dir, { recursive: true });
+  if (cfg !== null) {
+    await writeFile(join(dir, 'agent-config.json'), JSON.stringify(cfg, null, 2));
+  }
+}
+
+test('adds a missing entry for an on-disk workspace', async () => {
+  const fx = await setupFixture({ agents: { list: [] } });
+  try {
+    await writeWorkspace(fx.workspacesDir, 'acme-bot', {
+      agentSlug: 'acme-bot',
+      agentName: 'Acme Bot',
+      skills: ['website-api', 'website-knowledge'],
+    });
+    const res = await reconcileOpenClawConfig(makeApp());
+    assert.deepEqual(res.added, ['acme-bot']);
+    assert.deepEqual(res.updated, []);
+    assert.deepEqual(res.removed, []);
+    assert.deepEqual(res.errors, []);
+
+    const written = JSON5.parse(await readFile(fx.configPath, 'utf8')) as {
+      agents: { list: { id: string; name: string; skills: string[]; workspace: string }[] };
+    };
+    assert.equal(written.agents.list.length, 1);
+    assert.equal(written.agents.list[0]!.id, 'acme-bot');
+    assert.equal(written.agents.list[0]!.name, 'Acme Bot');
+    assert.deepEqual(written.agents.list[0]!.skills, ['website-api', 'website-knowledge']);
+    assert.equal(written.agents.list[0]!.workspace, join(fx.workspacesDir, 'acme-bot'));
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test('updates skills when on-disk config differs from openclaw.json5', async () => {
+  const fx = await setupFixture({
+    agents: {
+      list: [
+        {
+          id: 'acme-bot',
+          name: 'Acme Bot',
+          workspace: '/old/path',
+          sandbox: { mode: 'off' },
+          skills: ['website-api'],
+          heartbeat: { every: '15m' },
+          customField: 'preserve me',
+        },
+      ],
+    },
+  });
+  try {
+    await writeWorkspace(fx.workspacesDir, 'acme-bot', {
+      agentSlug: 'acme-bot',
+      agentName: 'Acme Bot',
+      skills: ['website-api', 'website-knowledge'],
+    });
+    const res = await reconcileOpenClawConfig(makeApp());
+    assert.deepEqual(res.added, []);
+    assert.deepEqual(res.updated, ['acme-bot']);
+    assert.deepEqual(res.errors, []);
+
+    const written = JSON5.parse(await readFile(fx.configPath, 'utf8')) as {
+      agents: { list: Record<string, unknown>[] };
+    };
+    const entry = written.agents.list[0]!;
+    assert.deepEqual(entry.skills, ['website-api', 'website-knowledge']);
+    assert.equal(entry.workspace, join(fx.workspacesDir, 'acme-bot'));
+    // Custom hand-edited fields and existing heartbeat must be preserved.
+    assert.equal(entry.customField, 'preserve me');
+    assert.deepEqual(entry.heartbeat, { every: '15m' });
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test('skips the meta workspace', async () => {
+  const fx = await setupFixture({ agents: { list: [] } });
+  try {
+    await writeWorkspace(fx.workspacesDir, 'meta', {
+      agentSlug: 'meta',
+      agentName: 'Meta',
+      skills: ['create-agent'],
+    });
+    const res = await reconcileOpenClawConfig(makeApp());
+    assert.deepEqual(res.added, []);
+    assert.deepEqual(res.updated, []);
+    assert.deepEqual(res.errors, []);
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test('is idempotent: a second run produces no changes', async () => {
+  const fx = await setupFixture({ agents: { list: [] } });
+  try {
+    await writeWorkspace(fx.workspacesDir, 'acme-bot', {
+      agentSlug: 'acme-bot',
+      agentName: 'Acme Bot',
+      skills: ['website-api'],
+    });
+    await reconcileOpenClawConfig(makeApp());
+    const res2 = await reconcileOpenClawConfig(makeApp());
+    assert.deepEqual(res2.added, []);
+    assert.deepEqual(res2.updated, []);
+    assert.deepEqual(res2.removed, []);
+    assert.deepEqual(res2.errors, []);
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test('skips workspaces without agent-config.json', async () => {
+  const fx = await setupFixture({ agents: { list: [] } });
+  try {
+    await writeWorkspace(fx.workspacesDir, 'scratch', null);
+    const res = await reconcileOpenClawConfig(makeApp());
+    assert.deepEqual(res.added, []);
+    assert.deepEqual(res.errors, []);
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test('records errors for malformed agent-config.json without aborting other workspaces', async () => {
+  const fx = await setupFixture({ agents: { list: [] } });
+  try {
+    await mkdir(join(fx.workspacesDir, 'broken'), { recursive: true });
+    await writeFile(join(fx.workspacesDir, 'broken', 'agent-config.json'), '{ not json');
+    await writeWorkspace(fx.workspacesDir, 'good-bot', {
+      agentSlug: 'good-bot',
+      agentName: 'Good',
+      skills: ['website-api'],
+    });
+    const res = await reconcileOpenClawConfig(makeApp());
+    assert.equal(res.errors.length, 1);
+    assert.match(res.errors[0]!, /broken/);
+    assert.deepEqual(res.added, ['good-bot']);
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test('preserves orphan entries by default; removes them when env flag is true', async () => {
+  const fx = await setupFixture({
+    agents: {
+      list: [
+        {
+          id: 'orphan',
+          name: 'Orphan',
+          workspace: '/nowhere',
+          sandbox: { mode: 'off' },
+          skills: ['website-api'],
+        },
+      ],
+    },
+  });
+  try {
+    // No matching workspace dir for 'orphan'.
+    let res = await reconcileOpenClawConfig(makeApp());
+    assert.deepEqual(res.removed, []);
+
+    process.env.OPENCLAW_RECONCILE_REMOVE_ORPHANS = 'true';
+    res = await reconcileOpenClawConfig(makeApp());
+    assert.deepEqual(res.removed, ['orphan']);
+    const written = JSON5.parse(await readFile(fx.configPath, 'utf8')) as {
+      agents: { list: { id: string }[] };
+    };
+    assert.deepEqual(written.agents.list, []);
+  } finally {
+    fx.cleanup();
+  }
+});

--- a/packages/proxy/src/openclaw/__tests__/register-upsert.test.ts
+++ b/packages/proxy/src/openclaw/__tests__/register-upsert.test.ts
@@ -1,0 +1,98 @@
+// Test-only env stubs — must be set BEFORE importing api.ts (which transitively
+// pulls in client/config that validates these at module load).
+process.env.OPENCLAW_GATEWAY_TOKEN ??= 'test-token';
+process.env.OPENCLAW_GATEWAY_URL ??= 'http://127.0.0.1:0';
+process.env.DATABASE_URL ??= 'postgres://test:test@127.0.0.1:5432/test';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import JSON5 from 'json5';
+
+import { registerAgentInOpenClaw } from '../../routes/api.js';
+
+interface FakeApp {
+  log: {
+    info: (...a: unknown[]) => void;
+    warn: (...a: unknown[]) => void;
+    error: (...a: unknown[]) => void;
+  };
+}
+
+function makeApp(): FakeApp {
+  return {
+    log: { info: () => {}, warn: () => {}, error: () => {} },
+  };
+}
+
+async function setup(): Promise<{ configPath: string; workspacesDir: string }> {
+  const root = await mkdtemp(join(tmpdir(), 'openclaw-register-'));
+  const configDir = join(root, 'config');
+  const workspacesDir = join(root, 'workspaces');
+  await mkdir(configDir, { recursive: true });
+  await mkdir(workspacesDir, { recursive: true });
+  const configPath = join(configDir, 'openclaw.json5');
+  const initial = `// header comment\n${JSON5.stringify({ agents: { list: [] } }, null, 2)}\n`;
+  await writeFile(configPath, initial, 'utf8');
+  process.env.OPENCLAW_CONFIG_PATH = configPath;
+  process.env.OPENCLAW_WORKSPACES_DIR = workspacesDir;
+  return { configPath, workspacesDir };
+}
+
+test('registerAgentInOpenClaw: appends new entry when slug missing', async () => {
+  const { configPath } = await setup();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await registerAgentInOpenClaw('alpha', 'Alpha Bot', makeApp() as any, ['skill-a']);
+  const raw = await readFile(configPath, 'utf8');
+  assert.ok(raw.startsWith('// header comment'), 'leading header preserved');
+  const parsed = JSON5.parse(raw) as { agents: { list: Array<{ id: string; skills: string[] }> } };
+  assert.equal(parsed.agents.list.length, 1);
+  assert.equal(parsed.agents.list[0]!.id, 'alpha');
+  assert.deepEqual(parsed.agents.list[0]!.skills, ['skill-a']);
+});
+
+test('registerAgentInOpenClaw: 4a — updates existing entry skills in place', async () => {
+  const { configPath } = await setup();
+  // Seed an existing entry with stale skills + a hand-edited extra field.
+  const raw0 = await readFile(configPath, 'utf8');
+  const cfg = JSON5.parse(raw0) as {
+    agents: { list: Array<Record<string, unknown>> };
+  };
+  cfg.agents.list.push({
+    id: 'beta',
+    name: 'old name',
+    workspace: '/wrong/path',
+    sandbox: { mode: 'off' },
+    skills: ['stale'],
+    heartbeat: { every: '1h', target: 'custom-target' },
+    customField: 'preserve-me',
+  });
+  await writeFile(configPath, `${JSON5.stringify(cfg, null, 2)}\n`, 'utf8');
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await registerAgentInOpenClaw('beta', 'New Name', makeApp() as any, ['fresh-skill', 'another']);
+
+  const after = JSON5.parse(await readFile(configPath, 'utf8')) as {
+    agents: { list: Array<Record<string, unknown>> };
+  };
+  assert.equal(after.agents.list.length, 1, 'no duplicate appended');
+  const entry = after.agents.list[0]!;
+  assert.equal(entry.id, 'beta');
+  assert.equal(entry.name, 'New Name');
+  assert.deepEqual(entry.skills, ['fresh-skill', 'another']);
+  assert.equal(entry.customField, 'preserve-me', 'extra fields preserved');
+  // heartbeat override preserved (we only set heartbeat if absent).
+  assert.deepEqual(entry.heartbeat, { every: '1h', target: 'custom-target' });
+});
+
+test('registerAgentInOpenClaw: 4d — output is valid JSON5 (no orphan tmp)', async () => {
+  const { configPath } = await setup();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await registerAgentInOpenClaw('gamma', 'Gamma', makeApp() as any);
+  const raw = await readFile(configPath, 'utf8');
+  // Round-trips through JSON5 cleanly.
+  assert.doesNotThrow(() => JSON5.parse(raw));
+  assert.ok(raw.endsWith('\n'));
+});

--- a/packages/proxy/src/openclaw/atomic-write.ts
+++ b/packages/proxy/src/openclaw/atomic-write.ts
@@ -1,0 +1,34 @@
+import { randomBytes } from 'node:crypto';
+import { open, rename, unlink } from 'node:fs/promises';
+
+/**
+ * Atomic file write: write to a sibling temp file in the same directory,
+ * fsync, then rename over the target. The directory rename is atomic on
+ * POSIX, so a concurrent reader either sees the old file or the new one —
+ * never a half-written one.
+ *
+ * The temp file lives next to the destination so the rename stays inside
+ * the same filesystem (cross-fs renames are not atomic).
+ */
+export async function atomicWriteFile(targetPath: string, contents: string): Promise<void> {
+  const tmp = `${targetPath}.tmp.${process.pid}.${randomBytes(6).toString('hex')}`;
+  let handle: Awaited<ReturnType<typeof open>> | null = null;
+  try {
+    handle = await open(tmp, 'w', 0o644);
+    await handle.writeFile(contents, 'utf8');
+    await handle.sync();
+  } finally {
+    if (handle) await handle.close();
+  }
+  try {
+    await rename(tmp, targetPath);
+  } catch (err) {
+    // Best-effort cleanup of the orphaned temp file.
+    try {
+      await unlink(tmp);
+    } catch {
+      /* ignore */
+    }
+    throw err;
+  }
+}

--- a/packages/proxy/src/openclaw/reconciler.ts
+++ b/packages/proxy/src/openclaw/reconciler.ts
@@ -1,96 +1,296 @@
+import { execFile } from 'node:child_process';
 import { readFile, readdir, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { FastifyInstance } from 'fastify';
+import JSON5 from 'json5';
 
 import {
-  registerAgentInOpenClaw,
+  extractLeadingHeader,
+  resolveOpenClawConfigPath,
   resolveOpenClawWorkspacesDir,
 } from '../routes/api.js';
+import { atomicWriteFile } from './atomic-write.js';
 
 export interface ReconcileResult {
-  updated: number;
-  skipped: number;
+  added: string[];
+  updated: string[];
+  removed: string[];
   errors: string[];
 }
 
+interface OpenClawAgentEntry {
+  id: string;
+  name?: string;
+  workspace?: string;
+  sandbox?: { mode?: string };
+  skills?: string[];
+  heartbeat?: { every?: string; target?: string };
+  userTokenKey?: string;
+  [k: string]: unknown;
+}
+
+interface OpenClawConfig {
+  agents?: { list?: OpenClawAgentEntry[] };
+  [k: string]: unknown;
+}
+
+interface DesiredEntry {
+  id: string;
+  name: string;
+  skills?: string[];
+  userTokenKey?: string;
+}
+
+const RESERVED_SLUGS = new Set(['meta']);
+
 /**
- * Walk every per-agent workspace directory under the configured workspaces
- * root and ensure each `agent-config.json` is reflected in `openclaw.json5`.
+ * Reconcile `openclaw.json5` against the per-agent workspaces on disk.
  *
- * - Skips workspaces without an `agent-config.json` (e.g. `meta`).
- * - A single broken workspace must NOT abort the rest of the reconcile.
- * - Errors are accumulated and returned; never thrown.
+ * - For every `openclaw/workspaces/<slug>/agent-config.json` (skipping
+ *   `meta` and dirs without that file), ensure an entry exists in
+ *   openclaw.json5 with up-to-date `name`, `skills`, `userTokenKey`,
+ *   `workspace`, and `sandbox`.
+ * - When env `OPENCLAW_RECONCILE_REMOVE_ORPHANS=true`, also delete
+ *   entries whose workspace dir no longer exists (excluding RESERVED_SLUGS
+ *   and any whose `id` matches an agent-config we couldn't read — those
+ *   are surfaced as errors instead).
+ * - Performs ONE atomic JSON5 write and ONE gateway SIGHUP, regardless
+ *   of how many entries changed. No-ops when nothing changed.
+ * - Never throws on per-workspace errors; surfaces them in `errors`.
  */
 export async function reconcileOpenClawConfig(app: FastifyInstance): Promise<ReconcileResult> {
-  const result: ReconcileResult = { updated: 0, skipped: 0, errors: [] };
+  const result: ReconcileResult = { added: [], updated: [], removed: [], errors: [] };
+
+  const configPath = resolveOpenClawConfigPath();
   const workspacesDir = resolveOpenClawWorkspacesDir();
 
-  let entries: string[];
+  // 1. Load openclaw.json5 (must exist — refuse to run otherwise).
+  let raw: string;
   try {
-    entries = await readdir(workspacesDir);
+    raw = await readFile(configPath, 'utf8');
   } catch (err) {
-    const msg = `failed to read workspaces dir ${workspacesDir}: ${(err as Error).message}`;
-    app.log.warn({ err, workspacesDir }, 'reconciler: cannot list workspaces');
+    const msg = `cannot read openclaw config at ${configPath}: ${(err as Error).message}`;
+    app.log.warn({ err, configPath }, 'reconciler: openclaw config unreadable; skipping');
     result.errors.push(msg);
     return result;
   }
 
-  for (const slug of entries) {
+  let config: OpenClawConfig;
+  try {
+    config = JSON5.parse(raw) as OpenClawConfig;
+  } catch (err) {
+    const msg = `openclaw config is not valid JSON5: ${(err as Error).message}`;
+    app.log.error({ err, configPath }, 'reconciler: openclaw config parse failed');
+    result.errors.push(msg);
+    return result;
+  }
+
+  if (!config.agents || !Array.isArray(config.agents.list)) {
+    result.errors.push('openclaw config missing agents.list');
+    return result;
+  }
+
+  // 2. Walk workspaces and build the desired-state map.
+  const desiredById = new Map<string, DesiredEntry>();
+  let workspaceSlugs: string[];
+  try {
+    workspaceSlugs = await readdir(workspacesDir);
+  } catch (err) {
+    const msg = `failed to list workspaces dir ${workspacesDir}: ${(err as Error).message}`;
+    app.log.warn({ err, workspacesDir }, 'reconciler: workspaces dir unreadable');
+    result.errors.push(msg);
+    return result;
+  }
+
+  for (const slug of workspaceSlugs) {
+    if (RESERVED_SLUGS.has(slug)) continue;
     const workspacePath = join(workspacesDir, slug);
     try {
       const st = await stat(workspacePath);
-      if (!st.isDirectory()) {
-        result.skipped++;
-        continue;
-      }
+      if (!st.isDirectory()) continue;
     } catch {
-      result.skipped++;
       continue;
     }
 
-    const configPath = join(workspacePath, 'agent-config.json');
-    let raw: string;
+    const agentConfigPath = join(workspacePath, 'agent-config.json');
+    let agentRaw: string;
     try {
-      raw = await readFile(configPath, 'utf8');
+      agentRaw = await readFile(agentConfigPath, 'utf8');
     } catch {
-      // No agent-config.json (e.g. the `meta` workspace) — skip silently.
-      result.skipped++;
+      // No agent-config.json — not a registerable agent (e.g. scratch dir).
       continue;
     }
 
-    let parsed: { agentSlug?: unknown; agentName?: unknown; skills?: unknown };
+    let parsed: { agentSlug?: unknown; agentName?: unknown; skills?: unknown; userTokenKey?: unknown };
     try {
-      parsed = JSON.parse(raw);
+      parsed = JSON.parse(agentRaw);
     } catch (err) {
-      const msg = `${slug}: invalid agent-config.json: ${(err as Error).message}`;
-      app.log.warn({ err, slug, configPath }, 'reconciler: parse failed');
-      result.errors.push(msg);
+      result.errors.push(`${slug}: invalid agent-config.json: ${(err as Error).message}`);
       continue;
     }
 
-    const agentSlug = typeof parsed.agentSlug === 'string' && parsed.agentSlug.trim().length > 0
+    const id = typeof parsed.agentSlug === 'string' && parsed.agentSlug.trim().length > 0
       ? parsed.agentSlug.trim()
       : slug;
-    const agentName = typeof parsed.agentName === 'string' && parsed.agentName.trim().length > 0
+    const name = typeof parsed.agentName === 'string' && parsed.agentName.trim().length > 0
       ? parsed.agentName.trim()
-      : agentSlug;
+      : id;
     const skills = Array.isArray(parsed.skills)
       ? parsed.skills.filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
       : undefined;
+    const userTokenKey = typeof parsed.userTokenKey === 'string' && parsed.userTokenKey.trim().length > 0
+      ? parsed.userTokenKey.trim()
+      : undefined;
 
-    try {
-      await registerAgentInOpenClaw(agentSlug, agentName, app, skills && skills.length > 0 ? skills : undefined);
-      result.updated++;
-    } catch (err) {
-      const msg = `${slug}: registerAgentInOpenClaw failed: ${(err as Error).message}`;
-      app.log.warn({ err, slug }, 'reconciler: register failed');
-      result.errors.push(msg);
+    desiredById.set(id, {
+      id,
+      name,
+      skills: skills && skills.length > 0 ? skills : undefined,
+      userTokenKey,
+    });
+  }
+
+  // 3. Diff desired vs. current.
+  const current = config.agents.list;
+  const currentById = new Map(current.map((e) => [e.id, e]));
+  const removeOrphans = (process.env.OPENCLAW_RECONCILE_REMOVE_ORPHANS ?? '').toLowerCase() === 'true';
+  const newList: OpenClawAgentEntry[] = [];
+  let changed = false;
+
+  for (const existing of current) {
+    if (RESERVED_SLUGS.has(existing.id)) {
+      newList.push(existing);
+      continue;
     }
+    const desired = desiredById.get(existing.id);
+    if (!desired) {
+      // Orphan — entry in openclaw.json5 with no workspace on disk.
+      if (removeOrphans) {
+        result.removed.push(existing.id);
+        changed = true;
+        continue;
+      }
+      newList.push(existing);
+      continue;
+    }
+    // Update mutable fields in place; preserve any extra fields.
+    const desiredWorkspace = join(workspacesDir, existing.id);
+    const desiredSkills = desired.skills ?? ['website-api'];
+    const merged: OpenClawAgentEntry = {
+      ...existing,
+      name: desired.name,
+      workspace: desiredWorkspace,
+      sandbox: existing.sandbox ?? { mode: 'off' },
+      skills: desiredSkills,
+    };
+    if (desired.userTokenKey !== undefined) merged.userTokenKey = desired.userTokenKey;
+
+    if (!shallowEntryEqual(existing, merged)) {
+      result.updated.push(existing.id);
+      changed = true;
+    }
+    newList.push(merged);
+  }
+
+  for (const desired of desiredById.values()) {
+    if (currentById.has(desired.id)) continue;
+    const entry: OpenClawAgentEntry = {
+      id: desired.id,
+      name: desired.name,
+      workspace: join(workspacesDir, desired.id),
+      sandbox: { mode: 'off' },
+      skills: desired.skills ?? ['website-api'],
+      heartbeat: { every: '30m' },
+    };
+    if (desired.userTokenKey !== undefined) entry.userTokenKey = desired.userTokenKey;
+    newList.push(entry);
+    result.added.push(desired.id);
+    changed = true;
+  }
+
+  if (!changed) {
+    app.log.info(
+      {
+        configPath,
+        workspacesDir,
+        workspaces: desiredById.size,
+        currentEntries: current.length,
+      },
+      'openclaw reconciler: no changes',
+    );
+    return result;
+  }
+
+  config.agents.list = newList;
+
+  // 4. Write atomically (single write for all changes).
+  // 4d note: leading header (license/copyright) is preserved; inline
+  // comments inside the object are still lost.
+  const header = extractLeadingHeader(raw);
+  const serialized = JSON5.stringify(config, null, 2);
+  const output = `${header}${serialized}\n`;
+
+  try {
+    await atomicWriteFile(configPath, output);
+  } catch (err) {
+    result.errors.push(`atomic write failed: ${(err as Error).message}`);
+    app.log.error({ err, configPath }, 'reconciler: atomic write failed');
+    return result;
   }
 
   app.log.info(
-    { updated: result.updated, skipped: result.skipped, errorCount: result.errors.length, workspacesDir },
-    'openclaw config reconciler complete',
+    {
+      configPath,
+      added: result.added,
+      updated: result.updated,
+      removed: result.removed,
+    },
+    `openclaw reconciler: +${result.added.length} ~${result.updated.length} -${result.removed.length}`,
   );
+
+  // 5. Best-effort gateway reload (single SIGHUP for all changes).
+  await new Promise<void>((resolve) => {
+    execFile('pgrep', ['-f', 'openclaw.*gateway'], { timeout: 5_000 }, (err, stdout) => {
+      if (err || !stdout?.trim()) {
+        app.log.warn('reconciler: pgrep could not find openclaw gateway PID');
+        resolve();
+        return;
+      }
+      const pid = stdout.trim().split('\n')[0] ?? '';
+      if (!pid) {
+        resolve();
+        return;
+      }
+      execFile('kill', ['-HUP', pid], { timeout: 5_000 }, (killErr) => {
+        if (killErr) {
+          app.log.warn({ err: killErr, pid }, 'reconciler: SIGHUP failed');
+        } else {
+          app.log.info({ pid }, 'reconciler: sent SIGHUP to openclaw gateway');
+        }
+        resolve();
+      });
+    });
+  });
+
   return result;
+}
+
+/**
+ * Compare two entries for the fields the reconciler controls. Extra fields
+ * present on `a` but not produced by us are ignored (we always preserve
+ * them via spread, so they cannot drift).
+ */
+function shallowEntryEqual(a: OpenClawAgentEntry, b: OpenClawAgentEntry): boolean {
+  if (a.id !== b.id) return false;
+  if (a.name !== b.name) return false;
+  if (a.workspace !== b.workspace) return false;
+  if (a.userTokenKey !== b.userTokenKey) return false;
+  if ((a.sandbox?.mode ?? null) !== (b.sandbox?.mode ?? null)) return false;
+  const sa = a.skills ?? [];
+  const sb = b.skills ?? [];
+  if (sa.length !== sb.length) return false;
+  for (let i = 0; i < sa.length; i++) {
+    if (sa[i] !== sb[i]) return false;
+  }
+  return true;
 }

--- a/packages/proxy/src/openclaw/reconciler.ts
+++ b/packages/proxy/src/openclaw/reconciler.ts
@@ -1,0 +1,96 @@
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+
+import {
+  registerAgentInOpenClaw,
+  resolveOpenClawWorkspacesDir,
+} from '../routes/api.js';
+
+export interface ReconcileResult {
+  updated: number;
+  skipped: number;
+  errors: string[];
+}
+
+/**
+ * Walk every per-agent workspace directory under the configured workspaces
+ * root and ensure each `agent-config.json` is reflected in `openclaw.json5`.
+ *
+ * - Skips workspaces without an `agent-config.json` (e.g. `meta`).
+ * - A single broken workspace must NOT abort the rest of the reconcile.
+ * - Errors are accumulated and returned; never thrown.
+ */
+export async function reconcileOpenClawConfig(app: FastifyInstance): Promise<ReconcileResult> {
+  const result: ReconcileResult = { updated: 0, skipped: 0, errors: [] };
+  const workspacesDir = resolveOpenClawWorkspacesDir();
+
+  let entries: string[];
+  try {
+    entries = await readdir(workspacesDir);
+  } catch (err) {
+    const msg = `failed to read workspaces dir ${workspacesDir}: ${(err as Error).message}`;
+    app.log.warn({ err, workspacesDir }, 'reconciler: cannot list workspaces');
+    result.errors.push(msg);
+    return result;
+  }
+
+  for (const slug of entries) {
+    const workspacePath = join(workspacesDir, slug);
+    try {
+      const st = await stat(workspacePath);
+      if (!st.isDirectory()) {
+        result.skipped++;
+        continue;
+      }
+    } catch {
+      result.skipped++;
+      continue;
+    }
+
+    const configPath = join(workspacePath, 'agent-config.json');
+    let raw: string;
+    try {
+      raw = await readFile(configPath, 'utf8');
+    } catch {
+      // No agent-config.json (e.g. the `meta` workspace) — skip silently.
+      result.skipped++;
+      continue;
+    }
+
+    let parsed: { agentSlug?: unknown; agentName?: unknown; skills?: unknown };
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      const msg = `${slug}: invalid agent-config.json: ${(err as Error).message}`;
+      app.log.warn({ err, slug, configPath }, 'reconciler: parse failed');
+      result.errors.push(msg);
+      continue;
+    }
+
+    const agentSlug = typeof parsed.agentSlug === 'string' && parsed.agentSlug.trim().length > 0
+      ? parsed.agentSlug.trim()
+      : slug;
+    const agentName = typeof parsed.agentName === 'string' && parsed.agentName.trim().length > 0
+      ? parsed.agentName.trim()
+      : agentSlug;
+    const skills = Array.isArray(parsed.skills)
+      ? parsed.skills.filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
+      : undefined;
+
+    try {
+      await registerAgentInOpenClaw(agentSlug, agentName, app, skills && skills.length > 0 ? skills : undefined);
+      result.updated++;
+    } catch (err) {
+      const msg = `${slug}: registerAgentInOpenClaw failed: ${(err as Error).message}`;
+      app.log.warn({ err, slug }, 'reconciler: register failed');
+      result.errors.push(msg);
+    }
+  }
+
+  app.log.info(
+    { updated: result.updated, skipped: result.skipped, errorCount: result.errors.length, workspacesDir },
+    'openclaw config reconciler complete',
+  );
+  return result;
+}

--- a/packages/proxy/src/routes/api.ts
+++ b/packages/proxy/src/routes/api.ts
@@ -717,21 +717,31 @@ export function registerApiRoutes(app: FastifyInstance) {
         openclawAgentId: body.openclawAgentId,
       });
 
-      // 4b: keep openclaw.json5 in sync with the DB. Read skills from the
-      // agent's on-disk workspace (created by the meta-agent prior to this
-      // call); fall back to widgetConfig.skills if nothing is on disk yet.
-      const diskSkills = await getAgentSkillsFromDisk(body.openclawAgentId);
-      const widgetSkillsRaw = (body.widgetConfig as { skills?: unknown } | undefined)?.skills;
-      const widgetSkills = Array.isArray(widgetSkillsRaw)
-        ? widgetSkillsRaw.filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
-        : undefined;
-      const resolvedSkills = diskSkills ?? (widgetSkills && widgetSkills.length > 0 ? widgetSkills : undefined);
+      // 4b: ensure the new agent is registered in the OpenClaw gateway
+      // config so it is reachable immediately after creation. Prefer skills
+      // from the on-disk agent-config.json (source of truth maintained by
+      // the meta agent); fall back to widgetConfig.skills from the request
+      // body, then the registerAgentInOpenClaw default ('website-api').
       try {
-        await registerAgentInOpenClaw(body.openclawAgentId, body.name, app, resolvedSkills);
+        const diskSkills = await getAgentSkillsFromDisk(body.openclawAgentId);
+        const widgetSkills = (() => {
+          const wc = body.widgetConfig as { skills?: unknown } | undefined;
+          if (!wc || !Array.isArray(wc.skills)) return undefined;
+          const filtered = wc.skills.filter(
+            (s): s is string => typeof s === 'string' && s.trim().length > 0,
+          );
+          return filtered.length > 0 ? filtered : undefined;
+        })();
+        await registerAgentInOpenClaw(
+          body.openclawAgentId,
+          body.name,
+          app,
+          diskSkills ?? widgetSkills,
+        );
       } catch (err) {
         request.log.warn(
           { err, openclawAgentId: body.openclawAgentId },
-          'registerAgentInOpenClaw failed for internal agent (non-fatal)',
+          'failed to register internal agent in openclaw — agent row created but gateway not updated',
         );
       }
 

--- a/packages/proxy/src/routes/api.ts
+++ b/packages/proxy/src/routes/api.ts
@@ -1,5 +1,5 @@
-import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
-import { mkdir, readFile, rmdir, stat, writeFile } from 'fs/promises';
+import { createHmac, randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
+import { mkdir, open, readFile, rename, rmdir, stat, unlink } from 'fs/promises';
 import { join } from 'path';
 import { homedir } from 'node:os';
 import { execFile } from 'node:child_process';
@@ -215,8 +215,127 @@ async function insertAuditLog(
 }
 
 /**
- * Register a newly created agent in the OpenClaw gateway config (~/.openclaw/openclaw.json)
- * and restart the gateway so it picks up the new agent.
+ * Resolve the OpenClaw gateway config path (shared with reconciler).
+ *
+ * Order: OPENCLAW_CONFIG_PATH > <cwd>/openclaw/config/openclaw.json5
+ *        > ~/.openclaw/openclaw.json
+ */
+export function resolveOpenClawConfigPath(): string {
+  return (
+    process.env.OPENCLAW_CONFIG_PATH?.trim()
+    || join(process.cwd(), 'openclaw', 'config', 'openclaw.json5')
+    || join(homedir(), '.openclaw', 'openclaw.json')
+  );
+}
+
+/**
+ * Resolve the directory that contains per-agent workspaces.
+ * Mirrors the fallback logic in detectAgentCreation.
+ */
+export function resolveOpenClawWorkspacesDir(): string {
+  return (
+    process.env.OPENCLAW_WORKSPACES_DIR?.trim()
+    || join(process.cwd(), 'openclaw', 'workspaces')
+  );
+}
+
+/**
+ * Read on-disk agent-config.json for a given slug, trying both the configured
+ * workspaces dir and a repo-root fallback. Returns null on any failure.
+ */
+export async function readAgentConfigFromDisk(
+  slug: string,
+): Promise<Record<string, unknown> | null> {
+  const configuredWorkspacesDir = process.env.OPENCLAW_WORKSPACES_DIR?.trim();
+  const primaryWorkspacesDir = configuredWorkspacesDir || join(process.cwd(), 'openclaw', 'workspaces');
+  const candidates = [join(primaryWorkspacesDir, slug, 'agent-config.json')];
+  if (!configuredWorkspacesDir) {
+    const fallbackWorkspacesDir = join(process.cwd(), '..', '..', 'openclaw', 'workspaces');
+    const fallbackPath = join(fallbackWorkspacesDir, slug, 'agent-config.json');
+    if (fallbackPath !== candidates[0]) candidates.push(fallbackPath);
+  }
+  for (const p of candidates) {
+    try {
+      const raw = await readFile(p, 'utf8');
+      return JSON.parse(raw) as Record<string, unknown>;
+    } catch {}
+  }
+  return null;
+}
+
+/**
+ * Read just the skills array from a workspace's agent-config.json.
+ */
+export async function getAgentSkillsFromDisk(slug: string): Promise<string[] | undefined> {
+  const cfg = await readAgentConfigFromDisk(slug);
+  if (!cfg) return undefined;
+  const raw = (cfg as { skills?: unknown }).skills;
+  if (!Array.isArray(raw)) return undefined;
+  const skills = raw.filter((s): s is string => typeof s === 'string' && s.trim().length > 0);
+  return skills.length > 0 ? skills : undefined;
+}
+
+/**
+ * Extract a leading comment/whitespace block that appears BEFORE the first
+ * top-level `{`. JSON5 files in this repo place all comments inside the
+ * object so this is usually empty, but we preserve it when present so a
+ * future copyright/license header survives a rewrite. Walks character by
+ * character so the cut point is not confused by `{` inside comments.
+ */
+export function extractLeadingHeader(raw: string): string {
+  let i = 0;
+  while (i < raw.length) {
+    const ch = raw[i];
+    if (ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r') {
+      i++;
+      continue;
+    }
+    if (ch === '/' && raw[i + 1] === '/') {
+      const nl = raw.indexOf('\n', i + 2);
+      i = nl < 0 ? raw.length : nl + 1;
+      continue;
+    }
+    if (ch === '/' && raw[i + 1] === '*') {
+      const end = raw.indexOf('*/', i + 2);
+      i = end < 0 ? raw.length : end + 2;
+      continue;
+    }
+    break;
+  }
+  return raw.slice(0, i);
+}
+
+
+/**
+ * Atomic file write: write to a sibling temp file in the same directory,
+ * fsync, then rename over the target. The directory rename is atomic on POSIX.
+ */
+export async function writeFileAtomic(targetPath: string, contents: string): Promise<void> {
+  const tmp = `${targetPath}.tmp.${process.pid}.${randomBytes(6).toString('hex')}`;
+  let handle: Awaited<ReturnType<typeof open>> | null = null;
+  try {
+    handle = await open(tmp, 'w', 0o644);
+    await handle.writeFile(contents, 'utf8');
+    await handle.sync();
+  } finally {
+    if (handle) await handle.close();
+  }
+  try {
+    await rename(tmp, targetPath);
+  } catch (err) {
+    // Best-effort cleanup of the orphaned temp file.
+    try { await unlink(tmp); } catch {}
+    throw err;
+  }
+}
+
+/**
+ * Register (or update) an agent entry in the OpenClaw gateway config and
+ * restart/reload the gateway so it picks up the change.
+ *
+ * If an entry with the same id (slug) already exists, this updates its
+ * mutable fields (name, workspace, sandbox, skills, heartbeat) IN PLACE
+ * while preserving any additional fields that may have been hand-edited.
  */
 export async function registerAgentInOpenClaw(
   slug: string,
@@ -224,11 +343,7 @@ export async function registerAgentInOpenClaw(
   app: FastifyInstance,
   skills?: string[],
 ): Promise<void> {
-  // Resolve config path: OPENCLAW_CONFIG_PATH > /opt/webagent/openclaw/config/openclaw.json5 > ~/.openclaw/openclaw.json
-  const configPath =
-    process.env.OPENCLAW_CONFIG_PATH?.trim() ||
-    join(process.cwd(), 'openclaw', 'config', 'openclaw.json5') ||
-    join(homedir(), '.openclaw', 'openclaw.json');
+  const configPath = resolveOpenClawConfigPath();
   const lockPath = `${configPath}.lock`;
   let staleLockCleaned = false;
   try {
@@ -268,25 +383,49 @@ export async function registerAgentInOpenClaw(
         return;
       }
 
-      if (config.agents.list.some((a) => a.id === slug)) {
-        app.log.info({ slug }, 'agent already in openclaw config — skipping');
-        return;
-      }
-
-      // Resolve workspace path for the new agent
-      const workspacesDir = process.env.OPENCLAW_WORKSPACES_DIR?.trim()
-        || join(process.cwd(), 'openclaw', 'workspaces');
-
-      config.agents.list.push({
+      // Resolve workspace path for the agent
+      const workspacesDir = resolveOpenClawWorkspacesDir();
+      const desiredEntry = {
         id: slug,
         name,
         workspace: join(workspacesDir, slug),
         sandbox: { mode: 'off' },
         skills: skills?.length ? skills : ['website-api'],
         heartbeat: { every: '30m' },
-      });
+      };
 
-      await writeFile(configPath, JSON.stringify(config, null, 2), 'utf8');
+      const existingIdx = config.agents.list.findIndex((a) => a.id === slug);
+      if (existingIdx >= 0) {
+        // 4a: update existing entry in place. Preserve any extra fields that
+        // were hand-edited (e.g. custom heartbeat target) by spreading first.
+        const existing = config.agents.list[existingIdx]!;
+        config.agents.list[existingIdx] = {
+          ...existing,
+          name: desiredEntry.name,
+          workspace: desiredEntry.workspace,
+          sandbox: desiredEntry.sandbox,
+          skills: desiredEntry.skills,
+          // Only set heartbeat if not already present, to preserve overrides.
+          heartbeat: (existing as { heartbeat?: unknown }).heartbeat ?? desiredEntry.heartbeat,
+        };
+        app.log.info({ slug }, 'updated existing openclaw agent entry');
+      } else {
+        config.agents.list.push(desiredEntry);
+        app.log.info({ slug }, 'appended new openclaw agent entry');
+      }
+
+      // 4d: preserve a leading comment block from the original file. JSON5 inline
+      // comments inside the object are still lost — proper preservation requires
+      // a JSON5 CST-aware editor.
+      // TODO(#193): replace JSON5.stringify with surgical edits that preserve
+      // all inline comments. For now we keep any header comments that appear
+      // *before* the opening `{`.
+      const header = extractLeadingHeader(raw);
+      const serialized = JSON5.stringify(config, null, 2);
+      const output = `${header}${serialized}\n`;
+
+      // 4e: atomic write — write to temp file then rename.
+      await writeFileAtomic(configPath, output);
       app.log.info({ slug, configPath }, 'registered agent in openclaw config');
 
       // Try SIGHUP first (no root needed for same-user processes), fall back to systemctl
@@ -577,6 +716,24 @@ export function registerApiRoutes(app: FastifyInstance) {
         agentId: createdAgent.id,
         openclawAgentId: body.openclawAgentId,
       });
+
+      // 4b: keep openclaw.json5 in sync with the DB. Read skills from the
+      // agent's on-disk workspace (created by the meta-agent prior to this
+      // call); fall back to widgetConfig.skills if nothing is on disk yet.
+      const diskSkills = await getAgentSkillsFromDisk(body.openclawAgentId);
+      const widgetSkillsRaw = (body.widgetConfig as { skills?: unknown } | undefined)?.skills;
+      const widgetSkills = Array.isArray(widgetSkillsRaw)
+        ? widgetSkillsRaw.filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
+        : undefined;
+      const resolvedSkills = diskSkills ?? (widgetSkills && widgetSkills.length > 0 ? widgetSkills : undefined);
+      try {
+        await registerAgentInOpenClaw(body.openclawAgentId, body.name, app, resolvedSkills);
+      } catch (err) {
+        request.log.warn(
+          { err, openclawAgentId: body.openclawAgentId },
+          'registerAgentInOpenClaw failed for internal agent (non-fatal)',
+        );
+      }
 
       const embedToken = randomUUID();
       const createdEmbedRows = await app.db

--- a/packages/proxy/src/routes/api.ts
+++ b/packages/proxy/src/routes/api.ts
@@ -1,5 +1,5 @@
-import { createHmac, randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
-import { mkdir, open, readFile, rename, rmdir, stat, unlink } from 'fs/promises';
+import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
+import { mkdir, readFile, rmdir, stat } from 'fs/promises';
 import { join } from 'path';
 import { homedir } from 'node:os';
 import { execFile } from 'node:child_process';
@@ -8,6 +8,7 @@ import { and, count, eq, ne } from 'drizzle-orm';
 import { z } from 'zod';
 import JSON5 from 'json5';
 import { OpenClawClient } from '../openclaw/client.js';
+import { atomicWriteFile } from '../openclaw/atomic-write.js';
 import {
   appendMetaHistoryMessage,
   extractEmbedCodeFromMessages,
@@ -306,28 +307,6 @@ export function extractLeadingHeader(raw: string): string {
 }
 
 
-/**
- * Atomic file write: write to a sibling temp file in the same directory,
- * fsync, then rename over the target. The directory rename is atomic on POSIX.
- */
-export async function writeFileAtomic(targetPath: string, contents: string): Promise<void> {
-  const tmp = `${targetPath}.tmp.${process.pid}.${randomBytes(6).toString('hex')}`;
-  let handle: Awaited<ReturnType<typeof open>> | null = null;
-  try {
-    handle = await open(tmp, 'w', 0o644);
-    await handle.writeFile(contents, 'utf8');
-    await handle.sync();
-  } finally {
-    if (handle) await handle.close();
-  }
-  try {
-    await rename(tmp, targetPath);
-  } catch (err) {
-    // Best-effort cleanup of the orphaned temp file.
-    try { await unlink(tmp); } catch {}
-    throw err;
-  }
-}
 
 /**
  * Register (or update) an agent entry in the OpenClaw gateway config and
@@ -425,7 +404,7 @@ export async function registerAgentInOpenClaw(
       const output = `${header}${serialized}\n`;
 
       // 4e: atomic write — write to temp file then rename.
-      await writeFileAtomic(configPath, output);
+      await atomicWriteFile(configPath, output);
       app.log.info({ slug, configPath }, 'registered agent in openclaw config');
 
       // Try SIGHUP first (no root needed for same-user processes), fall back to systemctl

--- a/packages/proxy/src/ws/handler.ts
+++ b/packages/proxy/src/ws/handler.ts
@@ -13,7 +13,7 @@ import {
   getMetaHistory,
 } from '../openclaw/meta-history.js';
 import { getOrCreateSession, touchSessionLastActiveAt } from '../openclaw/sessions.js';
-import { detectAgentCreation, registerAgentInOpenClaw } from '../routes/api.js';
+import { detectAgentCreation, getAgentSkillsFromDisk, registerAgentInOpenClaw } from '../routes/api.js';
 
 interface WebSocket {
   readyState: number;
@@ -724,7 +724,11 @@ export function handleConnection(
                     'self-heal skipped; agent row not found',
                   );
                 } else {
-                  const skills = getSkillsFromWidgetConfig(agentRow.widgetConfig);
+                  // 4c: skills live in on-disk agent-config.json, NOT in widgetConfig
+                  // (detectAgentCreation does not persist skills to the DB column).
+                  // Read from disk first; fall back to widgetConfig for legacy rows.
+                  const diskSkills = await getAgentSkillsFromDisk(agentRow.openclawAgentId);
+                  const skills = diskSkills ?? getSkillsFromWidgetConfig(agentRow.widgetConfig);
                   await registerAgentInOpenClaw(agentRow.openclawAgentId, agentRow.name, ctx.app, skills);
                   result = await openclawClient.sendMessage({
                     message: outboundMessage,


### PR DESCRIPTION
## Summary

Phase 1 of #193 (Issue 4 — `openclaw.json5` registration / skill drift). Implements:

- **4a** (`api.ts` `registerAgentInOpenClaw`): when an entry with the same slug already exists, update its mutable fields (`name`, `workspace`, `sandbox`, `skills`) **in place** instead of skipping. Preserves any extra fields a human edited (e.g. custom `heartbeat`).
- **4b** (`api.ts` `POST /api/internal/agents`): now calls `registerAgentInOpenClaw` after the DB insert, with skills resolved from on-disk `agent-config.json` first, then `widgetConfig.skills`. Failure is logged, not fatal.
- **4c** (`ws/handler.ts` self-heal): reads skills from on-disk `agent-config.json` via the new `getAgentSkillsFromDisk(slug)` helper, with a `widgetConfig` fallback for legacy rows. Fixes the bug where self-heal always re-registered with `['website-api']`, dropping `website-knowledge` and specialized skills.
- **4d** (`api.ts` write step): uses `JSON5.stringify` instead of `JSON.stringify`, and preserves any leading header comments via `extractLeadingHeader()`. Inline JSON5 comments inside the object are still lost — see TODO referencing #193 for a future CST-aware editor.
- **4e** (`api.ts` write step): new `writeFileAtomic(path, contents)` helper (write to `${path}.tmp.<pid>.<rand>`, `fsync`, `rename` over target) replaces the non-atomic `writeFile`. Mid-write crashes can no longer corrupt `openclaw.json5`.
- **Startup reconciler** (new `packages/proxy/src/openclaw/reconciler.ts`): walks `openclaw/workspaces/*/agent-config.json` and re-asserts each agent in `openclaw.json5` via the now-idempotent `registerAgentInOpenClaw`. Resilient — a single broken workspace is logged and skipped. Wired into `index.ts` before `app.listen()`; errors do **not** block startup.

## Files changed

- `packages/proxy/src/routes/api.ts` — new helpers (`writeFileAtomic`, `extractLeadingHeader`, `resolveOpenClawConfigPath`, `resolveOpenClawWorkspacesDir`, `readAgentConfigFromDisk`, `getAgentSkillsFromDisk`); rewritten `registerAgentInOpenClaw`; internal-POST handler invokes it.
- `packages/proxy/src/ws/handler.ts` — self-heal pulls skills from disk.
- `packages/proxy/src/openclaw/reconciler.ts` — **new**.
- `packages/proxy/src/index.ts` — invokes reconciler before `app.listen`.

## Build / typecheck

`pnpm --filter @webagent/proxy build` passes (tsc + widget bundle).

## Out of scope (intentionally deferred per issue plan)

- Phase 2 (Issue 2): template `{{placeholder}}` lint
- Phase 3 (Issue 3): auth UI extension
- Phase 4 (Issue 1): API-spec injection eval script

## Known issues / follow-ups

- **JSON5 inline comment preservation**: `JSON5.stringify` still drops comments that live inside the JSON object (e.g. the `// Multi-agent configuration` line and the auth comments). Only the leading header before the first `{` is preserved. The current `openclaw.json5` keeps all comments inside the object, so the *first* reconciler write WILL strip them. A proper fix needs a JSON5 CST-aware editor and is tracked by the inline `TODO(#193)` in `registerAgentInOpenClaw`.
- Reconciler runs `registerAgentInOpenClaw` per workspace, each acquiring/releasing the file lock and rewriting+fsyncing the whole config. Acceptable for ~tens of agents; if it grows large the reconciler should switch to a single-pass batched write.
- Each successful `registerAgentInOpenClaw` call still attempts a `SIGHUP` / `systemctl restart openclaw-gateway`. During reconciliation startup this can mean N reload signals — non-fatal but noisy. Fine to address in a follow-up.

Closes part of #193 (Phase 1 only).