### PR TITLE
fix: install repo nginx template on deploy, add /health and /v1/ routes

### DIFF
--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -184,94 +184,15 @@ else
   echo "⚠️  No .env file at ${APP_DIR}/.env — skipping DB migrations"
 fi
 
-if [[ -f "${NGINX_SITE_PATH}" ]]; then
-  echo "→ Ensuring nginx /api auth routing + long-running API timeouts..."
-  python3 - "${NGINX_SITE_PATH}" <<'PY'
-import re
-import sys
-from pathlib import Path
-
-path = Path(sys.argv[1])
-text = path.read_text(encoding="utf-8")
-lines = text.splitlines()
-
-if "location ^~ /api/auth/" in text:
-    # Modern managed nginx template present; do not mutate route ordering.
-    raise SystemExit(0)
-
-api_idx = None
-for i, line in enumerate(lines):
-    if re.search(r'^\s*location\s+/api/?\s*\{', line):
-        api_idx = i
-        break
-
-if api_idx is not None:
-    api_end = None
-    for j in range(api_idx + 1, len(lines)):
-        if lines[j].strip() == "}":
-            api_end = j
-            break
-    if api_end is not None:
-        block = lines[api_idx:api_end + 1]
-        has_read = any("proxy_read_timeout" in line for line in block)
-        has_send = any("proxy_send_timeout" in line for line in block)
-        insert_at = api_end
-        if not has_read:
-            lines.insert(insert_at, "        proxy_read_timeout 300s;")
-            insert_at += 1
-            api_end += 1
-        if not has_send:
-            lines.insert(insert_at, "        proxy_send_timeout 300s;")
-            api_end += 1
-
-if "location /api/auth/" not in "\n".join(lines):
-    admin_upstream = "admin_frontend" if "upstream admin_frontend" in text else "admin_upstream"
-    auth_block = [
-        "    # NextAuth routes -> Admin (inserted by infra/deploy.sh)",
-        "    location /api/auth/ {",
-        f"        proxy_pass http://{admin_upstream};",
-        "        proxy_http_version 1.1;",
-        "        proxy_set_header Host $host;",
-        "        proxy_set_header X-Real-IP $remote_addr;",
-        "        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;",
-        "        proxy_set_header X-Forwarded-Proto $scheme;",
-        "    }",
-        "",
-    ]
-    insert_pos = 0
-    for i, line in enumerate(lines):
-        if re.search(r'^\s*location\s+/api/?\s*\{', line):
-            insert_pos = i
-            break
-    lines[insert_pos:insert_pos] = auth_block
-
-if "location /sso/" not in "\n".join(lines):
-    proxy_upstream = "proxy_upstream"
-    sso_block = [
-        "    # SSO / identity routes (inserted by infra/deploy.sh)",
-        "    location /sso/ {",
-        f"        proxy_pass http://{proxy_upstream};",
-        "        proxy_read_timeout 300s;",
-        "        proxy_send_timeout 300s;",
-        "        proxy_buffering on;",
-        "        limit_req zone=api_limit burst=60 nodelay;",
-        "        limit_req_status 429;",
-        "    }",
-        "",
-    ]
-    insert_pos = len(lines)
-    for i, line in enumerate(lines):
-        if re.search(r'^\s*location\s+/\s*\{', line):
-            insert_pos = i
-            break
-    lines[insert_pos:insert_pos] = sso_block
-
-new_text = "\n".join(lines) + "\n"
-if new_text != text:
-    path.write_text(new_text, encoding="utf-8")
-PY
+NGINX_TEMPLATE="${REPO_ROOT}/infra/nginx/webagent.conf"
+DOMAIN="${DOMAIN:-dev.lamoom.com}"
+if [[ -f "${NGINX_TEMPLATE}" ]]; then
+  echo "→ Installing nginx config from repo template..."
+  sed "s/\${DOMAIN}/${DOMAIN}/g" "${NGINX_TEMPLATE}" > "${NGINX_SITE_PATH}"
   nginx -t
   systemctl reload nginx
+else
+  echo "⚠️  Missing ${NGINX_TEMPLATE} — skipping nginx config"
 fi
 
 echo "→ Restarting services..."

--- a/infra/nginx/webagent.conf
+++ b/infra/nginx/webagent.conf
@@ -45,11 +45,6 @@ server {
     include             /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam         /etc/letsencrypt/ssl-dhparams.pem;
 
-    # ── SSL hardening ─────────────────────────────────────────────────────────
-    ssl_session_cache   shared:SSL:10m;
-    ssl_session_timeout 1d;
-    ssl_session_tickets off;
-
     # ── Gzip ─────────────────────────────────────────────────────────────────
     gzip on;
     gzip_vary on;
@@ -110,6 +105,22 @@ server {
     }
 
     location /api {
+        proxy_pass http://proxy_upstream;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+        proxy_buffering on;
+
+        limit_req zone=api_limit burst=60 nodelay;
+        limit_req_status 429;
+    }
+
+    # ── Proxy health check (/health) ─────────────────────────────────────────
+    location = /health {
+        proxy_pass http://proxy_upstream;
+    }
+
+    # ── OpenAI-compat routes (/v1/) ──────────────────────────────────────────
+    location /v1/ {
         proxy_pass http://proxy_upstream;
         proxy_read_timeout 300s;
         proxy_send_timeout 300s;


### PR DESCRIPTION
## Summary
- Replaces the legacy nginx patch-in-place Python script with a clean template install from `infra/nginx/webagent.conf`
- Adds `/health` and `/v1/` nginx routes so proxy health checks and OpenAI-compat endpoints are accessible externally
- Removes duplicate SSL session directives that conflicted with the system `nginx.conf`

The old approach mutated the live nginx config with regex patches, which was fragile and left stale `librechat_backend` routes causing 502s. The repo template is now the single source of truth.