### PR TITLE
feat: replace test widget iframe with full-width ChatGPT-style chat

### DIFF
--- a/.agents/knowledgebase/architecture.md
+++ b/.agents/knowledgebase/architecture.md
@@ -1,0 +1,52 @@
+# WebAgent Operations Architecture
+
+## Scope
+
+This document describes the runtime architecture as defined by repo docs and infra files.
+
+## Monorepo layout
+
+- Workspace manager: `pnpm` workspaces (`pnpm-workspace.yaml`)
+- Packages:
+  - `packages/admin` (`@webagent/admin`) - Next.js admin UI
+  - `packages/proxy` (`@webagent/proxy`) - Fastify proxy/API
+  - `packages/widget` (`@webagent/widget`) - widget bundle
+  - `packages/shared` (`@webagent/shared`) - shared types/protocol
+
+## Runtime topology (single VM)
+
+- Admin UI listens on `127.0.0.1:3000` (`infra/systemd/webagent-admin.service`)
+- Proxy listens on `127.0.0.1:3001` (`infra/systemd/webagent-proxy.service`)
+- OpenClaw gateway endpoint expected at `ws://127.0.0.1:18789` (`.env.example`)
+- Public entrypoint is Nginx, with:
+  - `/` -> admin upstream (`127.0.0.1:3000`)
+  - `/api`, `/ws`, `/widget.js`, `/sso/` -> proxy upstream (`127.0.0.1:3001`)
+
+## Service ownership and control plane
+
+- Repo docs state OpenClaw base unit is OpenClaw-owned (`openclaw.service`) and repo should only manage drop-ins under `openclaw.service.d/`.
+- Repo-managed override source: `infra/systemd/openclaw.service.d/override.conf`
+- Host override destination used by scripts: `/etc/systemd/system/openclaw.service.d/override.conf`
+- Override injects:
+  - `EnvironmentFile=-${APP_DIR}/.env`
+  - `OPENCLAW_CONFIG_PATH=${APP_DIR}/openclaw/config/openclaw.json5`
+
+## Noted repo-level service definitions
+
+- `infra/systemd/openclaw-gateway.service` exists and starts `pnpm --filter @openclaw/gateway start`.
+- `infra/systemd/webagent-proxy.service` includes `Requires=openclaw-gateway.service`.
+- `infra/setup.sh` enables `openclaw.service`, `webagent-proxy`, and `webagent-admin` (it does not install/enable `openclaw-gateway.service`).
+- `docs/openclaw.md` warns against running competing OpenClaw service ownership models simultaneously.
+
+## Key operational paths
+
+- App root on VM (default): `/opt/webagent`
+- Project env: `/opt/webagent/.env`
+- OpenClaw config: `/opt/webagent/openclaw/config/openclaw.json5`
+- Nginx site template in repo: `infra/nginx/webagent.conf`
+- Nginx site path targeted by deploy script: `/etc/nginx/sites-enabled/openclaw` (override via `NGINX_SITE_PATH`)
+
+## Optional sidecar (separate flow)
+
+- `infra/librechat/` contains Docker Compose deployment for LibreChat (`:3080`) and MongoDB.
+- This is separate from the core systemd-based admin/proxy/OpenClaw runtime.

--- a/.agents/knowledgebase/deployment-runbook.md
+++ b/.agents/knowledgebase/deployment-runbook.md
@@ -1,0 +1,83 @@
+# Deployment Runbook
+
+## Canonical deploy path
+
+- Primary script: `infra/deploy.sh`
+- Purpose: sync local repo state to VM with `rsync`, rebuild, run migrations, apply OpenClaw drop-in override, restart services, and run health checks.
+- Default target host in script: `78.47.152.177`
+
+## Preconditions
+
+- Local machine has `ssh` and `rsync` (checked by script).
+- Remote app directory exists or can be created (default `/opt/webagent`).
+- Remote has a valid `/opt/webagent/.env` when DB migrations are required.
+
+## Standard deployment commands
+
+```bash
+# Deploy to default host (from script defaults)
+bash infra/deploy.sh
+
+# Deploy to a specific host
+bash infra/deploy.sh <host>
+
+# Deploy with explicit env overrides
+DEPLOY_USER=root APP_DIR=/opt/webagent bash infra/deploy.sh <host>
+```
+
+## What deploy.sh does (ordered)
+
+1. Preserves runtime OpenClaw config backup from `/opt/webagent/openclaw/config/openclaw.json5`.
+2. `rsync`s repo content to `/opt/webagent` (excludes `.env`, `node_modules`, build caches, and `openclaw/workspaces/`).
+3. Separately syncs `openclaw/workspaces/meta/`.
+4. Merges runtime-registered OpenClaw agents from backup config into synced config.
+5. Runs `pnpm install` and `pnpm build` as user `openclaw`.
+6. Applies systemd drop-in from `infra/systemd/openclaw.service.d/override.conf` to `/etc/systemd/system/openclaw.service.d/override.conf`.
+7. Syncs admin static assets with `infra/admin-static-sync.sh sync`.
+8. Runs DB migration (`pnpm --filter @webagent/proxy db:migrate`) if `.env` exists.
+9. Patches Nginx site (if present) for `/api/auth/`, `/sso/`, and API timeouts; then reloads Nginx.
+10. Restarts `openclaw.service`, `webagent-proxy`, `webagent-admin`.
+11. Runs health checks:
+   - `http://127.0.0.1:3001/health`
+   - `http://127.0.0.1:3000/`
+   - `http://127.0.0.1:3001/health/openclaw` contains `"ok"`
+   - `infra/admin-static-sync.sh check http://127.0.0.1:3000`
+
+## First-time VM bootstrap
+
+- One-time setup script: `infra/setup.sh` (run on VM as root).
+- It installs system deps, Node 24, pnpm, clones repo, creates `.env` from `.env.example` if missing, builds, migrates DB, installs Nginx config, requests certbot cert, installs `webagent-admin`/`webagent-proxy` units, installs OpenClaw drop-in override, enables services, and configures firewall.
+
+Example from repo docs:
+
+```bash
+rsync -az ./infra/ root@<new-vm-ip>:/root/webagent-infra/
+ssh root@<new-vm-ip> "DOMAIN=myapp.example.com REPO_URL=git@github.com:OpenCodeEngineer/webagent.git APP_DIR=/opt/webagent APP_USER=openclaw bash /root/webagent-infra/setup.sh"
+```
+
+## GitHub Actions deployment
+
+- Workflow: `.github/workflows/deploy.yml`
+- Trigger: push to `main` or manual dispatch.
+- Behavior: runs `bash infra/deploy.sh "${VM_HOST}"`.
+- Required secrets:
+  - `VM_SSH_KEY`
+  - `VM_HOST`
+
+## Recovery / rollback options from current scripts
+
+- Re-run `infra/deploy.sh` from a known-good local checkout to restore full app state.
+- If only admin static assets are broken, run:
+
+```bash
+bash infra/admin-static-sync.sh sync /opt/webagent
+systemctl restart webagent-admin
+bash infra/admin-static-sync.sh check http://127.0.0.1:3000
+```
+
+- If Nginx config edits fail during deploy, validate and reload manually:
+
+```bash
+nginx -t
+systemctl reload nginx
+```

--- a/.agents/knowledgebase/troubleshooting.md
+++ b/.agents/knowledgebase/troubleshooting.md
@@ -1,0 +1,117 @@
+# Troubleshooting Reference
+
+## Fast health verification
+
+Run on VM:
+
+```bash
+curl -sf http://127.0.0.1:3001/health
+curl -sf http://127.0.0.1:3001/health/openclaw
+curl -sf http://127.0.0.1:3000/
+```
+
+Expected from deploy script gates:
+
+- proxy `/health` returns success
+- admin root returns success
+- `/health/openclaw` includes `"ok"`
+
+## Service status and logs
+
+```bash
+systemctl status openclaw.service webagent-proxy webagent-admin --no-pager
+journalctl -u openclaw.service -n 100 --no-pager
+journalctl -u webagent-proxy -n 100 --no-pager
+journalctl -u webagent-admin -n 100 --no-pager
+```
+
+Repo docs also reference remote checks:
+
+```bash
+ssh root@78.47.152.177 "journalctl -u openclaw.service --no-pager -n 50"
+ssh root@78.47.152.177 "journalctl -u webagent-proxy --no-pager -n 50"
+```
+
+## Config and env paths to verify
+
+- App env file: `/opt/webagent/.env`
+- OpenClaw config: `/opt/webagent/openclaw/config/openclaw.json5`
+- OpenClaw drop-in override: `/etc/systemd/system/openclaw.service.d/override.conf`
+- Nginx site (deploy default target): `/etc/nginx/sites-enabled/openclaw`
+
+## Common failure modes and checks
+
+### 1) OpenClaw health fails
+
+Symptoms:
+
+- `http://127.0.0.1:3001/health/openclaw` does not contain `"ok"`
+
+Checks:
+
+```bash
+systemctl status openclaw.service --no-pager
+journalctl -u openclaw.service -n 100 --no-pager
+grep -E 'OPENCLAW_GATEWAY_URL|OPENCLAW_GATEWAY_TOKEN' /opt/webagent/.env
+```
+
+Notes from repo docs:
+
+- Avoid mixed service ownership (`openclaw.service` vs repo `openclaw-gateway.service`) as a control-plane conflict.
+
+### 2) Admin login page loads without CSS/JS or returns 404 static assets
+
+Checks/fix:
+
+```bash
+bash /opt/webagent/infra/admin-static-sync.sh sync /opt/webagent
+systemctl restart webagent-admin
+bash /opt/webagent/infra/admin-static-sync.sh check http://127.0.0.1:3000
+```
+
+### 3) DB migrations skipped or failed during deploy
+
+Symptoms from deploy output:
+
+- `.env` missing => migrations skipped
+- migration command exits non-zero
+
+Checks/fix:
+
+```bash
+test -f /opt/webagent/.env && echo "env present"
+sudo -u openclaw bash -lc "cd /opt/webagent && set -a && source .env && set +a && pnpm --filter @webagent/proxy db:migrate"
+```
+
+### 4) Nginx routing or syntax issues
+
+Checks:
+
+```bash
+nginx -t
+systemctl reload nginx
+```
+
+Confirm routes expected in `infra/nginx/webagent.conf`:
+
+- `/ws`, `/api`, `/widget.js`, `/sso/` -> proxy (`127.0.0.1:3001`)
+- `/` -> admin (`127.0.0.1:3000`)
+
+### 5) Full redeploy recovery
+
+From a known-good local checkout:
+
+```bash
+bash infra/deploy.sh <host>
+```
+
+This is the repo-defined path to re-sync code/config and re-run build/migrations/restarts/health checks.
+
+## Optional model endpoint validation (from docs)
+
+```bash
+curl -s -X POST "https://vibe-dev-ai.cognitiveservices.azure.com/openai/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -H "api-key: ${AZURE_DEV_AI_API_KEY}" \
+  -d '{"model":"kimi-k2.5-thinking","messages":[{"role":"user","content":"hi"}],"max_tokens":5}'
+```

--- a/.agents/skills/e2e-playwright-test/scripts/test-e2e-full.sh
+++ b/.agents/skills/e2e-playwright-test/scripts/test-e2e-full.sh
@@ -26,7 +26,24 @@ set -euo pipefail
 BASE_URL="${1:-${PROXY_URL:-${BASE_URL:-https://dev.lamoom.com}}}"
 AUTH_SECRET="${2:-${PROXY_INTERNAL_SECRET:-${PROXY_API_TOKEN:-}}}"
 DEFAULT_TEST_CUSTOMER_ID="00000000-0000-4000-8000-000000000001"
-CUSTOMER_ID="${TEST_CUSTOMER_ID:-$DEFAULT_TEST_CUSTOMER_ID}"
+generate_test_customer_id() {
+  if command -v python3 &>/dev/null; then
+    python3 - <<'PY'
+import uuid
+print(str(uuid.uuid4()))
+PY
+    return
+  fi
+
+  if command -v node &>/dev/null; then
+    node -e "console.log(require('crypto').randomUUID())"
+    return
+  fi
+
+  echo "$DEFAULT_TEST_CUSTOMER_ID"
+}
+
+CUSTOMER_ID="${TEST_CUSTOMER_ID:-$(generate_test_customer_id)}"
 WORKSPACES_DIR="${OPENCLAW_WORKSPACES_DIR:-}"
 
 # Strip trailing slash
@@ -229,7 +246,7 @@ test_meta_greeting() {
     fail "T4: Meta-agent greeting" "failed to generate customer HMAC signature"
     return 1
   }
-  resp=$(curl -sk -w "\n%{http_code}" --max-time 60 \
+  resp=$(curl -sk -w "\n%{http_code}" --max-time 300 \
     -X POST "$BASE_URL/api/agents/create-via-meta" \
     -H "x-customer-id: $CUSTOMER_ID" \
     -H "x-customer-sig: $customer_sig" \
@@ -1142,7 +1159,7 @@ test_meta_discovery() {
     fail "T14: Website discovery" "failed to generate customer HMAC signature"
     return 1
   }
-  resp=$(curl -sk -w "\n%{http_code}" --max-time 120 \
+  resp=$(curl -sk -w "\n%{http_code}" --max-time 300 \
     -X POST "$BASE_URL/api/agents/create-via-meta" \
     -H "x-customer-id: $CUSTOMER_ID" \
     -H "x-customer-sig: $customer_sig" \

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -13,8 +13,8 @@
 ### Config Locations
 - OpenClaw config: `/opt/webagent/openclaw/config/openclaw.json5`
 - Proxy service: `systemctl restart webagent-proxy`
-- Gateway service: `systemctl restart openclaw.service`
-- OpenClaw systemd drop-in override: `/etc/systemd/system/openclaw.service.d/override.conf`
+- Gateway service: `sudo -u openclaw bash -lc "export XDG_RUNTIME_DIR=/run/user/$(id -u); systemctl --user restart openclaw-gateway.service"`
+- OpenClaw systemd drop-in override: `~openclaw/.config/systemd/user/openclaw-gateway.service.d/override.conf`
 
 ### Azure Models
 - Endpoint: `${AZURE_DEV_AI_BASE_URL}` → `https://vibe-dev-ai.cognitiveservices.azure.com/openai/v1`
@@ -29,7 +29,7 @@ Set in `agents.defaults.model` in openclaw.json5:
 ```
 
 ### Troubleshooting
-1. Check gateway: `ssh root@78.47.152.177 "journalctl -u openclaw.service --no-pager -n 50"`
+1. Check gateway: `ssh root@78.47.152.177 "sudo -u openclaw bash -lc 'export XDG_RUNTIME_DIR=/run/user/$(id -u); journalctl --user -u openclaw-gateway.service --no-pager -n 50'"`
 2. Check proxy: `ssh root@78.47.152.177 "journalctl -u webagent-proxy --no-pager -n 50"`
 3. Test model directly:
    ```bash
@@ -94,6 +94,6 @@ DOMAIN=myapp.example.com REPO_URL=git@github.com:OpenCodeEngineer/webagent.git b
 
 ### Service ownership
 
-- OpenClaw base unit (`openclaw.service`) is installed/owned by OpenClaw runtime tooling.
-- This repo must only apply drop-in overrides under `openclaw.service.d/`.
-- Do not maintain a competing gateway unit as the primary runtime owner.
+- OpenClaw gateway unit (`openclaw-gateway.service`) is installed/owned by OpenClaw runtime tooling as a user-level systemd service.
+- This repo must only apply drop-in overrides under `openclaw-gateway.service.d/` in the app user's systemd directory.
+- Do not maintain a competing system-level `openclaw.service` owner for the same gateway lifecycle.

--- a/docs/openclaw.md
+++ b/docs/openclaw.md
@@ -3,6 +3,7 @@
 This project runs OpenClaw on a single VM. Use OpenClaw's official installer guidance as the source of truth:
 
 - Install docs: `https://docs.openclaw.ai/install`
+- Source code: `https://github.com/openclaw/openclaw`
 
 ## Official install options (from OpenClaw docs)
 
@@ -16,8 +17,6 @@ This project runs OpenClaw on a single VM. Use OpenClaw's official installer gui
 
 ## Verify install
 
-Run:
-
 ```bash
 openclaw --version
 openclaw doctor
@@ -28,29 +27,62 @@ openclaw gateway status
 
 - Do not assume Docker/LibreChat for MVP runtime validation.
 - Current architecture is single-VM systemd services:
-  - `webagent-admin`
-  - `webagent-proxy`
-  - OpenClaw gateway service
-- Runtime OpenClaw config path remains:
-  - `/opt/webagent/openclaw/config/openclaw.json5`
+  - `webagent-admin` (system-level)
+  - `webagent-proxy` (system-level)
+  - OpenClaw gateway (user-level, managed by OpenClaw CLI)
 
-## Service ownership
+## Gateway service ownership
 
-OpenClaw gateway runs as a **user-level systemd service** owned by the official OpenClaw installer:
+The OpenClaw CLI **owns the gateway systemd unit entirely**. Do not create or patch it manually.
 
-- Install: `openclaw gateway install --port 18789 --force` (as `openclaw` user)
-- Service: `openclaw-gateway.service` (user-level, at `~/.config/systemd/user/`)
-- Manage: `sudo -u openclaw bash -lc "export XDG_RUNTIME_DIR=/run/user/$(id -u); systemctl --user {start|stop|restart|status} openclaw-gateway.service"`
-- Prerequisites: `loginctl enable-linger openclaw` (persists user services across logins)
+### How `openclaw gateway install` works
 
-Do **not** create a system-level `openclaw.service` — the official installer owns the gateway lifecycle.
+Source: `src/daemon/systemd-unit.ts` and `src/daemon/systemd.ts` in the OpenClaw repo.
 
-## Patch model (systemd drop-ins)
+1. **Writes a user-level systemd unit** to `~/.config/systemd/user/<service-name>.service`
+2. **Writes an env file** to `<stateDir>/gateway.systemd.env` (mode 0600) from `~/.openclaw/.env`
+3. **If the unit already exists**: backs up to `<unit>.bak`, then **overwrites** with fresh content
+4. **After writing**: runs `systemctl --user daemon-reload`, `enable`, and `restart`
 
-Use systemd drop-ins for repo-controlled customizations (config path, env file):
+The generated unit uses `Type=simple`, `Restart=always`, `RestartSec=5`, `KillMode=control-group`,
+`StartLimitBurst=5`, `StartLimitIntervalSec=60`. ExecStart points to the OpenClaw runtime node process.
 
-- Repo source: `infra/systemd/openclaw.service.d/override.conf`
-- Host path: `~openclaw/.config/systemd/user/openclaw-gateway.service.d/override.conf`
-- Deploy script applies this automatically.
+### Do NOT use systemd drop-ins or overrides
 
-This keeps OpenClaw's base unit replaceable by OpenClaw updates while preserving our environment wiring.
+The OpenClaw CLI regenerates the unit file on `gateway install`. Any drop-in overrides
+(`openclaw-gateway.service.d/override.conf`) risk conflicting with the generated unit and
+are not preserved across OpenClaw upgrades. Instead:
+
+- **Environment variables**: Add them to `~/.openclaw/.env` — the CLI reads this and writes
+  them into `gateway.systemd.env` which the unit loads via `EnvironmentFile=`.
+- **Config path**: Set `OPENCLAW_CONFIG_PATH` in `~/.openclaw/.env`.
+- **App env vars**: Source the app `.env` from `~/.openclaw/.env` or merge needed vars into it.
+
+### Managing the gateway
+
+```bash
+# Install/reinstall (as openclaw user):
+openclaw gateway install --port 18789
+
+# Status:
+openclaw gateway status
+
+# Manual systemctl (when needed):
+sudo -u openclaw bash -lc \
+  "export XDG_RUNTIME_DIR=/run/user/\$(id -u); \
+   systemctl --user {start|stop|restart|status} openclaw-gateway.service"
+```
+
+Prerequisites: `loginctl enable-linger openclaw` (persists user services across logins).
+
+### OpenClaw config
+
+Runtime config lives at the path set by `OPENCLAW_CONFIG_PATH`. For this project:
+`/opt/webagent/openclaw/config/openclaw.json5`.
+
+The OpenClaw state directory is `~/.openclaw/` which contains:
+- `openclaw.json` — runtime state/config managed by OpenClaw
+- `.env` — environment vars that get written into `gateway.systemd.env`
+- `gateway.systemd.env` — generated env file loaded by the systemd unit
+- `agents/` — agent data
+- `workspace/` — agent workspaces

--- a/infra/setup.sh
+++ b/infra/setup.sh
@@ -81,22 +81,20 @@ for svc in webagent-proxy webagent-admin; do
   sed -i "s|\${APP_USER}|${APP_USER}|g" "/etc/systemd/system/${svc}.service"
 done
 
-# OpenClaw-managed base service override (do not replace openclaw.service directly)
-install -d -m 0755 /etc/systemd/system/openclaw.service.d
-cp "${SCRIPT_DIR}/systemd/openclaw.service.d/override.conf" /etc/systemd/system/openclaw.service.d/override.conf
-sed -i "s|\${APP_DIR}|${APP_DIR}|g" /etc/systemd/system/openclaw.service.d/override.conf
+# Keep user systemd alive across logouts so openclaw-gateway.service survives.
+loginctl enable-linger "${APP_USER}" || true
 
 systemctl daemon-reload
-systemctl enable --now openclaw.service webagent-proxy webagent-admin
+systemctl enable --now webagent-proxy webagent-admin
+
+# OpenClaw gateway is managed entirely by `openclaw gateway install`.
+# Do NOT create custom unit files or drop-in overrides — see docs/openclaw.md.
+# After initial OpenClaw install, run as the openclaw user:
+#   openclaw gateway install --port 18789
 
 # ── 11. Firewall ──────────────────────────────────────────────────────────────
 ufw allow OpenSSH
 ufw allow 'Nginx Full'
 ufw --force enable
-
-# ── 12. Sudoers — allow webagent user to restart openclaw service without password ──
-# (fallback for when SIGHUP doesn't work)
-echo "${APP_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart openclaw.service" > /etc/sudoers.d/webagent-openclaw
-chmod 440 /etc/sudoers.d/webagent-openclaw
 
 echo "✅  Setup complete. Services running on ${DOMAIN}"

--- a/infra/systemd/openclaw.service.d/override.conf
+++ b/infra/systemd/openclaw.service.d/override.conf
@@ -1,3 +1,0 @@
-[Service]
-EnvironmentFile=-${APP_DIR}/.env
-Environment=OPENCLAW_CONFIG_PATH=${APP_DIR}/openclaw/config/openclaw.json5

--- a/packages/admin/src/app/dashboard/agents/[id]/page.tsx
+++ b/packages/admin/src/app/dashboard/agents/[id]/page.tsx
@@ -89,6 +89,57 @@ export default async function AgentDetailPage({ params }: Props) {
             </CardContent>
           </Card>
 
+          {/* Passing User Data */}
+          {agent.embedToken && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Passing End-User Data</CardTitle>
+                <CardDescription>
+                  Forward your logged-in user&apos;s bearer token so the agent can call
+                  authenticated APIs on their behalf.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div>
+                  <p className="text-sm font-medium text-muted-foreground mb-2">
+                    Option 1 &mdash; Inline token (server-rendered)
+                  </p>
+                  <pre className="rounded-lg bg-zinc-900 border border-zinc-800 p-4 overflow-x-auto">
+                    <code className="text-emerald-400 font-mono text-xs whitespace-pre">{`<script
+  src="https://${WIDGET_BASE_URL.replace(/^https?:\/\//i, "").replace(/\/+$/, "")}/widget.js"
+  data-agent-token="${agent.embedToken}"
+  data-user-token="<%= currentUser.jwt %>"
+  async
+></script>`}</code>
+                  </pre>
+                  <p className="text-xs text-muted-foreground mt-1.5">
+                    Replace <code className="rounded bg-zinc-800 px-1 py-0.5 text-zinc-300">&lt;%= currentUser.jwt %&gt;</code> with
+                    your template language&apos;s expression for the signed-in user&apos;s JWT or API token.
+                  </p>
+                </div>
+
+                <div>
+                  <p className="text-sm font-medium text-muted-foreground mb-2">
+                    Option 2 &mdash; Read from localStorage
+                  </p>
+                  <pre className="rounded-lg bg-zinc-900 border border-zinc-800 p-4 overflow-x-auto">
+                    <code className="text-emerald-400 font-mono text-xs whitespace-pre">{`<script
+  src="https://${WIDGET_BASE_URL.replace(/^https?:\/\//i, "").replace(/\/+$/, "")}/widget.js"
+  data-agent-token="${agent.embedToken}"
+  data-user-token-key="auth_token"
+  async
+></script>`}</code>
+                  </pre>
+                  <p className="text-xs text-muted-foreground mt-1.5">
+                    The widget reads <code className="rounded bg-zinc-800 px-1 py-0.5 text-zinc-300">localStorage.getItem(&quot;auth_token&quot;)</code> at
+                    init and sends it as <code className="rounded bg-zinc-800 px-1 py-0.5 text-zinc-300">Authorization: Bearer &lt;token&gt;</code> with
+                    every agent request.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
           {/* API Configuration */}
           {agent.embedToken && (
             <Card>

--- a/packages/admin/src/app/dashboard/agents/[id]/page.tsx
+++ b/packages/admin/src/app/dashboard/agents/[id]/page.tsx
@@ -5,12 +5,12 @@ import { normalizeCustomerIdToUuid } from "@/lib/customer-id";
 import { AgentDetailActions } from "@/components/agent-detail-actions";
 import { AgentEditForm } from "@/components/agent-edit-form";
 import { AgentAuthContext } from "@/components/agent-auth-context";
-import { WidgetPreview } from "@/components/widget-preview";
+import { TestAgentChat } from "@/components/test-agent-chat";
 import { CreateAgentChat } from "@/components/create-agent-chat";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { MessageCircle } from "lucide-react";
+
 import { cn } from "@/lib/utils";
 
 const WIDGET_BASE_URL = process.env.NEXT_PUBLIC_APP_URL || process.env.AUTH_URL || "https://dev.lamoom.com";
@@ -195,19 +195,16 @@ export default async function AgentDetailPage({ params }: Props) {
         </TabsContent>
 
         <TabsContent value="test-chat">
-          <Card>
-            <CardHeader>
-              <div className="flex items-center gap-2">
-                <MessageCircle className="h-4 w-4 text-muted-foreground" />
-                <CardTitle>Test chat</CardTitle>
-              </div>
-              <CardDescription>Test the final embedded agent exactly as site visitors will see it.</CardDescription>
-            </CardHeader>
-            <CardContent>
+          <Card className="overflow-hidden">
+            <CardContent className="p-0">
               {agent.embedToken ? (
-                <WidgetPreview agentToken={agent.embedToken} widgetBaseUrl={WIDGET_BASE_URL} />
+                <div className="h-[600px] rounded-b-xl overflow-hidden">
+                  <TestAgentChat agentToken={agent.embedToken} widgetBaseUrl={WIDGET_BASE_URL} />
+                </div>
               ) : (
-                <p className="text-sm text-muted-foreground">No embed token is available for this agent yet.</p>
+                <div className="p-6">
+                  <p className="text-sm text-muted-foreground">No embed token is available for this agent yet.</p>
+                </div>
               )}
             </CardContent>
           </Card>

--- a/packages/admin/src/components/test-agent-chat.tsx
+++ b/packages/admin/src/components/test-agent-chat.tsx
@@ -1,0 +1,355 @@
+"use client";
+
+import { useRef, useEffect, useState, useCallback } from "react";
+import { Bot, SendHorizontal, RotateCcw } from "lucide-react";
+import { renderMarkdownToReactNodes } from "@/lib/markdown";
+import { cn } from "@/lib/utils";
+
+const BASE_RECONNECT_MS = 1000;
+const MAX_RECONNECT_MS = 30000;
+
+interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+interface TestAgentChatProps {
+  agentToken: string;
+  widgetBaseUrl?: string;
+  className?: string;
+}
+
+export function TestAgentChat({ agentToken, widgetBaseUrl, className }: TestAgentChatProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [isAuthed, setIsAuthed] = useState(false);
+
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const socketRef = useRef<WebSocket | null>(null);
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectAttempt = useRef(0);
+  const mountedRef = useRef(true);
+  const shouldReconnectRef = useRef(true);
+  const streamingIdRef = useRef<string | null>(null);
+  const userIdRef = useRef(`test-${crypto.randomUUID().slice(0, 8)}`);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, loading]);
+
+  // Auto-resize textarea
+  const adjustTextarea = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
+  }, []);
+
+  // --- WebSocket lifecycle ---
+  useEffect(() => {
+    mountedRef.current = true;
+
+    function connect() {
+      if (!mountedRef.current) return;
+      shouldReconnectRef.current = true;
+
+      const host = widgetBaseUrl
+        ? widgetBaseUrl.replace(/^https?:\/\//, "").replace(/\/+$/, "")
+        : window.location.host;
+      const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+      const wsUrl = `${wsProtocol}//${host}/ws`;
+
+      const ws = new WebSocket(wsUrl);
+      socketRef.current = ws;
+
+      ws.addEventListener("open", () => {
+        if (!mountedRef.current) { ws.close(); return; }
+        reconnectAttempt.current = 0;
+        // Authenticate as widget user (not admin)
+        ws.send(JSON.stringify({
+          type: "auth",
+          token: agentToken,
+          userId: userIdRef.current,
+        }));
+      });
+
+      ws.addEventListener("message", (event) => {
+        if (!mountedRef.current) return;
+
+        let data: Record<string, unknown>;
+        try {
+          data = JSON.parse(event.data as string) as Record<string, unknown>;
+        } catch {
+          return;
+        }
+
+        if (data.type === "auth_ok") {
+          setIsAuthed(true);
+          return;
+        }
+
+        if (data.type === "history") {
+          const rawMessages = Array.isArray(data.messages) ? data.messages : [];
+          const parsed: ChatMessage[] = rawMessages
+            .map((m) => {
+              if (!m || typeof m !== "object") return null;
+              const val = m as { role?: unknown; content?: unknown };
+              if ((val.role !== "user" && val.role !== "assistant") || typeof val.content !== "string") return null;
+              return { role: val.role, content: val.content } as ChatMessage;
+            })
+            .filter((m): m is ChatMessage => !!m);
+          setMessages(parsed);
+          return;
+        }
+
+        if (data.type === "auth_error") {
+          const reason = typeof data.reason === "string" ? data.reason : "Authentication failed";
+          shouldReconnectRef.current = false;
+          setIsAuthed(false);
+          setMessages((prev) => [
+            ...prev,
+            { role: "assistant", content: `Unable to connect: ${reason}` },
+          ]);
+          ws.close();
+          return;
+        }
+
+        if (data.type === "error") {
+          const errMsg = typeof data.message === "string" ? data.message : "An error occurred";
+          setMessages((prev) => [...prev, { role: "assistant", content: errMsg }]);
+          streamingIdRef.current = null;
+          setLoading(false);
+          return;
+        }
+
+        if (data.type === "message" && typeof data.done === "boolean") {
+          const content = typeof data.content === "string" ? data.content : "";
+          if (!data.done) {
+            if (!streamingIdRef.current) {
+              streamingIdRef.current = `s-${Date.now()}`;
+              setMessages((prev) => [...prev, { role: "assistant", content }]);
+            } else {
+              setMessages((prev) => {
+                const last = prev[prev.length - 1];
+                if (last?.role === "assistant") {
+                  return [...prev.slice(0, -1), { ...last, content: last.content + content }];
+                }
+                return prev;
+              });
+            }
+          } else {
+            if (streamingIdRef.current) {
+              streamingIdRef.current = null;
+              if (content) {
+                setMessages((prev) => {
+                  const last = prev[prev.length - 1];
+                  if (last?.role === "assistant") {
+                    return [...prev.slice(0, -1), { ...last, content: last.content + content }];
+                  }
+                  return [...prev, { role: "assistant", content }];
+                });
+              }
+            } else if (content) {
+              setMessages((prev) => [...prev, { role: "assistant", content }]);
+            }
+            setLoading(false);
+            textareaRef.current?.focus();
+          }
+        }
+      });
+
+      ws.addEventListener("close", () => {
+        if (!mountedRef.current) return;
+        socketRef.current = null;
+        setIsAuthed(false);
+        setLoading(false);
+        if (shouldReconnectRef.current) {
+          scheduleReconnect();
+        }
+      });
+
+      ws.addEventListener("error", () => { /* close fires after */ });
+    }
+
+    function scheduleReconnect() {
+      if (!mountedRef.current) return;
+      const delay = Math.min(
+        BASE_RECONNECT_MS * Math.pow(2, reconnectAttempt.current),
+        MAX_RECONNECT_MS,
+      );
+      reconnectAttempt.current += 1;
+      reconnectTimer.current = setTimeout(connect, delay);
+    }
+
+    connect();
+
+    return () => {
+      mountedRef.current = false;
+      if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
+      if (socketRef.current) {
+        socketRef.current.close();
+        socketRef.current = null;
+      }
+    };
+  }, [agentToken, widgetBaseUrl]);
+
+  // --- Send handler ---
+  const onSend = useCallback(() => {
+    const text = input.trim();
+    if (!text || loading || !isAuthed || !socketRef.current) return;
+
+    setMessages((prev) => [...prev, { role: "user", content: text }]);
+    setInput("");
+    setLoading(true);
+
+    if (textareaRef.current) {
+      textareaRef.current.style.height = "auto";
+    }
+
+    socketRef.current.send(JSON.stringify({ type: "message", content: text }));
+  }, [input, loading, isAuthed]);
+
+  // --- Reset conversation ---
+  const onReset = useCallback(() => {
+    // Generate new user ID to get a fresh session
+    userIdRef.current = `test-${crypto.randomUUID().slice(0, 8)}`;
+    setMessages([]);
+    setLoading(false);
+    streamingIdRef.current = null;
+    // Reconnect with new userId
+    if (socketRef.current) {
+      socketRef.current.close();
+    }
+  }, []);
+
+  const hasMessages = messages.length > 0 || loading;
+
+  return (
+    <div className={cn("flex h-full flex-col bg-[#171717]", className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-3">
+        <div className="flex items-center gap-2">
+          <div className="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-700">
+            <Bot className="h-3.5 w-3.5 text-zinc-300" />
+          </div>
+          <span className="text-sm font-medium text-zinc-300">Test conversation</span>
+          {isAuthed && (
+            <span className="h-2 w-2 rounded-full bg-emerald-500" title="Connected" />
+          )}
+        </div>
+        {hasMessages && (
+          <button
+            type="button"
+            onClick={onReset}
+            className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-200"
+            title="Reset conversation"
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+            New chat
+          </button>
+        )}
+      </div>
+
+      {/* Messages area */}
+      <div className="relative flex-1 overflow-y-auto">
+        {!hasMessages && (
+          <div className="flex h-full items-center justify-center">
+            <div className="text-center space-y-4">
+              <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-zinc-800">
+                <Bot className="h-7 w-7 text-zinc-400" />
+              </div>
+              <h2 className="text-xl font-semibold text-zinc-200">Test your agent</h2>
+              <p className="text-sm text-zinc-500 max-w-md">
+                Send a message to see how your agent responds to visitors.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {hasMessages && (
+          <div className="mx-auto max-w-3xl px-4 py-8 space-y-2">
+            {messages.map((message, index) => {
+              const isUser = message.role === "user";
+              return isUser ? (
+                <div key={`${message.role}-${index}`} className="flex justify-end py-2">
+                  <div className="max-w-[85%] space-y-2 rounded-2xl bg-zinc-800 px-4 py-3 text-sm text-zinc-100">
+                    {renderMarkdownToReactNodes(message.content)}
+                  </div>
+                </div>
+              ) : (
+                <div key={`${message.role}-${index}`} className="flex gap-3 py-6">
+                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-zinc-700 mt-0.5">
+                    <Bot className="h-4 w-4 text-zinc-400" />
+                  </div>
+                  <div className="min-w-0 flex-1 space-y-3 text-base leading-relaxed text-zinc-200">
+                    {renderMarkdownToReactNodes(message.content)}
+                  </div>
+                </div>
+              );
+            })}
+
+            {loading && !streamingIdRef.current && (
+              <div className="flex gap-3 py-6">
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-zinc-700 mt-0.5">
+                  <Bot className="h-4 w-4 text-zinc-400" />
+                </div>
+                <div className="pt-1">
+                  <span className="inline-flex gap-1 text-zinc-500">
+                    <span className="animate-bounce text-lg" style={{ animationDelay: "0ms" }}>·</span>
+                    <span className="animate-bounce text-lg" style={{ animationDelay: "150ms" }}>·</span>
+                    <span className="animate-bounce text-lg" style={{ animationDelay: "300ms" }}>·</span>
+                  </span>
+                </div>
+              </div>
+            )}
+
+            <div ref={bottomRef} />
+          </div>
+        )}
+
+        <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-[#171717] to-transparent" />
+      </div>
+
+      {/* Input area */}
+      <div>
+        <div className="mx-auto max-w-3xl px-4 pb-6 pt-2">
+          <div className="flex items-end gap-3 rounded-2xl border border-zinc-700 bg-zinc-800 px-4 py-3 focus-within:border-zinc-500 transition-colors">
+            <textarea
+              ref={textareaRef}
+              value={input}
+              onChange={(e) => {
+                setInput(e.target.value);
+                adjustTextarea();
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  onSend();
+                }
+              }}
+              placeholder="Send a message..."
+              className="flex-1 resize-none bg-transparent text-sm text-zinc-200 placeholder:text-zinc-500 outline-none min-h-[24px] max-h-[160px]"
+              disabled={loading || !isAuthed}
+              rows={1}
+            />
+            <button
+              type="button"
+              onClick={onSend}
+              disabled={loading || !isAuthed || input.trim().length === 0}
+              className={cn(
+                "flex h-8 w-8 shrink-0 items-center justify-center rounded-xl transition-colors",
+                loading || !isAuthed || input.trim().length === 0
+                  ? "bg-zinc-600 text-zinc-400"
+                  : "bg-white text-black hover:bg-zinc-200"
+              )}
+            >
+              <SendHorizontal className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/components/test-agent-chat.tsx
+++ b/packages/admin/src/components/test-agent-chat.tsx
@@ -19,6 +19,15 @@ interface TestAgentChatProps {
   className?: string;
 }
 
+function createSessionUserId(): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  if (uuid) {
+    return `test-${uuid.slice(0, 8)}`;
+  }
+
+  return `test-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
 export function TestAgentChat({ agentToken, widgetBaseUrl, className }: TestAgentChatProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
@@ -33,7 +42,7 @@ export function TestAgentChat({ agentToken, widgetBaseUrl, className }: TestAgen
   const mountedRef = useRef(true);
   const shouldReconnectRef = useRef(true);
   const streamingIdRef = useRef<string | null>(null);
-  const userIdRef = useRef(`test-${crypto.randomUUID().slice(0, 8)}`);
+  const userIdRef = useRef(createSessionUserId());
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -214,7 +223,7 @@ export function TestAgentChat({ agentToken, widgetBaseUrl, className }: TestAgen
   // --- Reset conversation ---
   const onReset = useCallback(() => {
     // Generate new user ID to get a fresh session
-    userIdRef.current = `test-${crypto.randomUUID().slice(0, 8)}`;
+    userIdRef.current = createSessionUserId();
     setMessages([]);
     setLoading(false);
     streamingIdRef.current = null;

--- a/packages/proxy/src/openclaw/client.ts
+++ b/packages/proxy/src/openclaw/client.ts
@@ -851,7 +851,7 @@ export class OpenClawClient {
     timeoutSeconds?: number;
     onDelta?: (delta: string) => void;
   }): Promise<AgentResponse> {
-    const timeoutMs = (opts.timeoutSeconds ?? 120) * 1000;
+    const timeoutMs = (opts.timeoutSeconds ?? 300) * 1000;
     let lastError = '';
 
     for (let index = 0; index < this.tokenCandidates.length; index += 1) {

--- a/packages/proxy/src/routes/widget.ts
+++ b/packages/proxy/src/routes/widget.ts
@@ -15,6 +15,8 @@ function resolveWidgetDistPath(): string | null {
     resolve(process.cwd(), 'packages/proxy/dist/widget.js'),
     resolve(import.meta.dirname, '../../dist/widget.js'),
     resolve(import.meta.dirname, '../widget.js'),
+    resolve(process.cwd(), 'packages/proxy/dist/widget/widget.js'),
+    resolve(import.meta.dirname, '../widget/widget.js'),
   ];
 
   for (const path of paths) {

--- a/packages/proxy/src/ws/handler.ts
+++ b/packages/proxy/src/ws/handler.ts
@@ -605,13 +605,14 @@ export function handleConnection(
             state.userContext = normalizeSessionAuthContext(serverAuthCtx as Record<string, unknown>);
           }
 
-          // Client context can add NON-auth fields only (safety)
+          // Client context: allow auth passthrough only when widgetConfig.allowClientAuth is true
+          const allowClientAuth = !!(tokenData.widgetConfig as Record<string, unknown> | null)?.allowClientAuth;
           const rawContext = msg.context;
           if (rawContext && typeof rawContext === 'object' && !Array.isArray(rawContext)) {
             const clientCtx = rawContext as Record<string, unknown>;
             const AUTH_KEYS = new Set(['Authorization', 'Bearer', 'apiToken', 'token', 'headers']);
             for (const [k, v] of Object.entries(clientCtx)) {
-              if (!AUTH_KEYS.has(k)) {
+              if (allowClientAuth || !AUTH_KEYS.has(k)) {
                 state.userContext[k] = v;
               }
             }


### PR DESCRIPTION
## Summary
- Replaces the iframe-based widget preview (tiny bubble at 540px) with a native full-width chat component
- ChatGPT-style UI: dark theme, streaming messages, centered layout, markdown rendering
- Connects via WebSocket using the agent's embed token (same as the real widget)
- Adds "New chat" reset button to start fresh test conversations