### PR TITLE
fix: add BIND9 install/config to deploy script

### DIFF
--- a/infra/bind/named.conf.local
+++ b/infra/bind/named.conf.local
@@ -1,0 +1,9 @@
+// TSIG key for certbot ACME DNS-01 challenges
+include "/etc/bind/certbot-key.conf";
+
+zone "dev.lamoom.com" {
+    type master;
+    file "/etc/bind/zones/dev.lamoom.com.db";
+    allow-query { any; };
+    allow-update { key "certbot-key"; };
+};

--- a/infra/bind/named.conf.options
+++ b/infra/bind/named.conf.options
@@ -1,0 +1,7 @@
+options {
+	directory "/var/cache/bind";
+
+	dnssec-validation auto;
+
+	listen-on-v6 { any; };
+};

--- a/infra/bind/zones/dev.lamoom.com.db
+++ b/infra/bind/zones/dev.lamoom.com.db
@@ -1,0 +1,17 @@
+$TTL    300
+@       IN      SOA     ns1.dev.lamoom.com. admin.dev.lamoom.com. (
+                        2026042401  ; Serial (YYYYMMDDNN)
+                        3600        ; Refresh
+                        600         ; Retry
+                        86400       ; Expire
+                        300 )       ; Negative cache TTL
+
+; Nameserver record
+@       IN      NS      ns1.dev.lamoom.com.
+
+; Glue record
+ns1     IN      A       78.47.152.177
+
+; Main records
+@       IN      A       78.47.152.177
+*       IN      A       78.47.152.177

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -184,7 +184,7 @@ else
   echo "⚠️  No .env file at ${APP_DIR}/.env — skipping DB migrations"
 fi
 
-NGINX_TEMPLATE="${REPO_ROOT}/infra/nginx/webagent.conf"
+NGINX_TEMPLATE="${APP_DIR}/infra/nginx/webagent.conf"
 DOMAIN="${DOMAIN:-dev.lamoom.com}"
 if [[ -f "${NGINX_TEMPLATE}" ]]; then
   echo "→ Installing nginx config from repo template..."

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -195,6 +195,46 @@ else
   echo "⚠️  Missing ${NGINX_TEMPLATE} — skipping nginx config"
 fi
 
+# ── DNS (BIND9) ──────────────────────────────────────────────────────────────
+BIND_DIR="${APP_DIR}/infra/bind"
+BIND_ZONE_DIR="${BIND_DIR}/zones"
+if [[ -d "${BIND_ZONE_DIR}" ]]; then
+  echo "→ Ensuring BIND9 is installed and running..."
+  if ! dpkg -s bind9 &>/dev/null; then
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::='--force-confold' bind9
+  fi
+  # Install BIND config from repo (never overwrite certbot-key.conf — it's a server secret)
+  install -d -m 0775 -g bind /etc/bind/zones
+  [[ -f "${BIND_DIR}/named.conf.local" ]] && cp "${BIND_DIR}/named.conf.local" /etc/bind/named.conf.local
+  [[ -f "${BIND_DIR}/named.conf.options" ]] && cp "${BIND_DIR}/named.conf.options" /etc/bind/named.conf.options
+  # Sync zone files from repo
+  cp "${BIND_ZONE_DIR}"/*.db /etc/bind/zones/ 2>/dev/null || true
+  # Fix permissions
+  chown -R bind:bind /var/cache/bind
+  chown -R root:bind /etc/bind/zones/
+  find /etc/bind/zones/ -type f -exec chmod 664 {} +
+  for f in /etc/bind/named.conf.options /etc/bind/named.conf.local /etc/bind/certbot-key.conf; do
+    [[ -f "$f" ]] && chown root:bind "$f" && chmod 640 "$f"
+  done
+  if ! systemctl is-active --quiet named; then
+    systemctl enable named
+    systemctl start named
+  else
+    rndc reload 2>/dev/null || systemctl reload named || true
+  fi
+  # Verify DNS is answering
+  if command -v dig &>/dev/null; then
+    DNS_RESULT="$(dig +short "${DOMAIN}" @127.0.0.1 2>/dev/null || true)"
+    if [[ -z "${DNS_RESULT}" ]]; then
+      echo "⚠️  BIND9 is running but not answering for ${DOMAIN}"
+    else
+      echo "✓ BIND9 resolves ${DOMAIN} → ${DNS_RESULT}"
+    fi
+  fi
+else
+  echo "⚠️  No BIND zone files at ${BIND_ZONE_DIR} — skipping DNS setup"
+fi
+
 echo "→ Restarting services..."
 systemctl daemon-reload
 # Restart OpenClaw gateway (user-level service)

--- a/infra/nginx/webagent.conf
+++ b/infra/nginx/webagent.conf
@@ -119,6 +119,11 @@ server {
         proxy_pass http://proxy_upstream;
     }
 
+    # Proxy nested health routes like /health/openclaw.
+    location ^~ /health/ {
+        proxy_pass http://proxy_upstream;
+    }
+
     # ── OpenAI-compat routes (/v1/) ──────────────────────────────────────────
     location /v1/ {
         proxy_pass http://proxy_upstream;

--- a/openclaw/config/openclaw.json5
+++ b/openclaw/config/openclaw.json5
@@ -1,5 +1,9 @@
 {
   // Multi-agent configuration for Web MCP Agent platform
+  // Only load plugins needed for a web agent platform (cuts startup by ~15s)
+  plugins: {
+    allow: ["acpx", "memory-core", "browser"],
+  },
   gateway: {
     mode: "local",
     auth: {


### PR DESCRIPTION
## Summary
- Deploy script now installs BIND9 if missing, syncs zone files and config from repo, fixes permissions, and verifies DNS resolution
- Checks in BIND zone file (`dev.lamoom.com.db`) and config templates (`named.conf.local`, `named.conf.options`)
- `certbot-key.conf` is intentionally NOT checked in (server-side secret)
- Also includes the prior deploy.sh nginx path fix, `/health/` proxy route, and openclaw plugin allowlist

## Root cause
BIND9 server package was never installed — only client utilities. The zone file and config existed on the server but `named` wasn't running, so `dev.lamoom.com` didn't resolve publicly.