### PR TITLE
fix: remove duplicate paperclipAgentId in schema

### DIFF
--- a/packages/proxy/src/db/schema.ts
+++ b/packages/proxy/src/db/schema.ts
@@ -26,7 +26,6 @@ export const agents = pgTable('agents', {
   widgetConfig: jsonb('widget_config').default({}).notNull(),
   apiDescription: text('api_description'),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
-  paperclipAgentId: text('paperclip_agent_id'),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow()
 });
 


### PR DESCRIPTION
## Summary
- Removes duplicate `paperclipAgentId` column definition in `packages/proxy/src/db/schema.ts` (lines 21 and 29) that was introduced by a merge artifact, causing the proxy build to fail with `TS1117: An object literal cannot have multiple properties with the same name`.