### PR TITLE
feat: make HubSpot E2E test target configurable

### DIFF
--- a/infra/nginx/webagent.conf
+++ b/infra/nginx/webagent.conf
@@ -14,7 +14,7 @@ upstream proxy_upstream {
 server {
     listen 80;
     listen [::]:80;
-    server_name dev.lamoom.com;
+    server_name ${DOMAIN};
 
     return 301 https://$host$request_uri;
 }
@@ -22,10 +22,10 @@ server {
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
-    server_name dev.lamoom.com;
+    server_name ${DOMAIN};
 
-    ssl_certificate     /etc/letsencrypt/live/dev.lamoom.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/dev.lamoom.com/privkey.pem;
+    ssl_certificate     /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 

--- a/tests/hubspot-e2e.ts
+++ b/tests/hubspot-e2e.ts
@@ -156,8 +156,8 @@ const SETUP_TIMEOUT_MS = getIntArg("setup-timeout-ms", 12 * 60 * 1000);
 const SCENARIO_TIMEOUT_MS = getIntArg("scenario-timeout-ms", 10 * 60 * 1000);
 const EVAL_TIMEOUT_MS = getIntArg("eval-timeout-ms", 3 * 60 * 1000);
 
-const WIDGET_URL = "https://dev.lamoom.com/widget.js";
-const LAMOOM_BASE_URL = "https://dev.lamoom.com";
+const LAMOOM_BASE_URL = getArg("lamoom-base-url") ?? process.env.LAMOOM_BASE_URL ?? "https://dev.lamoom.com";
+const WIDGET_URL = getArg("widget-url") ?? process.env.WIDGET_URL ?? `${LAMOOM_BASE_URL}/widget.js`;
 const HUBSPOT_CONTEXT_URL =
   getArg("hubspot-context-url") ??
   process.env.HUBSPOT_CONTEXT_URL ??


### PR DESCRIPTION
## Summary
- Make `LAMOOM_BASE_URL` and `WIDGET_URL` configurable via CLI args and env vars in `tests/hubspot-e2e.ts`
- Enables running the HubSpot E2E test against v2 (`v2.dev.lamoom.com`) or any other deployment without code changes
- Defaults remain `https://dev.lamoom.com` for backward compatibility

## Usage
```bash
# Target v2
LAMOOM_BASE_URL=https://v2.dev.lamoom.com npx tsx tests/hubspot-e2e.ts

# Or via CLI args
npx tsx tests/hubspot-e2e.ts --lamoom-base-url https://v2.dev.lamoom.com
```