### PR TITLE
fix(admin): #193 phase 3 — auth context UI + prompt improvements

### DIFF
--- a/openclaw/workspaces/meta/templates/AGENTS.md
+++ b/openclaw/workspaces/meta/templates/AGENTS.md
@@ -19,7 +19,7 @@ You help website visitors with questions about {{WEBSITE_NAME}}. You can:
 6. **Respect privacy.** Never expose internal system details, API keys, or other visitors' data.
 7. **Link-first for setup/support.** For install, onboarding, docs, pricing, and support questions, include direct URLs when known.
 8. **Never request browser token scraping.** Do not ask visitors to open DevTools, copy localStorage/sessionStorage/cookies, or paste raw JWT/API tokens.
-9. **If credentials are missing, escalate safely.** Ask the workspace admin/integrator to configure server-side session auth context (`Authorization`/`apiToken`) and then retry.
+9. **If credentials are missing, escalate safely.** Direct the admin to configure API credentials at `https://{{ADMIN_DOMAIN}}/dashboard/agents/{{AGENT_ID}}/settings` (Settings → Auth Context). Do not ask end users to provide tokens manually.
 
 ## About the Product
 {{API_DESCRIPTION}}

--- a/packages/admin/src/components/agent-auth-context.tsx
+++ b/packages/admin/src/components/agent-auth-context.tsx
@@ -1,30 +1,96 @@
 "use client";
 
 import { useState } from "react";
-import { Lock } from "lucide-react";
+import { Lock, Plus, Trash2 } from "lucide-react";
 import { serverUpdateAgent } from "@/lib/actions";
 import { useToast } from "@/components/toast";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+
+type AuthScheme = "Bearer" | "Token" | "ApiKey" | "Basic" | "Custom";
+
+const AUTH_SCHEMES: AuthScheme[] = ["Bearer", "Token", "ApiKey", "Basic", "Custom"];
+
+interface CustomHeader {
+  key: string;
+  value: string;
+}
 
 interface AgentAuthContextProps {
   agentId: string;
   initialApiToken?: string;
+  initialHeaderName?: string;
+  initialScheme?: AuthScheme;
+  initialCustomHeaders?: CustomHeader[];
 }
 
-export function AgentAuthContext({ agentId, initialApiToken }: AgentAuthContextProps) {
+export function AgentAuthContext({
+  agentId,
+  initialApiToken,
+  initialHeaderName,
+  initialScheme,
+  initialCustomHeaders,
+}: AgentAuthContextProps) {
   const [apiToken, setApiToken] = useState(initialApiToken || "");
+  const [headerName, setHeaderName] = useState(initialHeaderName || "Authorization");
+  const [scheme, setScheme] = useState<AuthScheme>(initialScheme || "Bearer");
+  const [customHeaders, setCustomHeaders] = useState<CustomHeader[]>(
+    initialCustomHeaders || []
+  );
   const [saving, setSaving] = useState(false);
   const { toast } = useToast();
+
+  const addCustomHeader = () => {
+    setCustomHeaders([...customHeaders, { key: "", value: "" }]);
+  };
+
+  const removeCustomHeader = (index: number) => {
+    setCustomHeaders(customHeaders.filter((_, i) => i !== index));
+  };
+
+  const updateCustomHeader = (index: number, field: "key" | "value", value: string) => {
+    const updated = [...customHeaders];
+    updated[index] = { ...updated[index]!, [field]: value };
+    setCustomHeaders(updated);
+  };
 
   const handleSave = async () => {
     setSaving(true);
     try {
+      // Build headers map from custom headers
+      const headers: Record<string, string> = {};
+      for (const h of customHeaders) {
+        if (h.key.trim()) {
+          headers[h.key.trim()] = h.value;
+        }
+      }
+
+      // Build the primary Authorization value using scheme + token
+      let authorizationValue: string | undefined;
+      if (apiToken) {
+        if (scheme === "Custom") {
+          authorizationValue = apiToken;
+        } else {
+          authorizationValue = `${scheme} ${apiToken}`;
+        }
+      }
+
+      // If header name is not Authorization, put it in custom headers instead
+      if (apiToken && headerName.trim() && headerName.trim() !== "Authorization") {
+        headers[headerName.trim()] = authorizationValue!;
+        authorizationValue = undefined;
+      }
+
       await serverUpdateAgent(agentId, {
         widgetConfig: {
           authContext: {
             apiToken: apiToken || undefined,
+            headerName: headerName || "Authorization",
+            scheme,
+            Authorization: authorizationValue,
+            headers: Object.keys(headers).length > 0 ? headers : undefined,
           },
         },
       });
@@ -47,23 +113,96 @@ export function AgentAuthContext({ agentId, initialApiToken }: AgentAuthContextP
           Configure credentials for API calls. These are stored securely on the server.
         </CardDescription>
       </CardHeader>
-      <CardContent>
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
-          <div className="flex-1">
-            <label htmlFor="apiToken" className="text-sm font-medium">
-              API Token
-            </label>
+      <CardContent className="space-y-6">
+        {/* Primary token */}
+        <div className="space-y-2">
+          <Label htmlFor="apiToken">API Token</Label>
+          <Input
+            id="apiToken"
+            type="password"
+            value={apiToken}
+            onChange={(e) => setApiToken(e.target.value)}
+            placeholder="Enter API token (optional)"
+          />
+        </div>
+
+        {/* Header name + scheme row */}
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="headerName">Header Name</Label>
             <Input
-              id="apiToken"
-              type="password"
-              value={apiToken}
-              onChange={(e) => setApiToken(e.target.value)}
-              placeholder="Enter API token (optional)"
-              className="mt-1"
+              id="headerName"
+              value={headerName}
+              onChange={(e) => setHeaderName(e.target.value)}
+              placeholder="Authorization"
             />
           </div>
+          <div className="space-y-2">
+            <Label htmlFor="scheme">Scheme</Label>
+            <select
+              id="scheme"
+              value={scheme}
+              onChange={(e) => setScheme(e.target.value as AuthScheme)}
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {AUTH_SCHEMES.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Custom headers */}
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <Label>Custom Headers</Label>
+            <Button type="button" variant="outline" size="sm" onClick={addCustomHeader}>
+              <Plus className="mr-1 h-3 w-3" />
+              Add Header
+            </Button>
+          </div>
+          {customHeaders.length > 0 && (
+            <div className="space-y-2">
+              {customHeaders.map((header, index) => (
+                <div key={index} className="flex items-center gap-2">
+                  <Input
+                    value={header.key}
+                    onChange={(e) => updateCustomHeader(index, "key", e.target.value)}
+                    placeholder="Header name"
+                    className="flex-1"
+                  />
+                  <Input
+                    value={header.value}
+                    onChange={(e) => updateCustomHeader(index, "value", e.target.value)}
+                    placeholder="Header value"
+                    type="password"
+                    className="flex-1"
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => removeCustomHeader(index)}
+                  >
+                    <Trash2 className="h-3 w-3" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+          {customHeaders.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              No custom headers configured. Add headers for additional auth requirements.
+            </p>
+          )}
+        </div>
+
+        {/* Save */}
+        <div className="flex justify-end">
           <Button onClick={handleSave} disabled={saving}>
-            {saving ? "Saving…" : "Save"}
+            {saving ? "Saving\u2026" : "Save Configuration"}
           </Button>
         </div>
       </CardContent>

--- a/packages/proxy/src/ws/handler.ts
+++ b/packages/proxy/src/ws/handler.ts
@@ -256,13 +256,23 @@ function buildWidgetMessageWithSessionPolicy(userContext: Record<string, unknown
     + '2. Explain: "I need session auth context to execute this. An admin must configure the `Authorization` or `apiToken` field in the widget integration settings (Settings → Integrations → Auth Context)."\n'
     + '3. Never give a vague refusal — always name the endpoint (e.g., `POST /api/v1/tenants/:id/restart`) and confirm expected outcome + that you will execute it once credentials are available.';
   if (Object.keys(userContext).length > 0) {
+    // Determine if actual credentials are present
+    const hasToken = typeof userContext.apiToken === 'string' && (userContext.apiToken as string).trim() !== '';
+    const hasAuthorization = typeof userContext.Authorization === 'string' && (userContext.Authorization as string).trim() !== '';
+    const hasHeaders = isRecord(userContext.headers) && Object.keys(userContext.headers).length > 0;
+    const hasCredentials = hasToken || hasAuthorization || hasHeaders;
+
+    const credentialStatus = hasCredentials
+      ? 'Authentication credentials are configured and will be injected into API requests automatically. Proceed with API calls confidently — do not ask the user to provide credentials.'
+      : 'Auth context is present but contains no usable credentials. If the user needs to make authenticated API calls, direct them to the admin dashboard to configure credentials.';
+
     const contextLines = Object.entries(userContext)
       .map(([k, v]) => `${k}: ${formatContextValue(v)}`)
       .join('\n');
-    return `[Session Context]\n${credentialPolicy}\n${fallbackGuidance}\n${contextLines}\n\nUser: ${customerContent}`;
+    return `[Session Context]\n${credentialPolicy}\n${credentialStatus}\n${fallbackGuidance}\n${contextLines}\n\nUser: ${customerContent}`;
   }
 
-  return `[Session Context — no credentials]\n${credentialPolicy}\nNo auth credentials were provided in session context.\n${fallbackGuidance}\n\nUser: ${customerContent}`;
+  return `[Session Context — no credentials]\n${credentialPolicy}\nNo API credentials are configured. If the user needs to make authenticated API calls, direct them to the admin dashboard to configure credentials.\n${fallbackGuidance}\n\nUser: ${customerContent}`;
 }
 
 function isStrictBase64(value: string): boolean {


### PR DESCRIPTION
## Summary

- **Auth context UI** (`agent-auth-context.tsx`): Extended from a single API token field to include header name (default: `Authorization`), scheme dropdown (`Bearer`/`Token`/`ApiKey`/`Basic`/`Custom`), and a dynamic custom headers key-value list. All values persist to `widgetConfig.authContext` matching the shape `normalizeSessionAuthContext` already supports.

- **Prompt improvements** (`handler.ts`): `buildWidgetMessageWithSessionPolicy` now differentiates between credentials-present (emits confident "proceed with API calls" directive) vs credentials-absent (directs to admin dashboard).

- **Template deep link** (`AGENTS.md`): Replaced generic "contact admin" fallback with actionable URL: `https://{{ADMIN_DOMAIN}}/dashboard/agents/{{AGENT_ID}}/settings`.

## Build status
- `pnpm -C packages/admin typecheck` — passes
- `pnpm -C packages/proxy lint` — passes

Refs #193