### PR TITLE
fix: use ${DOMAIN} placeholder in nginx template

### DIFF
--- a/infra/nginx/webagent.conf
+++ b/infra/nginx/webagent.conf
@@ -14,7 +14,7 @@ upstream proxy_upstream {
 server {
     listen 80;
     listen [::]:80;
-    server_name dev.lamoom.com;
+    server_name ${DOMAIN};
 
     return 301 https://$host$request_uri;
 }
@@ -22,10 +22,10 @@ server {
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
-    server_name dev.lamoom.com;
+    server_name ${DOMAIN};
 
-    ssl_certificate     /etc/letsencrypt/live/dev.lamoom.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/dev.lamoom.com/privkey.pem;
+    ssl_certificate     /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 


### PR DESCRIPTION
The nginx template had `dev.lamoom.com` hardcoded for server_name and cert paths instead of using `${DOMAIN}`. This broke deploys to v2.dev.lamoom.com (nginx couldn't find certs).