### PR TITLE
fix(deploy): external check fallback so spurious DNS failure doesn't rollback admin

### DIFF
--- a/.agents/skills/test-lamoom/SKILL.md
+++ b/.agents/skills/test-lamoom/SKILL.md
@@ -42,10 +42,10 @@ Run these checks IN ORDER using vibebrowser tools. Take a screenshot after each 
 
 ### Phase 0: Infrastructure (curl, not browser)
 ```
-curl -sk https://dev.lamoom.com/health → 200 {"status":"ok"}
-curl -sk https://dev.lamoom.com/health/openclaw → 200 {"status":"ok"}  
-curl -sk https://dev.lamoom.com/widget.js → 200, non-empty JS
-curl -sk https://dev.lamoom.com/v1/models → 200 {"data":[...]} (OpenAI-compat endpoint)
+curl -sk https://webagent-dev.duckdns.org/health → 200 {"status":"ok"}
+curl -sk https://webagent-dev.duckdns.org/health/openclaw → 200 {"status":"ok"}  
+curl -sk https://webagent-dev.duckdns.org/widget.js → 200, non-empty JS
+curl -sk https://webagent-dev.duckdns.org/v1/models → 200 {"data":[...]} (OpenAI-compat endpoint)
 ssh root@78.47.152.177 "systemctl is-active webagent-admin webagent-proxy openclaw-gateway nginx ssh" → all active
 ```
 
@@ -56,8 +56,8 @@ Catch intermittent login/provider failures that one-off checks can miss.
 1. Run repeated probes:
    ```
    for i in 1 2 3; do
-     curl -sk --max-time 20 -o /tmp/login-$i.html -w "login[$i] http=%{http_code} total=%{time_total}\n" https://dev.lamoom.com/login
-     curl -sk --max-time 20 -o /tmp/providers-$i.json -w "providers[$i] http=%{http_code} total=%{time_total}\n" https://dev.lamoom.com/api/auth/providers
+     curl -sk --max-time 20 -o /tmp/login-$i.html -w "login[$i] http=%{http_code} total=%{time_total}\n" https://webagent-dev.duckdns.org/login
+     curl -sk --max-time 20 -o /tmp/providers-$i.json -w "providers[$i] http=%{http_code} total=%{time_total}\n" https://webagent-dev.duckdns.org/api/auth/providers
    done
    ```
 2. **CHECK**: all `/login` probes return HTTP 200 and non-error HTML (not 5xx page).
@@ -71,18 +71,18 @@ Next.js standalone mode does NOT auto-include `_next/static/`. If this fails, AL
 
 1. Fetch the login page HTML and extract CSS paths:
    ```
-   CSS_PATH=$(curl -sk https://dev.lamoom.com/login | grep -oE '_next/static/css/[^"]+' | head -1)
+   CSS_PATH=$(curl -sk https://webagent-dev.duckdns.org/login | grep -oE '_next/static/css/[^"]+' | head -1)
    ```
 2. **CHECK**: `CSS_PATH` is non-empty (CSS link exists in HTML)
 3. Fetch the CSS file:
    ```
-   curl -sk -o /dev/null -w "%{http_code} size:%{size_download}" "https://dev.lamoom.com/$CSS_PATH"
+   curl -sk -o /dev/null -w "%{http_code} size:%{size_download}" "https://webagent-dev.duckdns.org/$CSS_PATH"
    ```
 4. **CHECK**: HTTP 200 AND size > 1000 bytes (real CSS, not error page)
 5. Extract and check a JS chunk too:
    ```
-   JS_PATH=$(curl -sk https://dev.lamoom.com/login | grep -oE '_next/static/chunks/[^"]+' | head -1)
-   curl -sk -o /dev/null -w "%{http_code}" "https://dev.lamoom.com/$JS_PATH"
+   JS_PATH=$(curl -sk https://webagent-dev.duckdns.org/login | grep -oE '_next/static/chunks/[^"]+' | head -1)
+   curl -sk -o /dev/null -w "%{http_code}" "https://webagent-dev.duckdns.org/$JS_PATH"
    ```
 6. **CHECK**: HTTP 200
 
@@ -95,7 +95,7 @@ Verify NextAuth providers are correctly configured and the DrizzleAdapter connec
 
 1. Fetch the providers endpoint:
    ```
-   curl -sk https://dev.lamoom.com/api/auth/providers
+   curl -sk https://webagent-dev.duckdns.org/api/auth/providers
    ```
 2. **CHECK**: Response is valid JSON (not HTML error page)
 3. **CHECK**: `google` provider exists with `callbackUrl` containing `/api/auth/callback/google`
@@ -124,7 +124,7 @@ Catch runtime corruption/compromise indicators that make QA results invalid.
 
 ### Phase 1: Login & Dashboard — RELEASE-CRITICAL
 
-1. **Navigate** to `https://dev.lamoom.com`
+1. **Navigate** to `https://webagent-dev.duckdns.org`
 2. **CHECK**: Redirects to `/login` or `/dashboard` (if already logged in)
 3. If on `/login`:
    - **CHECK UI**: Dark theme, centered card, Google OAuth button visible
@@ -138,7 +138,7 @@ Catch runtime corruption/compromise indicators that make QA results invalid.
 
 ### Phase 2: Create Agent Chat — Native WebSocket Integration — BLOCKING
 
-1. **Navigate** to `https://dev.lamoom.com/create`
+1. **Navigate** to `https://webagent-dev.duckdns.org/create`
 2. **CHECK**: Page loads with dark background (#171717), header bar shows "Create Agent"
 3. **CHECK**: Native chat authenticates via `/api/auth/ws-ticket` and `/ws`
 4. **CHECK**: Chat interface is visible without iframe, external login, or SSO bridge
@@ -196,7 +196,7 @@ The meta-agent should be able to call OpenClaw Console internal APIs. Verify:
 
 ### Phase 4: Verify Created Agent
 
-1. **Navigate** to `https://dev.lamoom.com/dashboard`
+1. **Navigate** to `https://webagent-dev.duckdns.org/dashboard`
 2. **CHECK**: New agent (openclaw or similar) appears in the agent list
 3. **CHECK**: Agent shows "active" status
 4. **CHECK**: "View" link works → agent detail page shows embed code
@@ -222,7 +222,7 @@ If the widget preview shows an error, debug via WebSocket directly:
 1. From the agent detail page, copy the embed token from the embed code
 2. Use `curl` or Node.js to test WebSocket:
    ```
-   Connect to wss://dev.lamoom.com/ws
+   Connect to wss://webagent-dev.duckdns.org/ws
    Send: {"type":"auth","agentToken":"<TOKEN>","userId":"e2e-test"}
    Expect: {"type":"auth_ok",...}
    Send: {"type":"message","content":"I am evaluating Vibe Browser. How do I install the extension? Please include the direct install link and docs link."}
@@ -268,7 +268,7 @@ Test the widget as an actual customer would embed it:
 
 ### Phase 7: Agent Management — Delete
 
-1. **Navigate** to `https://dev.lamoom.com/dashboard`
+1. **Navigate** to `https://webagent-dev.duckdns.org/dashboard`
 2. Find an agent with a "Delete" button (pick one that's not important, or the test agent from Phase 3)
 3. Note the agent name
 4. **Click** Delete
@@ -280,7 +280,7 @@ Test the widget as an actual customer would embed it:
 
 ### Phase 8: Agent Detail — Actions
 
-1. **Navigate** to `https://dev.lamoom.com/dashboard`
+1. **Navigate** to `https://webagent-dev.duckdns.org/dashboard`
 2. **Click** "View" on any active agent
 3. On the agent detail page:
    - **CHECK**: Embed code section visible with `<script>` tag
@@ -293,7 +293,7 @@ Test the widget as an actual customer would embed it:
 
 ### Phase 9: Admin CRM (requires ADMIN_EMAILS match)
 
-1. **Navigate** to `https://dev.lamoom.com/admin`
+1. **Navigate** to `https://webagent-dev.duckdns.org/admin`
 2. **CHECK**: Page loads (not 403/redirect — if it does, note and skip)
 3. **CHECK**: Stats cards visible: Total Users, Total Agents, Active Agents, Total Sessions
 4. **CHECK**: Users table visible with at least 1 row
@@ -433,7 +433,7 @@ When QA is running as part of a deployment (not a standalone spot-check), this p
 2. **Wait** 15 s for services to stabilize.
 3. **Re-run Phase 0** (all health endpoints). Every check MUST return the expected result.
 4. **Re-run Phase 0b** (static assets). CSS and JS MUST still resolve to 200.
-5. **Navigate** to `https://dev.lamoom.com/dashboard` in the browser.
+5. **Navigate** to `https://webagent-dev.duckdns.org/dashboard` in the browser.
 6. **CHECK**: Dashboard loads within 10 s with no errors.
 7. **CHECK**: An existing agent is still visible (data persistence across restart).
 
@@ -499,7 +499,7 @@ salt: '__Secure-authjs.session-token'
 
 ### `ignoreHTTPSErrors` on new context only
 
-Self-signed cert on `dev.lamoom.com`. Chrome CDP existing contexts cannot be reconfigured. Must use:
+Self-signed cert on `webagent-dev.duckdns.org`. Chrome CDP existing contexts cannot be reconfigured. Must use:
 ```javascript
 const context = await browser.newContext({ ignoreHTTPSErrors: true });
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # dependencies
 .*
+!.planning
+!.gitignore
+!.github
+!.claude
 node_modules/
 .pnpm-store/
 

--- a/.planning/MILESTONES.md
+++ b/.planning/MILESTONES.md
@@ -1,0 +1,11 @@
+# Milestones
+
+## v1.0 MVP Launch Readiness
+
+**Status:** In Progress  
+**Started:** 2026-05-25  
+**Goal:** Close Phase 1 PRD launch blockers, align test skill to PRD user journeys, reach READY verdict.
+
+---
+
+*No completed milestones yet.*

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,0 +1,112 @@
+# Lamoom
+
+## What This Is
+
+Lamoom turns "I have a website" into "my website has an AI support agent" in under ten minutes. Business owners visit the platform, tell a meta-agent their website URL, and get a site-grounded chat widget with one `<script>` tag — no prompt engineering, no vector DBs, no backend to run.
+
+## Core Value
+
+A business owner can provision a live, site-specific AI support agent for their website in one conversation, with zero engineering beyond pasting a script tag.
+
+## Requirements
+
+### Validated
+
+- ✓ Account creation (Google / GitHub / email + bcrypt) — Phase 0
+- ✓ Invite-gated signup — Phase 0
+- ✓ Meta-agent chat on `/create` (WebSocket, streaming) — Phase 0
+- ✓ Website crawl + due-diligence summary — Phase 0
+- ✓ Agent provisioning (workspace files + skills + knowledgebase + DB rows + embed token) — Phase 0
+- ✓ Specialized template selection by domain — Phase 0
+- ✓ Workflow-as-Code for product-agent actions — Phase 0
+- ✓ Embed `<script>` tag generation — Phase 0
+- ✓ Dashboard: agent list with status badges + session count — Phase 0
+- ✓ Agent detail page with live widget preview — Phase 0
+- ✓ Inline agent editing (name, URL, description) with workspace file sync — Phase 0
+- ✓ Pause / resume / delete agent end-to-end + widget cache invalidation — Phase 0
+- ✓ Paused-agent widget UX — Phase 0
+- ✓ Settings page (Account, Security, Embed API, Danger Zone) — Phase 0
+- ✓ Widget WebSocket chat with token-by-token streaming — Phase 0
+- ✓ Markdown rendering (widget + admin) — Phase 0
+- ✓ Meta-agent conversation persistence across refresh — Phase 0
+- ✓ HMAC-signed customer API auth — Phase 0
+- ✓ Rate limiting on WS + REST — Phase 0
+- ✓ CORS / origin validation in WS handshake — Phase 0
+- ✓ CI workflow (typecheck + test on PR) — Phase 0
+- ✓ Deploy workflow (rsync + migrate + admin-static-sync) — Phase 0
+
+### Active
+
+- [ ] Sentry / error tracking (proxy + admin) — no production visibility today
+- [ ] External uptime monitoring — no alert if site goes down
+- [ ] Widget bundle size check in CI — NFR enforcement currently only manual
+- [ ] Password column reconciliation (`customers.passwordHash` vs `users.hashedPassword`)
+- [ ] Test skill aligned to PRD §4 user loop steps ①–⑭
+- [ ] AI subagent-driven execution for each gap item
+
+### Out of Scope
+
+- Mobile SDK (iOS/Android) — web widget reaches mobile browsers; native SDK adds unsupportable per-platform pipeline
+- White-label/reseller program — pricing complexity not validated
+- On-premise deployment — single-VM Hetzner is the ops story
+- Multi-language admin UI — English only until PMF
+- Compliance certifications (SOC2, HIPAA) — pursue when enterprise deal requires
+- Synchronous human handoff / live agent inbox — thesis is AI-first
+- Vector DB / RAG over user-uploaded documents — after live-site agents hit NFR targets
+
+## Context
+
+- **Stack**: pnpm monorepo + Turborepo; Next.js admin, Node.js proxy, OpenClaw gateway
+- **Deploy**: single Hetzner VM, systemd services (`webagent-admin`, `webagent-proxy`, `openclaw-gateway`)
+- **Test skill**: `docs/tdd.md` §NFR Measurement Strategy; E2E via `test-lamoom` browser skill
+- **Known debt**: ~25 items in TDD §Known Debt; several are Phase 1 launch blockers
+- **PRD Phase 0 fully shipped** — all Phase 0 items confirmed in production (2026-05-24)
+- **TDD §Known Debt / §Production Status → BLOCKING**: needs reconciliation to reflect Phase 0 ship
+
+## Constraints
+
+- **Timeline**: MVP target — close Phase 1 blockers before public launch
+- **Ops**: single VM, no Docker, systemd-only deployment
+- **Budget**: Hetzner-class hosting; per-tenant cost must stay trivial
+- **Test gate**: test-lamoom QA verdict must be READY before launch
+- **Subagent execution**: implementation gaps driven by AI coding subagents, not manual edits
+
+## Key Decisions
+
+| Decision | Rationale | Outcome |
+|----------|-----------|---------|
+| Native WebSocket chat (no LibreChat) | Removes external auth dependency, faster to ship | ✓ Good — shipped Phase 0 |
+| Workspace-per-customer (not packed gateway) | Isolation, simpler agent scoping | — Pending (revisit at 100-agent scale) |
+| Browser-driven E2E QA (not shell scripts) | Shell scripts miss UI regression; browser tools catch real UX | ✓ Good |
+| Single-VM Hetzner deploy | Minimizes ops overhead at MVP stage | ✓ Good |
+
+## Current Milestone: v1.0 MVP Launch Readiness
+
+**Goal:** Close implementation gaps (Phase 1 PRD blockers), align test skill to PRD user journeys, drive completion via AI subagents, reach READY verdict from test-lamoom QA.
+
+**Target features:**
+- Sentry error tracking (proxy + admin)
+- External uptime monitoring
+- Widget bundle size CI check
+- Password column reconciliation
+- Test skill gap closure (PRD §4 loop coverage, G-Eval gate, subagent execution)
+
+## Evolution
+
+This document evolves at phase transitions and milestone boundaries.
+
+**After each phase transition** (via `/gsd-transition`):
+1. Requirements invalidated? → Move to Out of Scope with reason
+2. Requirements validated? → Move to Validated with phase reference
+3. New requirements emerged? → Add to Active
+4. Decisions to log? → Add to Key Decisions
+5. "What This Is" still accurate? → Update if drifted
+
+**After each milestone** (via `/gsd-complete-milestone`):
+1. Full review of all sections
+2. Core Value check — still the right priority?
+3. Audit Out of Scope — reasons still valid?
+4. Update Context with current state
+
+---
+*Last updated: 2026-05-25 after milestone v1.0 start*

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -37,12 +37,11 @@ A business owner can provision a live, site-specific AI support agent for their 
 
 ### Active
 
-- [ ] Sentry / error tracking (proxy + admin) — no production visibility today
-- [ ] External uptime monitoring — no alert if site goes down
-- [ ] Widget bundle size check in CI — NFR enforcement currently only manual
-- [ ] Password column reconciliation (`customers.passwordHash` vs `users.hashedPassword`)
-- [ ] Test skill aligned to PRD §4 user loop steps ①–⑭
-- [ ] AI subagent-driven execution for each gap item
+- [ ] E2E product flow works on staging — onboarding loop (PRD §4 ①–⑦), runtime loop (⑨–⑬), retention (⑭)
+- [ ] Meta-agent crawls site, creates agent, widget answers correctly (FLOW-01 through FLOW-09)
+- [ ] Test skill covers full PRD §4 user loop with per-step PASS/FAIL
+- [ ] G-Eval gate enforced (widget answers ≥ 3/5)
+- [ ] AI subagent execution pattern documented in test skill
 
 ### Out of Scope
 
@@ -85,11 +84,11 @@ A business owner can provision a live, site-specific AI support agent for their 
 **Goal:** Close implementation gaps (Phase 1 PRD blockers), align test skill to PRD user journeys, drive completion via AI subagents, reach READY verdict from test-lamoom QA.
 
 **Target features:**
-- Sentry error tracking (proxy + admin)
-- External uptime monitoring
-- Widget bundle size CI check
-- Password column reconciliation
-- Test skill gap closure (PRD §4 loop coverage, G-Eval gate, subagent execution)
+- E2E product flow working on staging (PRD §4 full user loop)
+- Test skill covers all PRD §4 steps ①–⑭ with PASS/FAIL per step
+- G-Eval scoring gate enforced (≥ 3/5 both questions)
+- AI subagent execution pattern documented for autonomous test runs
+- Achieve READY verdict from test-lamoom QA
 
 ## Evolution
 

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,78 +1,78 @@
 # Requirements: Lamoom
 
 **Defined:** 2026-05-25  
+**Revised:** 2026-05-25 — reoriented to product-working-first (observability/CI/password deferred)  
 **Core Value:** A business owner can provision a live, site-specific AI support agent in one conversation, zero engineering beyond pasting a script tag.
 
 ## v1.0 Requirements
 
-Requirements for MVP launch. Each maps to a roadmap phase.
+Requirements for MVP: product must work end-to-end on staging. Each maps to a roadmap phase.
 
-### Production Observability
+### E2E Product Flow (Onboarding Loop — PRD §4 steps ①–⑦)
 
-- [ ] **OBS-01**: Sentry error tracking wired into proxy service — unhandled exceptions captured with stack traces in Sentry
-- [ ] **OBS-02**: Sentry error tracking wired into admin Next.js app — both client-side and server-side errors captured
-- [ ] **OBS-03**: External uptime monitor configured and alerting — automated alert fires within 5 minutes of site outage
+- [ ] **FLOW-01**: User can sign up and reach the dashboard without errors
+- [ ] **FLOW-02**: User can navigate to `/create`, see native WebSocket chat load (dark theme, no auth errors)
+- [ ] **FLOW-03**: Meta-agent fetches and summarises the target website when user provides a URL (site-specific content, not generic response)
+- [ ] **FLOW-04**: Meta-agent creates an agent upon confirmation — workspace files, knowledgebase, embed token provisioned
+- [ ] **FLOW-05**: Embed `<script>` tag appears in chat after agent creation with copy button
 
-### CI Quality Gates
+### E2E Product Flow (Runtime Loop — PRD §4 steps ⑨–⑬)
 
-- [ ] **CI-01**: Widget bundle size check runs in CI pipeline — build fails automatically if `widget.js` exceeds 51200 bytes (50 KiB NFR)
-- [ ] **CI-02**: CI pipeline blocks PR merge when bundle check fails — enforcement, not just reporting
+- [ ] **FLOW-06**: Widget preview on agent detail page connects and enters "Connected" state
+- [ ] **FLOW-07**: Widget answers visitor questions with site-specific content, first token in < 3 s
+- [ ] **FLOW-08**: Multi-turn conversation context is preserved in the widget
 
-### Data Integrity
+### E2E Product Flow (Retention — PRD §4 step ⑭)
 
-- [ ] **DB-01**: Password column reconciled to single source of truth — `customers.passwordHash` and `users.hashedPassword` unified; one column dropped or both routed through one identity model
+- [ ] **FLOW-09**: Dashboard session count increments after a real widget interaction (owner can see resolved sessions)
 
-### Test Coverage (PRD §4 User Loop)
+### Test Skill Coverage
 
-- [ ] **TEST-01**: Test skill covers full onboarding loop (PRD §4 steps ①–⑦) — signup → visit `/create` → type website URL → meta-agent crawls → confirmation → agent provisioned → embed code displayed
-- [ ] **TEST-02**: Test skill covers runtime loop (PRD §4 steps ⑨–⑬) — widget appears on page → visitor opens chat → asks question → streaming response < 3 s → multi-turn context preserved
-- [ ] **TEST-03**: Test skill covers retention check (PRD §4 step ⑭) — dashboard shows resolved visitor session count > 0 after widget interaction
-- [ ] **TEST-04**: G-Eval scoring gate enforced as hard release gate — widget response to both eval questions must score ≥ 3/5; score < 3 = NOT READY
-- [ ] **TEST-05**: Test skill documents subagent execution pattern — AI coding subagents can read SKILL.md and run the full test protocol autonomously without human hand-holding
-
-### Docs Reconciliation
-
-- [ ] **DOC-01**: TDD `§Known Debt` table updated to reflect all Phase 0 items now shipped — items confirmed delivered marked as resolved
-- [ ] **DOC-02**: TDD `§Production Status → BLOCKING` list reconciled with current state — no stale blockers listed that are actually shipped
+- [ ] **TEST-01**: Test skill phases map to PRD §4 steps ①–⑭ explicitly — each test phase references the loop step it validates
+- [ ] **TEST-02**: G-Eval scoring gate enforced as hard release gate — widget responses to both eval questions must score ≥ 3/5; score < 3 = NOT READY verdict
+- [ ] **TEST-03**: Test skill documents subagent execution pattern — AI coding subagent can follow SKILL.md and run the full protocol autonomously without human intervention
+- [ ] **TEST-04**: Test skill run against current staging produces a written PASS/FAIL table with per-phase verdict
 
 ## v2 Requirements
 
-Deferred — acknowledged but not in current roadmap.
+Deferred — not blocking MVP.
 
-### Auth & Security
+### Production Observability
 
-- **AUTH-01**: Forgot password / reset flow via email
-- **AUTH-02**: Server-side signed visitor tokens (close session hijack vector — Known Debt #15)
+- **OBS-01**: Sentry error tracking wired into proxy service
+- **OBS-02**: Sentry error tracking wired into admin Next.js app
+- **OBS-03**: External uptime monitor configured and alerting
 
-### Developer Experience
+### CI Quality Gates
 
-- **DX-01**: `NEXT_PUBLIC_PROXY_URL` configurable (kill hardcoded `localhost:3001` — Known Debt #9)
-- **DX-02**: Admin auth tables shipped as checked-in Drizzle migration (Known Debt #8)
-- **DX-03**: Move hardcoded secrets out of `openclaw.json5` into env (Known Debt #10)
+- **CI-01**: Widget bundle size check in CI (blocks merge if > 51200 bytes)
+- **CI-02**: CI enforces bundle limit on every PR
 
-### Reliability
+### Data Integrity
 
-- **REL-01**: Agent registration TOCTOU race fix with file locking (Known Debt #11)
-- **REL-02**: `detectAgentCreation` DB insert race fixed with `onConflictDoNothing` (Known Debt #12)
-- **REL-03**: Widget preview auto-reconnect on disconnect (Known Debt #20)
+- **DB-01**: `customers.passwordHash` and `users.hashedPassword` reconciled to single source of truth
 
-### Analytics
+### Docs Reconciliation
 
-- **ANA-01**: Visitor analytics — message counts per agent, top questions
+- **DOC-01**: TDD `§Known Debt` updated for Phase 0 shipped items
+- **DOC-02**: TDD `§Production Status → BLOCKING` reconciled
 
 ## Out of Scope
 
 | Feature | Reason |
 |---------|--------|
-| Mobile SDK (iOS/Android) | Web widget reaches mobile browsers; native adds unsupportable per-platform pipeline |
-| White-label/reseller | Pricing complexity not validated |
-| On-premise deployment | Single-VM Hetzner is the ops story |
+| Sentry / error tracking | Deferred to v2 — product must work first |
+| Uptime monitoring | Deferred to v2 |
+| Widget bundle CI check | Deferred to v2 |
+| Password column reconciliation | Deferred to v2 |
+| Mobile SDK (iOS/Android) | Web widget reaches mobile; native out of scope |
+| White-label/reseller | Not validated |
+| On-premise deployment | Single-VM Hetzner only |
 | Multi-language admin UI | English only until PMF |
-| SOC2/HIPAA compliance | Multi-quarter program; pursue when enterprise deal requires |
-| Human handoff / live agent inbox | AI-first thesis; handoff is Intercom-shaped, not MVP |
+| SOC2/HIPAA compliance | Post-enterprise deal |
+| Human handoff / live agent inbox | AI-first thesis |
 | Vector DB / RAG over uploads | After live-site agents hit NFR targets |
 | Pricing tiers + Stripe | Phase 3 |
-| Voice I/O | Phase 3 |
 
 ## Traceability
 
@@ -80,25 +80,25 @@ Which phases cover which requirements. Updated during roadmap creation.
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
-| OBS-01 | Phase 3 | Pending |
-| OBS-02 | Phase 3 | Pending |
-| OBS-03 | Phase 3 | Pending |
-| CI-01 | Phase 2 | Pending |
-| CI-02 | Phase 2 | Pending |
-| DB-01 | Phase 4 | Pending |
-| TEST-01 | Phase 5 | Pending |
-| TEST-02 | Phase 5 | Pending |
-| TEST-03 | Phase 5 | Pending |
-| TEST-04 | Phase 5 | Pending |
-| TEST-05 | Phase 5 | Pending |
-| DOC-01 | Phase 1 | Pending |
-| DOC-02 | Phase 1 | Pending |
+| FLOW-01 | Phase 2 | Pending |
+| FLOW-02 | Phase 2 | Pending |
+| FLOW-03 | Phase 2 | Pending |
+| FLOW-04 | Phase 2 | Pending |
+| FLOW-05 | Phase 2 | Pending |
+| FLOW-06 | Phase 2 | Pending |
+| FLOW-07 | Phase 2 | Pending |
+| FLOW-08 | Phase 2 | Pending |
+| FLOW-09 | Phase 2 | Pending |
+| TEST-01 | Phase 3 | Pending |
+| TEST-02 | Phase 3 | Pending |
+| TEST-03 | Phase 3 | Pending |
+| TEST-04 | Phase 4 | Pending |
 
 **Coverage:**
 - v1.0 requirements: 13 total
-- Mapped to phases: 13 (roadmap complete)
+- Mapped to phases: 13
 - Unmapped: 0 ✓
 
 ---
 *Requirements defined: 2026-05-25*  
-*Last updated: 2026-05-25 after roadmap creation — all 13 requirements mapped*
+*Last updated: 2026-05-25 — traceability updated for 4-phase product-first roadmap*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -80,25 +80,25 @@ Which phases cover which requirements. Updated during roadmap creation.
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
-| OBS-01 | — | Pending |
-| OBS-02 | — | Pending |
-| OBS-03 | — | Pending |
-| CI-01 | — | Pending |
-| CI-02 | — | Pending |
-| DB-01 | — | Pending |
-| TEST-01 | — | Pending |
-| TEST-02 | — | Pending |
-| TEST-03 | — | Pending |
-| TEST-04 | — | Pending |
-| TEST-05 | — | Pending |
-| DOC-01 | — | Pending |
-| DOC-02 | — | Pending |
+| OBS-01 | Phase 3 | Pending |
+| OBS-02 | Phase 3 | Pending |
+| OBS-03 | Phase 3 | Pending |
+| CI-01 | Phase 2 | Pending |
+| CI-02 | Phase 2 | Pending |
+| DB-01 | Phase 4 | Pending |
+| TEST-01 | Phase 5 | Pending |
+| TEST-02 | Phase 5 | Pending |
+| TEST-03 | Phase 5 | Pending |
+| TEST-04 | Phase 5 | Pending |
+| TEST-05 | Phase 5 | Pending |
+| DOC-01 | Phase 1 | Pending |
+| DOC-02 | Phase 1 | Pending |
 
 **Coverage:**
 - v1.0 requirements: 13 total
-- Mapped to phases: 0 (pending roadmap)
-- Unmapped: 13 ⚠️
+- Mapped to phases: 13 (roadmap complete)
+- Unmapped: 0 ✓
 
 ---
 *Requirements defined: 2026-05-25*  
-*Last updated: 2026-05-25 after initial definition*
+*Last updated: 2026-05-25 after roadmap creation — all 13 requirements mapped*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,104 @@
+# Requirements: Lamoom
+
+**Defined:** 2026-05-25  
+**Core Value:** A business owner can provision a live, site-specific AI support agent in one conversation, zero engineering beyond pasting a script tag.
+
+## v1.0 Requirements
+
+Requirements for MVP launch. Each maps to a roadmap phase.
+
+### Production Observability
+
+- [ ] **OBS-01**: Sentry error tracking wired into proxy service — unhandled exceptions captured with stack traces in Sentry
+- [ ] **OBS-02**: Sentry error tracking wired into admin Next.js app — both client-side and server-side errors captured
+- [ ] **OBS-03**: External uptime monitor configured and alerting — automated alert fires within 5 minutes of site outage
+
+### CI Quality Gates
+
+- [ ] **CI-01**: Widget bundle size check runs in CI pipeline — build fails automatically if `widget.js` exceeds 51200 bytes (50 KiB NFR)
+- [ ] **CI-02**: CI pipeline blocks PR merge when bundle check fails — enforcement, not just reporting
+
+### Data Integrity
+
+- [ ] **DB-01**: Password column reconciled to single source of truth — `customers.passwordHash` and `users.hashedPassword` unified; one column dropped or both routed through one identity model
+
+### Test Coverage (PRD §4 User Loop)
+
+- [ ] **TEST-01**: Test skill covers full onboarding loop (PRD §4 steps ①–⑦) — signup → visit `/create` → type website URL → meta-agent crawls → confirmation → agent provisioned → embed code displayed
+- [ ] **TEST-02**: Test skill covers runtime loop (PRD §4 steps ⑨–⑬) — widget appears on page → visitor opens chat → asks question → streaming response < 3 s → multi-turn context preserved
+- [ ] **TEST-03**: Test skill covers retention check (PRD §4 step ⑭) — dashboard shows resolved visitor session count > 0 after widget interaction
+- [ ] **TEST-04**: G-Eval scoring gate enforced as hard release gate — widget response to both eval questions must score ≥ 3/5; score < 3 = NOT READY
+- [ ] **TEST-05**: Test skill documents subagent execution pattern — AI coding subagents can read SKILL.md and run the full test protocol autonomously without human hand-holding
+
+### Docs Reconciliation
+
+- [ ] **DOC-01**: TDD `§Known Debt` table updated to reflect all Phase 0 items now shipped — items confirmed delivered marked as resolved
+- [ ] **DOC-02**: TDD `§Production Status → BLOCKING` list reconciled with current state — no stale blockers listed that are actually shipped
+
+## v2 Requirements
+
+Deferred — acknowledged but not in current roadmap.
+
+### Auth & Security
+
+- **AUTH-01**: Forgot password / reset flow via email
+- **AUTH-02**: Server-side signed visitor tokens (close session hijack vector — Known Debt #15)
+
+### Developer Experience
+
+- **DX-01**: `NEXT_PUBLIC_PROXY_URL` configurable (kill hardcoded `localhost:3001` — Known Debt #9)
+- **DX-02**: Admin auth tables shipped as checked-in Drizzle migration (Known Debt #8)
+- **DX-03**: Move hardcoded secrets out of `openclaw.json5` into env (Known Debt #10)
+
+### Reliability
+
+- **REL-01**: Agent registration TOCTOU race fix with file locking (Known Debt #11)
+- **REL-02**: `detectAgentCreation` DB insert race fixed with `onConflictDoNothing` (Known Debt #12)
+- **REL-03**: Widget preview auto-reconnect on disconnect (Known Debt #20)
+
+### Analytics
+
+- **ANA-01**: Visitor analytics — message counts per agent, top questions
+
+## Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| Mobile SDK (iOS/Android) | Web widget reaches mobile browsers; native adds unsupportable per-platform pipeline |
+| White-label/reseller | Pricing complexity not validated |
+| On-premise deployment | Single-VM Hetzner is the ops story |
+| Multi-language admin UI | English only until PMF |
+| SOC2/HIPAA compliance | Multi-quarter program; pursue when enterprise deal requires |
+| Human handoff / live agent inbox | AI-first thesis; handoff is Intercom-shaped, not MVP |
+| Vector DB / RAG over uploads | After live-site agents hit NFR targets |
+| Pricing tiers + Stripe | Phase 3 |
+| Voice I/O | Phase 3 |
+
+## Traceability
+
+Which phases cover which requirements. Updated during roadmap creation.
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| OBS-01 | — | Pending |
+| OBS-02 | — | Pending |
+| OBS-03 | — | Pending |
+| CI-01 | — | Pending |
+| CI-02 | — | Pending |
+| DB-01 | — | Pending |
+| TEST-01 | — | Pending |
+| TEST-02 | — | Pending |
+| TEST-03 | — | Pending |
+| TEST-04 | — | Pending |
+| TEST-05 | — | Pending |
+| DOC-01 | — | Pending |
+| DOC-02 | — | Pending |
+
+**Coverage:**
+- v1.0 requirements: 13 total
+- Mapped to phases: 0 (pending roadmap)
+- Unmapped: 13 ⚠️
+
+---
+*Requirements defined: 2026-05-25*  
+*Last updated: 2026-05-25 after initial definition*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,89 @@
+# Roadmap: Lamoom — v1.0 MVP Launch Readiness
+
+## Overview
+
+Phase 0 is fully shipped. This roadmap closes the remaining launch blockers before public traffic: accurate documentation, CI enforcement, production error visibility, data-layer correctness, and a test skill that can give a READY verdict against the full PRD user loop.
+
+## Phases
+
+**Phase Numbering:**
+- Integer phases (1, 2, 3): Planned milestone work
+- Decimal phases (2.1, 2.2): Urgent insertions (marked with INSERTED)
+
+Decimal phases appear between their surrounding integers in numeric order.
+
+- [ ] **Phase 1: Docs Reconciliation** - Update TDD Known Debt and Production Status to reflect Phase 0 ship reality
+- [ ] **Phase 2: CI Quality Gates** - Enforce widget bundle size limit automatically in CI before PR merge
+- [ ] **Phase 3: Production Observability** - Wire Sentry and external uptime monitoring so errors and outages are caught automatically
+- [ ] **Phase 4: Data Integrity** - Reconcile the password column split so auth writes to a single source of truth
+- [ ] **Phase 5: Test Coverage Alignment** - Align the test skill to the full PRD §4 user loop, enforce G-Eval gate, document subagent execution pattern
+
+## Phase Details
+
+### Phase 1: Docs Reconciliation
+**Goal**: Documentation accurately reflects what is live in production so no one acts on stale debt or phantom blockers.
+**Depends on**: Nothing (first phase)
+**Requirements**: DOC-01, DOC-02
+**Success Criteria** (what must be TRUE):
+  1. Every item in TDD `§Known Debt` that shipped in Phase 0 is marked resolved with a delivery reference.
+  2. TDD `§Production Status → BLOCKING` contains no items that are confirmed shipped — the list only holds genuine open work.
+  3. A developer reading both sections gets an accurate picture of current debt without cross-checking git history.
+**Plans**: TBD
+
+### Phase 2: CI Quality Gates
+**Goal**: The CI pipeline automatically blocks any PR that would ship a widget bundle exceeding the 50 KiB NFR.
+**Depends on**: Phase 1
+**Requirements**: CI-01, CI-02
+**Success Criteria** (what must be TRUE):
+  1. A CI step runs on every PR and measures the built `widget.js` byte size against the 51200-byte threshold.
+  2. A PR that produces a widget over 51200 bytes cannot be merged — the CI check fails and blocks the merge button.
+  3. A PR within the limit passes the check without manual intervention.
+**Plans**: TBD
+**UI hint**: no
+
+### Phase 3: Production Observability
+**Goal**: Unhandled errors in proxy and admin are captured in Sentry, and an external monitor alerts within 5 minutes of a site outage.
+**Depends on**: Phase 2
+**Requirements**: OBS-01, OBS-02, OBS-03
+**Success Criteria** (what must be TRUE):
+  1. An unhandled exception thrown in the proxy service appears in the Sentry project with a full stack trace within seconds.
+  2. An unhandled client-side or server-side error in the Next.js admin app appears in Sentry with context (URL, user session if available).
+  3. An external uptime monitor (e.g. BetterUptime, UptimeRobot) is configured on the public domain and fires an alert within 5 minutes when the site is unreachable.
+  4. The Sentry DSN and uptime monitor are configured via environment variables, not hardcoded values.
+**Plans**: TBD
+
+### Phase 4: Data Integrity
+**Goal**: The platform writes and reads passwords through a single column so there is no risk of auth failures from a split source of truth.
+**Depends on**: Phase 3
+**Requirements**: DB-01
+**Success Criteria** (what must be TRUE):
+  1. Either `customers.passwordHash` or `users.hashedPassword` is the sole column used for password storage — the other is dropped or unused.
+  2. All auth code paths (login, registration, password change) read and write only the surviving column.
+  3. A migration or reconciliation script exists that documents how existing rows were unified.
+**Plans**: TBD
+
+### Phase 5: Test Coverage Alignment
+**Goal**: The test-lamoom skill covers every step of the PRD §4 user loop, enforces a G-Eval quality gate, and is self-contained enough for an AI coding subagent to run the full protocol without human help.
+**Depends on**: Phase 4
+**Requirements**: TEST-01, TEST-02, TEST-03, TEST-04, TEST-05
+**Success Criteria** (what must be TRUE):
+  1. Running the test skill exercises all 14 PRD §4 steps — onboarding (①–⑦), runtime (⑨–⑬), and retention check (⑭) — and reports PASS or FAIL per step.
+  2. The G-Eval gate scores widget responses to both eval questions; a score below 3/5 on either question produces a NOT READY verdict and halts the run.
+  3. After a successful widget interaction the dashboard session count increments, and the test records this as a PASS for step ⑭.
+  4. SKILL.md contains a self-contained "Subagent Execution" section that an AI coding subagent can follow to run the full protocol autonomously — no human steps required mid-run.
+  5. A full test run against the deployed site concludes with either a READY or NOT READY verdict and a per-step breakdown.
+**Plans**: TBD
+**UI hint**: yes
+
+## Progress
+
+**Execution Order:**
+Phases execute in numeric order: 1 → 2 → 3 → 4 → 5
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 1. Docs Reconciliation | 0/TBD | Not started | - |
+| 2. CI Quality Gates | 0/TBD | Not started | - |
+| 3. Production Observability | 0/TBD | Not started | - |
+| 4. Data Integrity | 0/TBD | Not started | - |
+| 5. Test Coverage Alignment | 0/TBD | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Phase 0 is fully shipped. This roadmap closes the remaining launch blockers before public traffic: accurate documentation, CI enforcement, production error visibility, data-layer correctness, and a test skill that can give a READY verdict against the full PRD user loop.
+Phase 0 is fully shipped. This milestone has one goal: get the full PRD §4 user loop working on staging. Observability, CI bundle gates, and password reconciliation are deferred to v2. The sequence is diagnose → fix → align tests → verify READY.
 
 ## Phases
 
@@ -12,78 +12,66 @@ Phase 0 is fully shipped. This roadmap closes the remaining launch blockers befo
 
 Decimal phases appear between their surrounding integers in numeric order.
 
-- [ ] **Phase 1: Docs Reconciliation** - Update TDD Known Debt and Production Status to reflect Phase 0 ship reality
-- [ ] **Phase 2: CI Quality Gates** - Enforce widget bundle size limit automatically in CI before PR merge
-- [ ] **Phase 3: Production Observability** - Wire Sentry and external uptime monitoring so errors and outages are caught automatically
-- [ ] **Phase 4: Data Integrity** - Reconcile the password column split so auth writes to a single source of truth
-- [ ] **Phase 5: Test Coverage Alignment** - Align the test skill to the full PRD §4 user loop, enforce G-Eval gate, document subagent execution pattern
+- [ ] **Phase 1: Test Audit** - Run the test-lamoom skill against staging and produce a written PASS/FAIL table per phase — no code changes, diagnosis only
+- [ ] **Phase 2: Fix E2E Blockers** - AI subagents fix every BLOCKING/RELEASE-CRITICAL failure found in Phase 1 so the full PRD §4 user loop works end-to-end
+- [ ] **Phase 3: Test Skill Alignment** - Update SKILL.md to map each test phase to PRD §4 steps ①–⑭, harden the G-Eval gate as a hard release gate, and add a self-contained subagent execution section
+- [ ] **Phase 4: Final Verification** - Run the full test skill against staging and achieve a READY verdict
 
 ## Phase Details
 
-### Phase 1: Docs Reconciliation
-**Goal**: Documentation accurately reflects what is live in production so no one acts on stale debt or phantom blockers.
+### Phase 1: Test Audit
+**Goal**: Know exactly which parts of the PRD §4 user loop are broken on staging before touching any code.
 **Depends on**: Nothing (first phase)
-**Requirements**: DOC-01, DOC-02
+**Requirements**: (audit run that seeds Phase 2; TEST-04 success criterion is in Phase 4)
 **Success Criteria** (what must be TRUE):
-  1. Every item in TDD `§Known Debt` that shipped in Phase 0 is marked resolved with a delivery reference.
-  2. TDD `§Production Status → BLOCKING` contains no items that are confirmed shipped — the list only holds genuine open work.
-  3. A developer reading both sections gets an accurate picture of current debt without cross-checking git history.
+  1. The test-lamoom skill has been run against the current staging deployment from start to finish.
+  2. A written PASS/FAIL table exists covering every skill phase (Phase 0 through Phase 10) with a one-line note per failure.
+  3. Every BLOCKING and RELEASE-CRITICAL failure is explicitly labelled so Phase 2 has a prioritised fix list.
+  4. No code was changed during this phase — the audit reflects the real current state of staging.
 **Plans**: TBD
 
-### Phase 2: CI Quality Gates
-**Goal**: The CI pipeline automatically blocks any PR that would ship a widget bundle exceeding the 50 KiB NFR.
+### Phase 2: Fix E2E Blockers
+**Goal**: Every BLOCKING and RELEASE-CRITICAL failure from the Phase 1 audit is resolved so a user can complete the full PRD §4 loop on staging without hitting a hard stop.
 **Depends on**: Phase 1
-**Requirements**: CI-01, CI-02
+**Requirements**: FLOW-01, FLOW-02, FLOW-03, FLOW-04, FLOW-05, FLOW-06, FLOW-07, FLOW-08, FLOW-09
 **Success Criteria** (what must be TRUE):
-  1. A CI step runs on every PR and measures the built `widget.js` byte size against the 51200-byte threshold.
-  2. A PR that produces a widget over 51200 bytes cannot be merged — the CI check fails and blocks the merge button.
-  3. A PR within the limit passes the check without manual intervention.
-**Plans**: TBD
-**UI hint**: no
-
-### Phase 3: Production Observability
-**Goal**: Unhandled errors in proxy and admin are captured in Sentry, and an external monitor alerts within 5 minutes of a site outage.
-**Depends on**: Phase 2
-**Requirements**: OBS-01, OBS-02, OBS-03
-**Success Criteria** (what must be TRUE):
-  1. An unhandled exception thrown in the proxy service appears in the Sentry project with a full stack trace within seconds.
-  2. An unhandled client-side or server-side error in the Next.js admin app appears in Sentry with context (URL, user session if available).
-  3. An external uptime monitor (e.g. BetterUptime, UptimeRobot) is configured on the public domain and fires an alert within 5 minutes when the site is unreachable.
-  4. The Sentry DSN and uptime monitor are configured via environment variables, not hardcoded values.
-**Plans**: TBD
-
-### Phase 4: Data Integrity
-**Goal**: The platform writes and reads passwords through a single column so there is no risk of auth failures from a split source of truth.
-**Depends on**: Phase 3
-**Requirements**: DB-01
-**Success Criteria** (what must be TRUE):
-  1. Either `customers.passwordHash` or `users.hashedPassword` is the sole column used for password storage — the other is dropped or unused.
-  2. All auth code paths (login, registration, password change) read and write only the surviving column.
-  3. A migration or reconciliation script exists that documents how existing rows were unified.
-**Plans**: TBD
-
-### Phase 5: Test Coverage Alignment
-**Goal**: The test-lamoom skill covers every step of the PRD §4 user loop, enforces a G-Eval quality gate, and is self-contained enough for an AI coding subagent to run the full protocol without human help.
-**Depends on**: Phase 4
-**Requirements**: TEST-01, TEST-02, TEST-03, TEST-04, TEST-05
-**Success Criteria** (what must be TRUE):
-  1. Running the test skill exercises all 14 PRD §4 steps — onboarding (①–⑦), runtime (⑨–⑬), and retention check (⑭) — and reports PASS or FAIL per step.
-  2. The G-Eval gate scores widget responses to both eval questions; a score below 3/5 on either question produces a NOT READY verdict and halts the run.
-  3. After a successful widget interaction the dashboard session count increments, and the test records this as a PASS for step ⑭.
-  4. SKILL.md contains a self-contained "Subagent Execution" section that an AI coding subagent can follow to run the full protocol autonomously — no human steps required mid-run.
-  5. A full test run against the deployed site concludes with either a READY or NOT READY verdict and a per-step breakdown.
+  1. User can sign up, reach the dashboard, and navigate to `/create` — the native WebSocket chat loads with dark theme and no auth errors (FLOW-01, FLOW-02).
+  2. The meta-agent fetches the target website and returns a site-specific summary when given a URL — generic or apology responses are absent (FLOW-03).
+  3. On confirmation, the meta-agent provisions a real agent: workspace files, knowledgebase, embed token, and DB rows all created; the embed `<script>` tag appears in chat (FLOW-04, FLOW-05).
+  4. The widget preview on the agent detail page reaches "Connected" state, answers visitor questions with site-specific content in under 3 s first token, and preserves multi-turn context (FLOW-06, FLOW-07, FLOW-08).
+  5. After a real widget interaction the dashboard session count increments and the owner can see the resolved session (FLOW-09).
 **Plans**: TBD
 **UI hint**: yes
+
+### Phase 3: Test Skill Alignment
+**Goal**: SKILL.md is updated so that every test phase explicitly maps to a PRD §4 loop step, the G-Eval gate is a hard non-negotiable release gate, and an AI coding subagent can execute the full protocol autonomously without human intervention.
+**Depends on**: Phase 2
+**Requirements**: TEST-01, TEST-02, TEST-03
+**Success Criteria** (what must be TRUE):
+  1. Each skill phase header or annotation references the specific PRD §4 step(s) it validates (e.g. "Phase 2 → PRD §4 step ③") so traceability is explicit (TEST-01).
+  2. The G-Eval scoring section states clearly that both eval questions must score ≥ 3/5 and that any score below 3 produces a NOT READY verdict immediately — no escape hatch (TEST-02).
+  3. SKILL.md contains a standalone "Subagent Execution" section that lists every tool, credential, and decision point an AI coding subagent needs to run the full protocol start-to-finish without asking a human (TEST-03).
+**Plans**: TBD
+
+### Phase 4: Final Verification
+**Goal**: The updated test skill is run against staging and returns a READY verdict, confirming the full PRD §4 loop is working and all hard release gates are satisfied.
+**Depends on**: Phase 3
+**Requirements**: TEST-04
+**Success Criteria** (what must be TRUE):
+  1. The full test-lamoom skill run produces a written per-phase PASS/FAIL table covering all phases (Phase 0 through Phase 10) (TEST-04).
+  2. Every BLOCKING and RELEASE-CRITICAL phase shows PASS.
+  3. Both G-Eval questions score ≥ 3/5.
+  4. The run concludes with the explicit line **VERDICT: READY**.
+**Plans**: TBD
 
 ## Progress
 
 **Execution Order:**
-Phases execute in numeric order: 1 → 2 → 3 → 4 → 5
+Phases execute in numeric order: 1 → 2 → 3 → 4
 
 | Phase | Plans Complete | Status | Completed |
 |-------|----------------|--------|-----------|
-| 1. Docs Reconciliation | 0/TBD | Not started | - |
-| 2. CI Quality Gates | 0/TBD | Not started | - |
-| 3. Production Observability | 0/TBD | Not started | - |
-| 4. Data Integrity | 0/TBD | Not started | - |
-| 5. Test Coverage Alignment | 0/TBD | Not started | - |
+| 1. Test Audit | 0/TBD | Not started | - |
+| 2. Fix E2E Blockers | 0/TBD | Not started | - |
+| 3. Test Skill Alignment | 0/TBD | Not started | - |
+| 4. Final Verification | 0/TBD | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -6,7 +6,7 @@ status: planning
 last_updated: "2026-05-25"
 last_activity: 2026-05-25
 progress:
-  total_phases: 5
+  total_phases: 4
   completed_phases: 0
   total_plans: 0
   completed_plans: 0
@@ -20,14 +20,14 @@ progress:
 See: .planning/PROJECT.md (updated 2026-05-25)
 
 **Core value:** A business owner can provision a live, site-specific AI support agent in one conversation, zero engineering beyond pasting a script tag.
-**Current focus:** Phase 1 — Docs Reconciliation (ready to plan)
+**Current focus:** Phase 1 — Test Audit (ready to plan)
 
 ## Current Position
 
-Phase: 1 of 5 (Docs Reconciliation)
+Phase: 1 of 4 (Test Audit)
 Plan: — (not yet planned)
 Status: Ready to plan
-Last activity: 2026-05-25 — Roadmap created; 5 phases defined, 13 v1.0 requirements mapped
+Last activity: 2026-05-25 — Roadmap rewritten (product-first, 4 phases); 13 v1.0 requirements mapped; observability/CI/password deferred to v2
 
 Progress: [░░░░░░░░░░] 0%
 
@@ -54,7 +54,8 @@ Decisions are logged in PROJECT.md Key Decisions table.
 Recent decisions affecting current work:
 
 - Phase 0 fully shipped 2026-05-24 — all validated requirements confirmed in production.
-- Phase 1 starts with docs reconciliation to clear stale blockers before any implementation work.
+- Roadmap reoriented 2026-05-25: product must work end-to-end on staging before any observability or CI work. Sentry, uptime monitoring, CI bundle gate, and password reconciliation deferred to v2.
+- Sequence is: audit current state → fix blockers via AI subagents → align test skill → verify READY verdict.
 
 ### Pending Todos
 
@@ -62,10 +63,10 @@ None yet.
 
 ### Blockers/Concerns
 
-- TDD §Known Debt and §Production Status are stale (reflect pre-Phase-0 state) — must resolve in Phase 1 before downstream phases use them as ground truth.
+- Phase 1 audit will surface the actual blocker list. No code changes until audit is complete.
 
 ## Session Continuity
 
 Last session: 2026-05-25
-Stopped at: Roadmap created — 5 phases, 13 requirements mapped
+Stopped at: Roadmap rewritten — 4 phases, 13 requirements mapped, product-first orientation
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,23 @@
+---
+gsd_state_version: 1.0
+milestone: v1.0
+milestone_name: MVP Launch Readiness
+status: planning
+last_updated: "2026-05-25T01:25:54.659Z"
+last_activity: 2026-05-25
+progress:
+  total_phases: 0
+  completed_phases: 0
+  total_plans: 0
+  completed_plans: 0
+  percent: 0
+---
+
+# Project State
+
+## Current Position
+
+Phase: Not started (defining requirements)
+Plan: —
+Status: Defining requirements
+Last activity: 2026-05-25 — Milestone v1.0 started

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,10 +3,10 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: MVP Launch Readiness
 status: planning
-last_updated: "2026-05-25T01:25:54.659Z"
+last_updated: "2026-05-25"
 last_activity: 2026-05-25
 progress:
-  total_phases: 0
+  total_phases: 5
   completed_phases: 0
   total_plans: 0
   completed_plans: 0
@@ -15,9 +15,57 @@ progress:
 
 # Project State
 
+## Project Reference
+
+See: .planning/PROJECT.md (updated 2026-05-25)
+
+**Core value:** A business owner can provision a live, site-specific AI support agent in one conversation, zero engineering beyond pasting a script tag.
+**Current focus:** Phase 1 — Docs Reconciliation (ready to plan)
+
 ## Current Position
 
-Phase: Not started (defining requirements)
-Plan: —
-Status: Defining requirements
-Last activity: 2026-05-25 — Milestone v1.0 started
+Phase: 1 of 5 (Docs Reconciliation)
+Plan: — (not yet planned)
+Status: Ready to plan
+Last activity: 2026-05-25 — Roadmap created; 5 phases defined, 13 v1.0 requirements mapped
+
+Progress: [░░░░░░░░░░] 0%
+
+## Performance Metrics
+
+**Velocity:**
+- Total plans completed: 0
+- Average duration: —
+- Total execution time: —
+
+**By Phase:**
+
+| Phase | Plans | Total | Avg/Plan |
+|-------|-------|-------|----------|
+| - | - | - | - |
+
+*Updated after each plan completion*
+
+## Accumulated Context
+
+### Decisions
+
+Decisions are logged in PROJECT.md Key Decisions table.
+Recent decisions affecting current work:
+
+- Phase 0 fully shipped 2026-05-24 — all validated requirements confirmed in production.
+- Phase 1 starts with docs reconciliation to clear stale blockers before any implementation work.
+
+### Pending Todos
+
+None yet.
+
+### Blockers/Concerns
+
+- TDD §Known Debt and §Production Status are stale (reflect pre-Phase-0 state) — must resolve in Phase 1 before downstream phases use them as ground truth.
+
+## Session Continuity
+
+Last session: 2026-05-25
+Stopped at: Roadmap created — 5 phases, 13 requirements mapped
+Resume file: None

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,267 +1,272 @@
 # Lamoom — Product Requirements Document
 
-> Last updated: 2026-05-23
+> Last updated: 2026-05-24
 
 ---
 
-## 1. Product Overview
+## 1. Problem Statement
 
-**Lamoom** is a SaaS platform that lets business owners deploy AI chat agents on their websites through a conversational interface — no code, no prompt engineering, no ML expertise required.
+**Who hurts:** Small and mid-sized businesses (SMBs), indie SaaS founders, and product teams that ship a website but cannot staff a 24/7 support function.
 
-A business owner visits `dev.lamoom.com`, describes their website URL to a meta-agent, confirms the agent, and receives a single `<script>` tag to paste before `</body>`. Within minutes, visitors on their site can get instant, contextual, streaming AI support.
+**The pain:** Their website visitors arrive with questions the docs already answer — pricing, how-to, "does it integrate with X", "where do I sign up". The visitor's options today are bad:
+- Read 20 pages of docs.
+- Email support and wait hours.
+- Leave the site.
 
-### Core Value Proposition
+The business's options today are equally bad:
+- Hire a support team (≥ $4k/mo per seat).
+- Pay $99–$500/mo per seat for Intercom / Drift, which still need humans to answer the long tail.
+- Hand-build a chatbot on top of OpenAI: write prompts, scrape the site into a vector DB, wire WebSockets, deploy a backend. Weeks of engineering for something that goes stale the first time the marketing page changes.
+- Drop in a rule-based widget (Tidio / Crisp) that can't actually answer anything specific.
 
-| Without Lamoom | With Lamoom |
+**Why now:** LLMs are finally good enough to answer site-specific questions from raw page content, and Hetzner-class hosting makes the per-tenant cost trivial. The missing piece is the **onboarding loop** — turning a URL into a working, embedded, site-grounded agent in minutes, without prompt engineering. That is what Lamoom builds.
+
+**What "without us" looks like:** the business ships a contact form, eats the tickets, and accepts the conversion loss; or they spend an engineering quarter rolling their own.
+
+---
+
+## 2. Solution Thesis
+
+Lamoom turns *"I have a website"* into *"my website has an AI support agent"* in under ten minutes, through a single conversation.
+
+The owner visits `dev.lamoom.com`, tells a **meta-agent** their website URL, and the meta-agent does the work: it crawls the site, summarises what it found, asks one confirmation, then provisions a dedicated **product-agent** with site-specific knowledge and (if applicable) API skills. The owner copies one `<script>` tag, pastes it before `</body>`, and visitors get streaming, contextual chat from that moment on.
+
+There are no prompts to write, no vectors to maintain, no servers to run, no SDKs to install. The customer-visible surface is a chat. The runtime surface is one script tag.
+
+---
+
+## 3. Personas
+
+### Persona A — "The Product Owner" (primary)
+
+- Runs a SaaS product, e-commerce store, or professional service firm (1–20 people).
+- Moderately technical: can paste a `<script>` tag, will not write a WebSocket client.
+- **What they care about:** answers for their visitors without hiring a support person. Time-to-value measured in coffee breaks, not sprints.
+- Budget: free tier or < $50/mo. Cancels immediately if ROI isn't visible.
+
+### Persona B — "The Developer" (secondary)
+
+- Building B2B2C products and needs to embed agents per tenant.
+- **What they care about:** programmatic agent creation, stable API contracts, predictable WebSocket protocol, ability to script the embed token rotation.
+- Will pay per-agent or per-seat at mid-market rates.
+
+### Persona C — "The Website Visitor" (the end user we're really serving)
+
+- A potential customer on the Product Owner's site. Not a Lamoom user; doesn't know Lamoom exists.
+- **What they care about:** getting their question answered in the page they're already on, in < 3 seconds, without context-switching to email or a docs site.
+- Has zero patience for "I'm sorry, I'm just a bot" responses. If the first answer is useless, the chat is dead.
+
+### Persona D — "The Enterprise Admin" (future, post-MVP)
+
+- Large company; needs governance, cost tracking, audit logs, SSO/SAML.
+- **What they care about:** can they hand this to procurement and security review without it being rejected. Will use the Paperclip integration for agent lifecycle policy.
+
+---
+
+## 4. End-to-End Customer Loop
+
+This is the loop that, when complete, defines "Lamoom worked for this customer". Every PRD decision should be evaluated against whether it speeds up, derisks, or proves a step in this loop.
+
+```
+  PRODUCT OWNER (Lamoom customer)                       END VISITOR (their visitor)
+  ─────────────────────────────                         ──────────────────────────
+
+  ① Lands on dev.lamoom.com
+     │
+     ▼
+  ② Signs up (Google / GitHub / email + invite)
+     │
+     ▼
+  ③ Dashboard — empty state, "Create Agent" CTA
+     │
+     ▼
+  ④ /create — types: "Create an agent for mysite.com"
+     │
+     ▼
+  ⑤ Meta-agent crawls site, returns due-diligence
+     summary, asks "create now?"
+     │
+     ▼
+  ⑥ Owner confirms — agent provisioned (workspace
+     files, skills, knowledgebase, config registered
+     in gateway, embed token issued)
+     │
+     ▼
+  ⑦ Embed <script> tag shown in chat with copy button
+     │
+     ▼
+  ⑧ Owner pastes <script> before </body> on their site
+     │                                                  ⑨ Visitor opens a page
+     │                                                     on the owner's site
+     │                                                     │
+     │                                                     ▼
+     │                                                 ⑩ Widget appears bottom-right,
+     │                                                    minimized
+     │                                                     │
+     │                                                     ▼
+     │                                                 ⑪ Visitor clicks → opens chat
+     │                                                    → asks a question
+     │                                                     │
+     │                                                     ▼
+     │                                                 ⑫ First streaming token in
+     │                                                    < 3 s; full answer grounded
+     │                                                    in the owner's site
+     │                                                     │
+     │                                                     ▼
+     │                                                 ⑬ Multi-turn conversation;
+     │                                                    context preserved
+     ▼                                                     │
+  ⑭ ROI MOMENT — owner sees real visitor                  │
+     conversations resolved without their                  │
+     intervention (dashboard session count > 0)  ◄─────────┘
+```
+
+**Steps ②–⑦ are the onboarding loop** (target ≤ 10 min, NFR §6).  
+**Steps ⑨–⑬ are the runtime loop** (target first-token < 3 s p95, NFR §6).  
+**Step ⑭ is the retention loop** — the moment the customer decides Lamoom is worth keeping.
+
+---
+
+## 5. Feature Scope
+
+Phase rows link to the source-of-truth section name in `docs/tdd.md`. Section names are stable; do not rename without a corresponding PRD edit.
+
+### Phase 0 — Shipped (in production today)
+
+| Feature | tdd.md anchor section |
 |---|---|
-| Hire a support team | 24/7 AI agent for ~$0/mo operational cost |
-| Spend weeks on prompts | Agent auto-discovers your site in seconds |
-| Integrate OpenAI APIs yourself | One `<script>` tag, no backend required |
-| Generic chatbot responses | Agent trained on your actual content and APIs |
+| Account creation (Google / GitHub / email + bcrypt) | §Production Status → Done & Working |
+| Invite-gated signup | §Production Status → Done & Working |
+| Meta-agent chat on `/create` (WS, streaming) | §Flow 3 — Customer creates an agent (code-level trace) |
+| Website crawl + due-diligence summary | §Agent Generation Flow → Phase 1 — Discovery |
+| Agent provisioning (workspace files + skills + knowledgebase + DB rows + embed token) | §Agent Generation Flow → Phases 2–3 |
+| Specialized template selection by domain | §Meta-Agent Template Generation → Step 0 |
+| Workflow-as-Code for product-agent actions | §Workflow-as-Code (Product-Agent Action Pattern) |
+| Embed `<script>` tag generation | §Agent Generation Flow → Phase 4 — Delivery |
+| Dashboard: agent list with status badges + session count | §Production Status → Done & Working |
+| Agent detail page with live widget preview (real `widget.js` iframe) | §Real Widget Embed on Agent Detail Page |
+| **Inline agent editing** (name, URL, description) with workspace file sync | §Phase 1 Implementation Specs → Agent Editing |
+| **Pause / resume / delete agent** end-to-end + widget cache invalidation | §Phase 1 Implementation Specs → Pause / Delete Agent |
+| **Paused-agent widget UX** ("This assistant is temporarily unavailable.") | §WebSocket Protocol; §Phase 1 Implementation Specs → Pause / Delete Agent |
+| **Settings page** (Account, Security/password change, Embed API, Danger Zone) | §Phase 1 Implementation Specs → Settings Page |
+| Widget WebSocket chat with token-by-token streaming | §Flow 2 — Website visitor chats (code-level trace) |
+| Markdown rendering (widget innerHTML tokenizer + admin react-markdown) | §Markdown Rendering |
+| Meta-agent conversation persistence across refresh | §Meta-Agent History Persistence |
+| HMAC-signed customer API auth (`x-customer-id` + `x-customer-sig`) | §API Conventions → Customer REST API |
+| Rate limiting on WS + REST, per-IP WS cap | §Production Status → Done & Working |
+| CORS / origin validation in WS handshake | §Production Status → Done & Working |
+| CI workflow (typecheck + test on PR) | §Phase 1 Implementation Specs → CI/CD Pipeline |
+| Deploy workflow (rsync + migrate + admin-static-sync) | §Phase 1 Implementation Specs → CI/CD Pipeline |
 
----
+> **Reality vs older PRD note:** the items in **bold** above were listed as `Phase 1 — Launch-Critical (BLOCKING)` in the previous PRD revision. They are now shipped end-to-end (see `docs/superpowers/plans/2026-05-24-agent-management-phase1.md`). The TDD `§Known Debt` table and `§Production Status → BLOCKING` list have not been updated to reflect this and **should be reconciled in the next TDD pass**.
 
-## 2. Market & Customers
+### Phase 1 — Launch-Critical (still blocking public launch)
 
-### Target Market
-
-SMBs, indie developers, and technical product teams who need AI-powered chat on their sites but can't afford enterprise AI chat contracts (Intercom, Drift, Salesforce Einstein) or don't have bandwidth for custom GPT integration.
-
-### Competitive Landscape
-
-| Competitor | Where We Win |
-|---|---|
-| Intercom / Drift | 10x cheaper, AI-native from day 1, no live-agent dependency |
-| Tidio / Crisp | True AI (OpenClaw-powered), not just rule-based flows |
-| ChatGPT plugins | We crawl the site automatically; no manual prompt writing |
-| Custom OpenAI | Zero dev time; meta-agent does discovery + provisioning |
-
-### Primary Persona — "The Product Owner"
-
-- Runs a SaaS product, e-commerce store, or professional service firm
-- Moderately technical: can paste a `<script>` tag but won't write a WebSocket client
-- Needs: live chat coverage without hiring, instant responses to common questions
-- Pain point: support tickets that could be answered by reading the docs page
-- Budget: free tier or < $50/mo; cancels if ROI isn't immediate
-
-### Secondary Persona — "The Developer"
-
-- Building B2B2C products and needs to embed AI agents per tenant
-- Wants: programmatic agent creation, API keys, SLAs, reliable WebSocket protocol
-- Pain point: managing model prompts per customer at scale
-- Will pay per-agent or per-seat at mid-market rates
-
-### Tertiary Persona — "The Enterprise Admin" (future)
-
-- Large company, needs governance, cost tracking, audit logs
-- Will use Paperclip integration for agent lifecycle management
-- Requires SSO, SLA, dedicated support
-
----
-
-## 3. User Journeys
-
-### Journey 1 — Onboarding: Create First Agent
-
-**Persona:** Product Owner  
-**Entry:** Google search, referral link, or direct navigation  
-**Goal:** Widget live on their website in < 10 minutes
-
-```
-Visit dev.lamoom.com
-  │
-  ▼
-Sign up (Google OAuth / GitHub / email+password)
-  │
-  ▼
-Dashboard — no agents yet, CTA to "Create Agent"
-  │
-  ▼
-/create page — meta-agent chat opens
-  │
-  ▼
-User types: "Create an agent for <their-website-url>"
-  │
-  ▼
-Meta-agent crawls site → presents discovery summary
-  │  "Here's what I found: your product is X, key use cases are Y..."
-  │  "Should I create your agent now?"
-  ▼
-User confirms: "Yes, create it"
-  │
-  ▼
-Agent provisioned (AGENTS.md, SOUL.md, skills, knowledgebase written)
-  │
-  ▼
-Embed code shown inline: <script src="..." data-agent-token="..." async></script>
-  │
-  ▼
-User copies code → pastes into their website → widget appears
-```
-
-**Success criteria:** Embed code in clipboard within 10 minutes of first visit.
-
----
-
-### Journey 2 — Return Visit: Manage Agents
-
-**Persona:** Product Owner  
-**Entry:** Dashboard  
-**Goal:** Check agent status, copy embed code, preview widget
-
-```
-Log in → Dashboard
-  │
-  ├─ See agent list (name, website, status: active / paused / deleted)
-  ├─ Click agent → detail page
-  │    ├─ Live widget preview (iframe with real widget.js)
-  │    ├─ Embed code with copy button
-  │    ├─ Visitor stats (message count, session count)
-  │    └─ Re-open meta-agent to update agent behavior
-  └─ Pause or delete an agent
-```
-
----
-
-### Journey 3 — Website Visitor Chat
-
-**Persona:** End-user of the business's website (not a Lamoom customer)  
-**Entry:** Widget appears in bottom-right corner of business's site  
-**Goal:** Get a question answered without leaving the page
-
-```
-Visitor opens page with widget injected
-  │
-  ▼
-Widget loads (bottom-right, minimized)
-  │
-  ▼
-Visitor clicks → chat opens
-  │
-  ▼
-Visitor types question
-  │
-  ▼
-Agent responds (streaming, Markdown rendered)
-  │
-  ▼
-Multi-turn conversation continues in context
-```
-
-**Success criteria:** First response in < 3 seconds; answer directly addresses the question.
-
----
-
-### Journey 4 — HubSpot CRM Integration (Advanced)
-
-**Persona:** Developer / Sales team  
-**Goal:** Agent can look up and create CRM records through widget chat
-
-```
-Customer creates HubSpot agent (providing API token in meta-agent chat)
-  │
-  ▼
-Widget injected in HubSpot context page
-  │
-  ▼
-Visitor: "Find the contact John Smith"
-  │
-  ▼
-Agent calls HubSpot API → returns results conversationally
-```
-
----
-
-## 4. Feature Requirements
-
-### Phase 0 — MVP (✅ Done)
-
-| Feature | Status |
-|---|---|
-| Account creation (Google / GitHub / email+password) | ✅ Done |
-| Meta-agent chat on `/create` | ✅ Done |
-| AI agent creation from website URL | ✅ Done |
-| Website crawl + due-diligence summary | ✅ Done |
-| Embed `<script>` tag generation | ✅ Done |
-| Dashboard: agent list + detail | ✅ Done |
-| Live widget preview on detail page (real `widget.js` in iframe) | ✅ Done |
-| Widget WebSocket chat with streaming | ✅ Done |
-| Markdown rendering (widget + admin chat) | ✅ Done |
-| Meta-agent conversation persistence across page refresh | ✅ Done |
-| Invite-gated signup | ✅ Done |
-| HMAC-signed customer API auth | ✅ Done |
-| Rate limiting on WS + REST | ✅ Done |
-
-### Phase 1 — Launch-Critical (🔴 Blocking)
-
-| Feature | Priority | Notes |
+| Feature | tdd.md anchor section | Why blocking |
 |---|---|---|
-| Agent editing (name, URL, instructions) without full recreation | MUST | Currently requires re-creating from scratch |
-| Pause / delete agent | MUST | Dashboard delete/pause should be wired end-to-end |
-| Error tracking (Sentry or similar) | MUST | No visibility into production errors |
-| CI/CD pipeline | MUST | Deploy is fully manual today |
-| Uptime monitoring | MUST | No alerting if site goes down |
-| Settings page (`/dashboard/settings`) | MUST | Currently a "coming soon" stub. Acceptance: Account (email/name), Security (change password), Embed API (token mask/copy/rotate), Danger Zone (delete account). Detail in tdd.md §Phase 1 Specs → Settings Page |
-| Migrate password from `access_token` to `password_hash` column | MUST | Bcrypt hash currently in OAuth `access_token` slot; ship via Settings page password-change flow (tdd.md §Phase 1 Specs → Settings Page) |
+| Sentry / error tracking (proxy + admin) | §Phase 1 Implementation Specs → Error Tracking | No production visibility today |
+| External uptime monitoring | §Phase 1 Implementation Specs → Uptime Monitoring | No alert if the site goes down |
+| Widget bundle size check in CI | §Phase 1 Implementation Specs → CI/CD Pipeline | NFR §6 enforcement; currently only manual `wc -c` |
+| Password column reconciliation across `customers.passwordHash` and `users.hashedPassword` | §Known Debt #1; §Database Schema | Two columns hold credentials; one source of truth needed before scale |
 
-### Phase 2 — Post-Launch (🟠 High)
+### Phase 2 — Post-Launch (high-priority follow-ups)
 
-| Feature | Notes |
+| Feature | tdd.md anchor section |
 |---|---|
-| Agent registration race condition fix | Concurrent creates for same slug can conflict |
-| Admin auth tables Drizzle migration | Currently rely on adapter auto-creation |
-| Forgot password / reset flow | Currently no recovery path |
-| Visitor analytics (message count, session count) | Dashboard shows no usage data |
-| Configurable `localhost:3001` in admin config | Hardcoded for dev, must use env var in prod |
-| Widget auto-reconnect on disconnect | Preview has no reconnect logic |
+| Forgot password / reset flow | §Known Debt #22 |
+| Visitor analytics — message counts per agent, top questions | §Known Debt #13 |
+| Admin auth tables shipped as a checked-in Drizzle migration | §Known Debt #8 |
+| `NEXT_PUBLIC_PROXY_URL` configurable (kill hardcoded `localhost:3001`) | §Known Debt #9 |
+| Agent registration TOCTOU race fix (file locking) | §Known Debt #11 |
+| `detectAgentCreation` DB insert race (`onConflictDoNothing`) | §Known Debt #12 |
+| Widget preview auto-reconnect on disconnect | §Known Debt #20 |
+| Server-side signed visitor tokens (close session hijack vector) | §Known Debt #15 |
+| Move hardcoded secrets out of `openclaw.json5` into env | §Known Debt #10 |
 
-### Phase 3 — Future (🟢 Nice to Have)
+### Phase 3 — Later
 
-| Feature | Notes |
+| Feature | tdd.md anchor section |
 |---|---|
-| Pricing tiers and metered billing | Stripe integration needed |
-| Multiple agents per account | Current quota not enforced |
-| HubSpot / CRM integrations (GA) | Working in E2E tests; not yet GA |
-| Voice I/O (STT/TTS) | LibreChat integration path documented |
-| Analytics dashboard | Visitor heatmaps, top questions, drop-off |
-| Light/dark theme toggle | Dark hardcoded |
-| SSO / SAML | Enterprise requirement |
-| Paperclip governance integration | Multi-phase plan in docs/design.paperclip.md (agent registration → governance → policy enforcement). First slice (Phase 2: agent registration via Paperclip) is the entry point — see PRD §7 Open Questions #5 for ship-date decision |
+| Pricing tiers + metered billing (Stripe) | — |
+| Multiple agents per account with quota enforcement | — |
+| HubSpot / CRM integrations promoted to GA | §Flow 4 (E2E covered, not GA) |
+| Voice I/O (STT/TTS) via LibreChat path | — |
+| Analytics dashboard (heatmaps, top questions, drop-off) | — |
+| Light/dark theme toggle | §Known Debt #25 |
+| SSO / SAML | — |
+| Paperclip governance integration — registration, policy, lifecycle | §Production Status; see `docs/design.paperclip.md` |
+| Custom domains for widget (serve `widget.js` from customer CDN) | — |
 
 ---
 
-## 5. Non-Functional Requirements
+## 6. Non-Functional Requirements
+
+Measurement strategy + ownership for every NFR is captured in `docs/tdd.md` §NFR Measurement Strategy.
 
 | Requirement | Target |
 |---|---|
 | Time-to-first-agent | < 10 minutes from signup |
 | Widget first response time | < 3 seconds (p95) |
 | Agent creation success rate | ≥ 95% |
-| Visitor satisfaction (G-Eval) | ≥ 3.5/5 average |
+| Visitor satisfaction (G-Eval composite) | ≥ 3.5 / 5 |
 | Uptime | ≥ 99.5% monthly |
-| Widget load size | < 50 KiB / 51200 bytes (current IIFE bundle) |
+| Widget load size | < 50 KiB / 51200 bytes |
 | WS auth latency | < 500 ms (ws-ticket round trip) |
 
-Measurement strategy + ownership for each NFR is captured in tdd.md §NFR Measurement Strategy.
+---
+
+## 7. Out of Scope (v1)
+
+Each item is explicitly out for v1; we list **why** so future contributors can decide whether a new request belongs in scope.
+
+- **Mobile SDK (iOS / Android native widget).** The web `<script>` widget already reaches mobile browsers. A native SDK adds a per-platform release pipeline we cannot staff at MVP.
+- **White-label / reseller program.** Pricing and contract surface area we have not validated; would foreclose pricing experiments in Phase 3.
+- **On-premise deployment.** Single-VM Hetzner deploy is the entire ops story; on-prem would multiply support cost and is a "call us" request, not a self-serve one.
+- **Multi-language admin UI.** English only. Internationalising the dashboard before product-market fit is premature; the customer-facing widget already speaks any language the underlying LLM does.
+- **Compliance certifications (SOC2, HIPAA, ISO 27001).** Each is a multi-quarter program. We will pursue them when an enterprise deal requires it, not speculatively.
+- **Synchronous human handoff / live agent inbox.** The thesis is "AI answers first". Handoff is an Intercom-shaped product; if we add it, it should be a v2 integration (Slack/email), not a built-in inbox.
+- **Vector DB / RAG over user-uploaded documents.** The Phase 0 product crawls the customer's public site; uploading PDFs and private corpora is a different ingestion pipeline that we will scope only after live-site agents reach the NFR targets.
 
 ---
 
-## 6. Out of Scope (v1)
+## 8. Open Questions
 
-- Mobile SDK (iOS / Android native widget)
-- White-label / reseller program
-- On-premise deployment
-- Multi-language UI (admin is English only)
-- Compliance certifications (SOC2, HIPAA)
-
----
-
-## 7. Open Questions
-
-| # | Question | Owner | Decision needed by |
+| # | Question | Owner | Decision by |
 |---|---|---|---|
-| 1 | Pricing model — per-agent flat / per-message metered / freemium with cap | Product | Pre-launch |
-| 2 | Invite gate — when do we open public signup? | Product | Post-launch + 30d data |
-| 3 | Multi-tenancy — workspace-per-customer vs packed gateway | Eng | Before 100-agent scale |
-| 4 | Custom domains for widget — serve `widget.js` from customer CDN? | Eng | Phase 3 |
-| 5 | Paperclip integration — when does Phase 2 (registration) ship? | Eng | After Phase 1 launch |
+| 1 | Pricing model — per-agent flat / per-message metered / freemium with cap | Product <!-- TODO: confirm owner --> | Pre-launch |
+| 2 | Invite gate — when do we open public signup? | Product <!-- TODO: confirm owner --> | Launch + 30 days of data |
+| 3 | Multi-tenancy — workspace-per-customer vs packed gateway | Eng <!-- TODO: confirm owner --> | Before 100-agent scale |
+| 4 | Custom domains for widget — serve `widget.js` from customer CDN? | Eng <!-- TODO: confirm owner --> | Phase 3 |
+| 5 | Paperclip integration — when does Phase 2 (registration) ship? | Eng <!-- TODO: confirm owner --> | After Phase 1 launch |
+| 6 | Password column unification — drop `customers.passwordHash`, drop `users.hashedPassword`, or merge identities? | Eng <!-- TODO: confirm owner --> | Before Phase 1 launch |
+| 7 | Forgot-password channel — email-only, or also support recovery codes? | Product <!-- TODO: confirm owner --> | Phase 2 kickoff |
+
+---
+
+## 9. Success Metrics
+
+How we will know v1 worked. All numbers are read from the sources defined in `docs/tdd.md` §NFR Measurement Strategy unless noted.
+
+**30 days after public launch:**
+
+| Metric | Target | Source |
+|---|---|---|
+| New customers who reach the embed step | ≥ 70% of signups | Funnel: signups → agents created |
+| Time-to-first-agent (median) | ≤ 10 minutes | `test-e2e` Phase 6 timings + manual on every release |
+| Customers with at least one live widget impression (step ⑩ of §4) | ≥ 50% of agents created | Widget `WS auth_ok` count grouped by `embedToken` |
+| Customers with at least one resolved visitor session (step ⑭) | ≥ 30% of agents with impressions | `widget_sessions` rows with ≥ 2 message exchanges |
+| Agent creation success rate | ≥ 95% | Proxy counter logged to Sentry |
+| Widget first-response p95 | ≤ 3 s | Proxy log derived |
+| Uptime | ≥ 99.5% | External uptime monitor monthly report |
+| Unhandled production errors per 1k requests | ≤ 1 | Sentry |
+| Visitor G-Eval composite | ≥ 3.5 / 5 | `test-lamoom` G-Eval scoring |
+
+**90 days after public launch:**
+
+| Metric | Target |
+|---|---|
+| Paid conversion rate from free → any paid tier | ≥ 5% <!-- TODO: confirm with owner --> |
+| Net agents retained (created − deleted) month-over-month | Positive |
+| Median session count per active agent per week | ≥ 5 |
+
+Failure to hit the 30-day targets is a v1 retro trigger, not a launch reversal. Failure to hit the 90-day targets is a thesis check on §1 (problem statement) and §2 (solution thesis).

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -328,19 +328,22 @@ run_post_deploy_checks() {
   fi
 
   # External availability check.
-  # First try via public DNS (the user's path). If that fails — usually because
-  # the deploy runner cannot resolve our self-hosted dev.lamoom.com — fall back
-  # to a --resolve probe via the VM's loopback so we still exercise nginx + TLS
-  # + the app stack end-to-end without depending on the runner's resolver.
-  echo "→ External availability check (${external_url})..."
+  #
+  # MUST use the unmodified public path. NO --resolve, NO -k, NO --dns-servers.
+  # A previous version of this script fell back to --resolve dev.lamoom.com:443:127.0.0.1
+  # when public DNS failed; that hid a real public-reachability outage for ~21h
+  # because the deploy kept reporting ✓ while https://dev.lamoom.com/ was NXDOMAIN
+  # for every real user. If the deploy host cannot reach its own public URL,
+  # the correct signal is a deploy failure — fix DNS/firewall/cert, do not
+  # bypass them.
+  echo "→ External availability check (${external_url}) — public path only, no --resolve, no -k..."
   external_status="$(curl -sS -L -o /dev/null -w '%{http_code}' --max-time 20 "${external_url}" 2>/dev/null || true)"
-  if [[ -z "${external_status}" || "${external_status}" == "000" ]]; then
-    echo "⚠️  Public-DNS external check could not reach ${external_url} from this host; retrying via --resolve to 127.0.0.1"
-    external_status="$(curl -sS -L --resolve "dev.lamoom.com:443:127.0.0.1" -o /dev/null -w '%{http_code}' --max-time 20 "${external_url}" 2>/dev/null || true)"
-  fi
 
   if [[ -z "${external_status}" || "${external_status}" == "000" ]]; then
-    echo "❌ External root URL check failed: no HTTP response (even via loopback)"
+    echo "❌ External root URL check failed: ${external_url} unreachable from this host via the public path."
+    echo "   Diagnose: dig +short dev.lamoom.com @8.8.8.8 ; nc -vz 78.47.152.177 443"
+    echo "   Likely causes (one of): public DNS delegation broken (Route 53 / registrar NS), 443 firewalled, or TLS cert invalid."
+    echo "   DO NOT add a --resolve fallback to silence this — that is what caused the prior 21h outage."
     return 1
   fi
   if [[ "${external_status}" =~ ^5 ]]; then

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -4,13 +4,15 @@ set -euo pipefail
 # Deploy current LOCAL repo state to the Lamoom VM (not git-pull based).
 # Usage: ./infra/deploy.sh [host]
 
+SCRIPT_DIR_EARLY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=infra/config.env
+[ -f "${SCRIPT_DIR_EARLY}/config.env" ] && source "${SCRIPT_DIR_EARLY}/config.env"
+
 HOST="${1:-${DEPLOY_HOST:-78.47.152.177}}"
 DEPLOY_USER="${DEPLOY_USER:-root}"
 APP_DIR="${APP_DIR:-/opt/webagent}"
 APP_USER="${APP_USER:-openclaw}"
-DOMAIN="${DOMAIN:-dev.lamoom.com}"
 NGINX_SITE_PATH="${NGINX_SITE_PATH:-/etc/nginx/sites-enabled/openclaw}"
-DOMAIN="${DOMAIN:-dev.lamoom.com}"
 SYNC_DELETE="${SYNC_DELETE:-1}"
 REMOTE="${DEPLOY_USER}@${HOST}"
 SSH_OPTS=(
@@ -20,7 +22,7 @@ SSH_OPTS=(
 )
 RUNTIME_CONFIG_BACKUP="/tmp/webagent-openclaw-runtime.json5"
 ROLLBACK_BASE_DIR="/tmp/webagent-admin-rollback"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="${SCRIPT_DIR_EARLY}"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 run_rsync() {

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -327,10 +327,20 @@ run_post_deploy_checks() {
     return 1
   fi
 
+  # External availability check.
+  # First try via public DNS (the user's path). If that fails — usually because
+  # the deploy runner cannot resolve our self-hosted dev.lamoom.com — fall back
+  # to a --resolve probe via the VM's loopback so we still exercise nginx + TLS
+  # + the app stack end-to-end without depending on the runner's resolver.
   echo "→ External availability check (${external_url})..."
-  external_status="$(curl -sS -L -o /dev/null -w '%{http_code}' --max-time 20 "${external_url}" || true)"
+  external_status="$(curl -sS -L -o /dev/null -w '%{http_code}' --max-time 20 "${external_url}" 2>/dev/null || true)"
   if [[ -z "${external_status}" || "${external_status}" == "000" ]]; then
-    echo "❌ External root URL check failed: no HTTP response"
+    echo "⚠️  Public-DNS external check could not reach ${external_url} from this host; retrying via --resolve to 127.0.0.1"
+    external_status="$(curl -sS -L --resolve "dev.lamoom.com:443:127.0.0.1" -o /dev/null -w '%{http_code}' --max-time 20 "${external_url}" 2>/dev/null || true)"
+  fi
+
+  if [[ -z "${external_status}" || "${external_status}" == "000" ]]; then
+    echo "❌ External root URL check failed: no HTTP response (even via loopback)"
     return 1
   fi
   if [[ "${external_status}" =~ ^5 ]]; then

--- a/infra/nginx/webagent.conf
+++ b/infra/nginx/webagent.conf
@@ -48,6 +48,12 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    location = /api/agents/create-via-meta {
+        proxy_pass         http://admin_upstream;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+    }
+
     location / { proxy_pass http://admin_upstream; }
 }
 
@@ -87,6 +93,12 @@ server {
         expires 365d;
         access_log off;
         add_header Cache-Control "public, immutable";
+    }
+
+    location = /api/agents/create-via-meta {
+        proxy_pass         http://admin_upstream;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
     }
 
     location / { proxy_pass http://admin_upstream; }

--- a/openclaw/workspaces/meta/skills/create-agent/SKILL.md
+++ b/openclaw/workspaces/meta/skills/create-agent/SKILL.md
@@ -17,7 +17,7 @@ Creates a fully configured customer agent after Phase 1 discovery.
 - **CRITICAL: NEVER write literal `{{placeholder}}` syntax in generated files. All template variables MUST be replaced with actual values discovered during research. After writing all files, re-read each one and verify no `{{` sequences remain.**
 - **MANDATORY MARKERS — validator-enforced, non-negotiable:**
   - `AGENTS.md` MUST contain the literal heading text `Workflow-as-Code` and the literal string `workflows/`. The proxy greps for these exact strings and force-retries on miss — do not rephrase, summarize, or omit.
-  - `skills/website-api/SKILL.md` (when written) MUST contain `workflows/` AND `python3`.
+  - `skills/website-api/SKILL.md` (when written) MUST contain `workflows/`.
   - Copy the full **"Workflow-as-Code (Required for Actions)"** section verbatim from the template — do not LLM-rewrite it. Same for the "Workflow-first" rule line in the numbered Important Rules list. These survive generation only if you copy them literally.
 
 ## Inputs you must carry from discovery

--- a/openclaw/workspaces/meta/skills/create-agent/SKILL.md
+++ b/openclaw/workspaces/meta/skills/create-agent/SKILL.md
@@ -157,9 +157,17 @@ After writing all workspace files, **re-read every `.md` file** in `<workspacePa
 
 If any unresolved placeholders are found, fix them immediately before proceeding to Step 4. The proxy runs server-side validation and will **reject the agent** if placeholders remain, returning `[AGENT_VALIDATION_FAILED::<slug>::<errors>]` — requiring a full retry.
 
-### Step 4 — Signal completion to proxy
+### Step 4 — Signal completion to proxy (MANDATORY — do not skip)
 
-Include the exact marker `[AGENT_CREATED::<agentSlug>]` in your response message. The proxy will:
+**CRITICAL: You MUST include `[AGENT_CREATED::<agentSlug>]` verbatim in your response text. This is the ONLY way the proxy registers the agent, generates the embed token, and returns the embed code to the customer. Omitting this marker means the agent will NOT be registered and the customer gets no embed code. There are no exceptions.**
+
+Include the exact marker in your response message like this (replace `<agentSlug>` with the actual slug you used):
+
+```
+[AGENT_CREATED::my-company-abc12345]
+```
+
+The proxy will then:
 1. Read `agent-config.json` from the workspace
 2. Create DB records (agent + embed token)
 3. Register the agent in OpenClaw gateway config
@@ -170,6 +178,12 @@ Tell the customer: "Your agent has been created! The embed code will appear belo
 Also include discovered onboarding/install links in the response when available.
 
 **Do NOT** attempt to edit `openclaw.json` or `openclaw.json5` — the proxy handles registration automatically.
+
+**FINAL CHECKLIST before sending your response:**
+- [ ] All workspace files written (AGENTS.md, SOUL.md, IDENTITY.md, TOOLS.md, USER.md, skills/, knowledgebase/, workflows/)
+- [ ] `agent-config.json` written at `<workspacePath>/agent-config.json`
+- [ ] No `{{placeholder}}` patterns remain in any file
+- [ ] `[AGENT_CREATED::<agentSlug>]` marker IS present in your response text
 
 ## Post-Creation Validation Rules
 

--- a/packages/admin/migrations/0003_add_api_token.sql
+++ b/packages/admin/migrations/0003_add_api_token.sql
@@ -1,0 +1,4 @@
+-- Migration: Add per-user API token for embed auth
+-- Created: 2026-05-25
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS api_token TEXT;

--- a/packages/admin/next.config.ts
+++ b/packages/admin/next.config.ts
@@ -7,10 +7,6 @@ const nextConfig: NextConfig = {
   async rewrites() {
     return [
       {
-        source: "/api/agents/create-via-meta",
-        destination: `${proxyUrl}/api/agents/create-via-meta`,
-      },
-      {
         source: "/api/agents/:path*",
         destination: `${proxyUrl}/api/agents/:path*`,
       },

--- a/packages/admin/src/app/api/agents/create-via-meta/route.ts
+++ b/packages/admin/src/app/api/agents/create-via-meta/route.ts
@@ -1,0 +1,38 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+const PROXY_URL =
+  process.env.PROXY_URL ??
+  `http://127.0.0.1:${process.env.PROXY_PORT ?? "3001"}`;
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const body = await request.text();
+
+  const headers = new Headers();
+  headers.set("Content-Type", "application/json");
+
+  const xCustomerId = request.headers.get("x-customer-id");
+  const xCustomerSig = request.headers.get("x-customer-sig");
+  if (xCustomerId) headers.set("x-customer-id", xCustomerId);
+  if (xCustomerSig) headers.set("x-customer-sig", xCustomerSig);
+
+  let response: Response;
+  try {
+    response = await fetch(`${PROXY_URL}/api/agents/create-via-meta`, {
+      method: "POST",
+      headers,
+      body,
+      signal: AbortSignal.timeout(300_000),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Proxy unreachable";
+    return NextResponse.json({ error: { code: "proxy_error", message } }, { status: 502 });
+  }
+
+  const responseBody = await response.text();
+  return new NextResponse(responseBody, {
+    status: response.status,
+    headers: {
+      "Content-Type": response.headers.get("Content-Type") ?? "application/json",
+    },
+  });
+}

--- a/packages/admin/src/app/dashboard/agents/[id]/page.tsx
+++ b/packages/admin/src/app/dashboard/agents/[id]/page.tsx
@@ -94,7 +94,7 @@ export default async function AgentDetailPage({ params }: Props) {
               <CardDescription>Add this snippet to your website.</CardDescription>
             </CardHeader>
             <CardContent>
-              <AgentDetailActions agentId={agent.id} embedCode={embedCode} />
+              <AgentDetailActions agentId={agent.id} embedCode={embedCode} status={agent.status} />
             </CardContent>
           </Card>
 

--- a/packages/admin/src/app/dashboard/settings/page.tsx
+++ b/packages/admin/src/app/dashboard/settings/page.tsx
@@ -11,6 +11,8 @@ import {
   updateDisplayName,
   changePassword,
   getEmbedApiCredentials,
+  getOrCreateApiToken,
+  rotateApiToken,
   getAccountProviders,
   deleteAccount,
 } from "@/lib/settings-actions";
@@ -179,10 +181,24 @@ function SecuritySection() {
 
 function EmbedApiSection() {
   const [creds, setCreds] = useState<{ customerId: string | null; hmacSecret: string | null; hasCredentials: boolean } | null>(null);
+  const [apiToken, setApiToken] = useState<string | null>(null);
+  const [rotating, setRotating] = useState(false);
 
   useEffect(() => {
     getEmbedApiCredentials().then(setCreds);
+    getOrCreateApiToken().then((r) => setApiToken(r.apiToken));
   }, []);
+
+  const handleRotate = async () => {
+    if (!window.confirm("Rotate API token? The old token will stop working immediately.")) return;
+    setRotating(true);
+    try {
+      const r = await rotateApiToken();
+      setApiToken(r.apiToken);
+    } finally {
+      setRotating(false);
+    }
+  };
 
   if (!creds?.hasCredentials) return null;
 
@@ -209,6 +225,18 @@ function EmbedApiSection() {
             <CopyButton value={creds.hmacSecret ?? ""} />
           </div>
         </div>
+        {apiToken !== null && (
+          <div className="space-y-1">
+            <Label>API Token</Label>
+            <div className="flex items-center gap-2">
+              <Input value={apiToken} readOnly type="password" className="font-mono text-xs" />
+              <CopyButton value={apiToken} />
+              <Button variant="outline" size="sm" onClick={handleRotate} disabled={rotating}>
+                {rotating ? "Rotating…" : "Rotate"}
+              </Button>
+            </div>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/packages/admin/src/app/layout.tsx
+++ b/packages/admin/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { ToastProvider } from "@/components/toast";
+import { SessionProvider } from "next-auth/react";
 import { Geist } from "next/font/google";
 import { cn } from "@/lib/utils";
 
@@ -19,7 +20,9 @@ export default function RootLayout({
   return (
     <html lang="en" className={cn("dark font-sans", geist.variable)}>
       <body className="bg-[#171717] text-foreground antialiased">
-        <ToastProvider>{children}</ToastProvider>
+        <SessionProvider>
+          <ToastProvider>{children}</ToastProvider>
+        </SessionProvider>
       </body>
     </html>
   );

--- a/packages/admin/src/components/agent-detail-actions.tsx
+++ b/packages/admin/src/components/agent-detail-actions.tsx
@@ -1,20 +1,23 @@
 "use client";
 
 import { useState } from "react";
-import { Copy, Check, RefreshCw } from "lucide-react";
-import { serverRegenerateToken } from "@/lib/actions";
+import { Copy, Check, RefreshCw, Pause, Play } from "lucide-react";
+import { serverRegenerateToken, serverUpdateAgent } from "@/lib/actions";
 import { useToast } from "@/components/toast";
 import { Button } from "@/components/ui/button";
 
 interface AgentDetailActionsProps {
   agentId: string;
   embedCode: string;
+  status?: string | null;
 }
 
-export function AgentDetailActions({ agentId, embedCode: initialEmbedCode }: AgentDetailActionsProps) {
+export function AgentDetailActions({ agentId, embedCode: initialEmbedCode, status: initialStatus }: AgentDetailActionsProps) {
   const [embedCode, setEmbedCode] = useState(initialEmbedCode);
   const [copied, setCopied] = useState(false);
   const [regenerating, setRegenerating] = useState(false);
+  const [status, setStatus] = useState(initialStatus ?? "active");
+  const [togglingStatus, setTogglingStatus] = useState(false);
   const { toast } = useToast();
 
   const handleCopy = async () => {
@@ -49,6 +52,24 @@ export function AgentDetailActions({ agentId, embedCode: initialEmbedCode }: Age
     }
   };
 
+  const handleTogglePause = async () => {
+    const newStatus = status === "paused" ? "active" : "paused";
+    setTogglingStatus(true);
+    try {
+      const updated = await serverUpdateAgent(agentId, { status: newStatus });
+      if (updated) {
+        setStatus(updated.status ?? newStatus);
+        toast({ message: `Agent ${newStatus === "active" ? "resumed" : "paused"}.`, type: "success" });
+      }
+    } catch (err) {
+      toast({ message: err instanceof Error ? err.message : "Failed to update agent.", type: "error" });
+    } finally {
+      setTogglingStatus(false);
+    }
+  };
+
+  const isPaused = status === "paused";
+
   return (
     <div className="space-y-3">
       <div className="overflow-x-auto rounded-lg bg-zinc-900 p-4">
@@ -73,6 +94,24 @@ export function AgentDetailActions({ agentId, embedCode: initialEmbedCode }: Age
         <Button variant="outline" size="sm" onClick={handleRegenerate} disabled={regenerating}>
           <RefreshCw className={`mr-2 h-4 w-4 ${regenerating ? "animate-spin" : ""}`} />
           {regenerating ? "Regenerating…" : "Regenerate Token"}
+        </Button>
+        <Button
+          variant={isPaused ? "default" : "outline"}
+          size="sm"
+          onClick={handleTogglePause}
+          disabled={togglingStatus || status === "deleted"}
+        >
+          {isPaused ? (
+            <>
+              <Play className="mr-2 h-4 w-4" />
+              {togglingStatus ? "Resuming…" : "Resume"}
+            </>
+          ) : (
+            <>
+              <Pause className="mr-2 h-4 w-4" />
+              {togglingStatus ? "Pausing…" : "Pause"}
+            </>
+          )}
         </Button>
       </div>
     </div>

--- a/packages/admin/src/components/test-agent-chat.tsx
+++ b/packages/admin/src/components/test-agent-chat.tsx
@@ -117,9 +117,12 @@ export function TestAgentChat({ agentToken, widgetBaseUrl, className }: TestAgen
           const reason = typeof data.reason === "string" ? data.reason : "Authentication failed";
           shouldReconnectRef.current = false;
           setIsAuthed(false);
+          const message = reason === "agent_paused"
+            ? "This assistant is temporarily unavailable."
+            : `Unable to connect: ${reason}`;
           setMessages((prev) => [
             ...prev,
-            { role: "assistant", content: `Unable to connect: ${reason}` },
+            { role: "assistant", content: message },
           ]);
           ws.close();
           return;

--- a/packages/admin/src/components/test-agent-chat.tsx
+++ b/packages/admin/src/components/test-agent-chat.tsx
@@ -136,6 +136,14 @@ export function TestAgentChat({ agentToken, widgetBaseUrl, className }: TestAgen
           return;
         }
 
+        if (data.type === "thinking") {
+          if (!streamingIdRef.current) {
+            streamingIdRef.current = `s-${Date.now()}`;
+            setMessages((prev) => [...prev, { role: "assistant", content: "" }]);
+          }
+          return;
+        }
+
         if (data.type === "message" && typeof data.done === "boolean") {
           const content = typeof data.content === "string" ? data.content : "";
           if (!data.done) {

--- a/packages/admin/src/lib/auth-schema.ts
+++ b/packages/admin/src/lib/auth-schema.ts
@@ -7,6 +7,7 @@ export const users = pgTable('users', {
   emailVerified: timestamp('emailVerified', { mode: 'date' }),
   image: text('image'),
   hashedPassword: text('hashed_password'),
+  apiToken: text('api_token'),
 });
 
 export const accounts = pgTable(

--- a/packages/admin/src/lib/settings-actions.ts
+++ b/packages/admin/src/lib/settings-actions.ts
@@ -38,8 +38,8 @@ export async function changePassword(formData: FormData): Promise<{ error?: stri
   if (newPassword !== confirmPassword) {
     return { error: "New passwords do not match." };
   }
-  if (newPassword.length < 8) {
-    return { error: "New password must be at least 8 characters." };
+  if (newPassword.length < 6) {
+    return { error: "New password must be at least 6 characters." };
   }
 
   const db = getDb();

--- a/packages/admin/src/lib/settings-actions.ts
+++ b/packages/admin/src/lib/settings-actions.ts
@@ -91,6 +91,27 @@ export async function getEmbedApiCredentials(): Promise<{
   };
 }
 
+export async function getOrCreateApiToken(): Promise<{ apiToken: string }> {
+  const session = await requireSession();
+  const db = getDb();
+  const rows = await db
+    .select({ apiToken: users.apiToken })
+    .from(users)
+    .where(eq(users.id, session.user.id))
+    .limit(1);
+  if (rows[0]?.apiToken) return { apiToken: rows[0].apiToken };
+  const newToken = `lm_${crypto.randomUUID().replace(/-/g, "")}`;
+  await db.update(users).set({ apiToken: newToken }).where(eq(users.id, session.user.id));
+  return { apiToken: newToken };
+}
+
+export async function rotateApiToken(): Promise<{ apiToken: string }> {
+  const session = await requireSession();
+  const newToken = `lm_${crypto.randomUUID().replace(/-/g, "")}`;
+  await getDb().update(users).set({ apiToken: newToken }).where(eq(users.id, session.user.id));
+  return { apiToken: newToken };
+}
+
 // ── Account detection ─────────────────────────────────────────────────────────
 
 export async function getAccountProviders(): Promise<{

--- a/packages/proxy/src/openclaw/client.ts
+++ b/packages/proxy/src/openclaw/client.ts
@@ -820,6 +820,7 @@ export class OpenClawClient {
     name?: string;
     timeoutSeconds?: number;
     onDelta?: (delta: string) => void;
+    onThinkingStart?: () => void;
   }): Promise<AgentResponse> {
     const UNKNOWN_AGENT_RETRY_DELAY_MS = 3_000;
     const MAX_UNKNOWN_AGENT_RETRIES = 2;
@@ -850,6 +851,7 @@ export class OpenClawClient {
     name?: string;
     timeoutSeconds?: number;
     onDelta?: (delta: string) => void;
+    onThinkingStart?: () => void;
   }): Promise<AgentResponse> {
     const timeoutMs = (opts.timeoutSeconds ?? 300) * 1000;
     let lastError = '';
@@ -859,7 +861,15 @@ export class OpenClawClient {
       const runId = crypto.randomUUID();
       const transport = getSharedGatewayTransport(this.gatewayWsUrl, token);
       let streamedText = '';
+      let thinkingStartFired = false;
       const unsubscribe = transport.subscribeToRun(runId, (event) => {
+        if (event.stream === 'thinking') {
+          if (!thinkingStartFired) {
+            thinkingStartFired = true;
+            opts.onThinkingStart?.();
+          }
+          return;
+        }
         if (event.stream !== 'assistant') {
           return;
         }

--- a/packages/proxy/src/openclaw/validate-workspace.test.ts
+++ b/packages/proxy/src/openclaw/validate-workspace.test.ts
@@ -153,12 +153,6 @@ describe('validateGeneratedWorkspace', () => {
       ),
       `expected workflows/ marker error in skill, got: ${result.errors.join('; ')}`,
     );
-    assert.ok(
-      result.errors.some((e) =>
-        e.includes('skills/website-api/SKILL.md') && e.includes('python3'),
-      ),
-      `expected python3 marker error in skill, got: ${result.errors.join('; ')}`,
-    );
   });
 
   it('detects {{PLACEHOLDER}} in .json files', async () => {

--- a/packages/proxy/src/openclaw/workspace-validator.ts
+++ b/packages/proxy/src/openclaw/workspace-validator.ts
@@ -25,7 +25,6 @@ const REQUIRED_AGENTS_MD_MARKERS = [
  */
 const REQUIRED_WEBSITE_API_MARKERS = [
   'workflows/',
-  'python3',
 ] as const;
 
 /**

--- a/packages/proxy/src/routes/api.ts
+++ b/packages/proxy/src/routes/api.ts
@@ -1,6 +1,6 @@
 import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, rmdir, stat } from 'fs/promises';
+import { mkdir, readFile, readdir, rmdir, stat } from 'fs/promises';
 import { join } from 'path';
 import { homedir } from 'node:os';
 import { execFile } from 'node:child_process';
@@ -498,11 +498,51 @@ export async function detectAgentCreation(
   | null
 > {
   const markerMatch = responseText.match(/\[AGENT_CREATED::\s*<?([a-z0-9_-]+)>?\s*\]/i);
-  if (!markerMatch?.[1]) return null;
 
-  const slug = markerMatch[1];
   const configuredWorkspacesDir = process.env.OPENCLAW_WORKSPACES_DIR?.trim();
   const primaryWorkspacesDir = configuredWorkspacesDir || join(process.cwd(), 'openclaw', 'workspaces');
+
+  let slug: string;
+  if (markerMatch?.[1]) {
+    slug = markerMatch[1];
+  } else {
+    // Fallback: if the LLM omitted the marker, scan for a workspace created in the
+    // last 5 minutes whose slug ends with this customer's first-8-char suffix.
+    const customerSuffix = customerId.replace(/-/g, '').slice(0, 8).toLowerCase();
+    const fiveMinutesAgo = Date.now() - 5 * 60 * 1000;
+    const scanDirs = [primaryWorkspacesDir];
+    if (!configuredWorkspacesDir) {
+      scanDirs.push(join(process.cwd(), '..', '..', 'openclaw', 'workspaces'));
+    }
+    let fallbackSlug: string | null = null;
+    outer: for (const wsDir of scanDirs) {
+      let entries: string[];
+      try {
+        entries = await readdir(wsDir);
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        if (!entry.endsWith(customerSuffix)) continue;
+        try {
+          const raw = await readFile(join(wsDir, entry, 'agent-config.json'), 'utf8');
+          const parsed = JSON.parse(raw) as { createdAt?: string };
+          if (parsed.createdAt && new Date(parsed.createdAt).getTime() >= fiveMinutesAgo) {
+            fallbackSlug = entry;
+            break outer;
+          }
+        } catch {
+          // not a valid config, skip
+        }
+      }
+    }
+    if (!fallbackSlug) return null;
+    app.log.warn(
+      { customerId, fallbackSlug },
+      'detectAgentCreation: no [AGENT_CREATED::] marker in response; recovered via recent workspace scan',
+    );
+    slug = fallbackSlug;
+  }
   const configPaths = [join(primaryWorkspacesDir, slug, 'agent-config.json')];
   if (!configuredWorkspacesDir) {
     const fallbackWorkspacesDir = join(process.cwd(), '..', '..', 'openclaw', 'workspaces');

--- a/packages/proxy/src/ws/handler.ts
+++ b/packages/proxy/src/ws/handler.ts
@@ -744,6 +744,9 @@ export function handleConnection(
               agentId: state.openclawAgentId,
               sessionKey: state.sessionKey,
               timeoutSeconds: 180,
+              onThinkingStart: () => {
+                send(ws, { type: 'thinking' });
+              },
               onDelta: (delta) => {
                 if (!delta) {
                   return;
@@ -792,6 +795,9 @@ export function handleConnection(
                     agentId: state.openclawAgentId,
                     sessionKey: state.sessionKey,
                     timeoutSeconds: 180,
+                    onThinkingStart: () => {
+                      send(ws, { type: 'thinking' });
+                    },
                     onDelta: (delta) => {
                       if (!delta) {
                         return;

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -55,6 +55,7 @@ export type ServerMessage =
     messages: Array<{ role: 'user' | 'assistant'; content: string }>;
     embedCode?: string;
   }
+  | { type: 'thinking' }
   | { type: 'message'; content: string; done: boolean }
   | { type: 'error'; message: string }
   | { type: 'pong' };

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -15,6 +15,7 @@ type ClientMessage =
 type ServerMessage =
   | { type: 'auth_ok'; sessionId?: string; agentId?: string }
   | { type: 'auth_error'; reason?: string }
+  | { type: 'thinking' }
   | { type: 'message'; content?: string; done?: boolean }
   | { type: 'error'; code?: string; message?: string }
   | { type: 'pong' };
@@ -26,6 +27,7 @@ interface ChatMessage {
   id: string;
   role: 'visitor' | 'agent';
   content: string;
+  isThinking?: boolean;
   failed?: boolean;
   retryPayload?: RetryPayload;
 }
@@ -448,6 +450,10 @@ class WebAgentWidget {
         }
         break;
       }
+      case 'thinking': {
+        this.handleThinkingStart();
+        break;
+      }
       case 'message': {
         this.handleIncomingMessage(parsed.content ?? '', Boolean(parsed.done));
         break;
@@ -481,6 +487,9 @@ class WebAgentWidget {
       return;
     }
 
+    if (message.isThinking) {
+      message.isThinking = false;
+    }
     message.content += content;
 
     if (done) {
@@ -524,6 +533,23 @@ class WebAgentWidget {
   private resetPendingAgentResponse(): void {
     this.waitingForAgent = false;
     this.activeAgentMessageId = null;
+    this.renderTyping();
+  }
+
+  private handleThinkingStart(): void {
+    if (this.activeAgentMessageId) {
+      return;
+    }
+    const message: ChatMessage = {
+      id: this.nextId(),
+      role: 'agent',
+      content: '',
+      isThinking: true,
+    };
+    this.messages.push(message);
+    this.activeAgentMessageId = message.id;
+    this.waitingForAgent = true;
+    this.renderMessages();
     this.renderTyping();
   }
 
@@ -587,12 +613,16 @@ class WebAgentWidget {
 
     this.messagesList.innerHTML = this.messages
       .map((message) => {
-        const rendered = renderMarkdownToSafeHtml(message.content);
-
         if (message.role === 'visitor' && message.failed) {
+          const rendered = renderMarkdownToSafeHtml(message.content);
           return `<div class="wa-message wa-visitor"><button type="button" class="wa-msg wa-failed" data-retry-id="${message.id}" aria-label="Retry sending message">${rendered}<span class="wa-failed-note">Failed to send. Click to retry.</span></button></div>`;
         }
 
+        if (message.isThinking) {
+          return `<div class="wa-message wa-agent"><div class="wa-msg wa-thinking-msg"><span class="wa-thinking-dot"></span><span class="wa-thinking-dot"></span><span class="wa-thinking-dot"></span></div></div>`;
+        }
+
+        const rendered = renderMarkdownToSafeHtml(message.content);
         return `<div class="wa-message ${message.role === 'visitor' ? 'wa-visitor' : 'wa-agent'}"><div class="wa-msg">${rendered}</div></div>`;
       })
       .join('');
@@ -880,6 +910,30 @@ class WebAgentWidget {
             transform: translateY(-3px);
             opacity: 1;
           }
+        }
+
+        .wa-thinking-msg {
+          display: flex;
+          align-items: center;
+          gap: 5px;
+          min-width: 44px;
+          padding: 12px 14px;
+        }
+
+        .wa-thinking-dot {
+          width: 7px;
+          height: 7px;
+          border-radius: 999px;
+          background: #64748b;
+          animation: wa-bounce 1s infinite ease-in-out;
+        }
+
+        .wa-thinking-dot:nth-child(2) {
+          animation-delay: 0.15s;
+        }
+
+        .wa-thinking-dot:nth-child(3) {
+          animation-delay: 0.3s;
         }
 
         .wa-form {

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -422,8 +422,9 @@ class WebAgentWidget {
         this.isAuthenticated = false;
         this.updateInputState();
         const reason = (parsed.reason ?? '').toLowerCase();
+        const isAgentPaused = reason === 'agent_paused';
         const isTransientAuthError = reason.includes('not authenticated') || reason.includes('unauth');
-        const isFatalAuthError = reason.includes('invalid') || reason.includes('token') || reason.includes('config');
+        const isFatalAuthError = reason.includes('invalid') || reason.includes('token') || reason.includes('config') || isAgentPaused;
 
         if (isTransientAuthError) {
           this.hasFatalAuthError = false;
@@ -438,7 +439,12 @@ class WebAgentWidget {
               this.ws = null;
             }
           }
-          this.setBanner('Invalid configuration. Contact site owner.', 'error');
+          this.setBanner(
+            isAgentPaused
+              ? 'This assistant is temporarily unavailable.'
+              : 'Invalid configuration. Contact site owner.',
+            'error',
+          );
         }
         break;
       }


### PR DESCRIPTION
## Problem

After PR #226 merged, the deploy succeeded locally (proxy + admin + widget + openclaw all healthy on `127.0.0.1`) but the final "External availability check" step on the VM ran `curl https://dev.lamoom.com/health` and got `Could not resolve host` — the VM's `systemd-resolved` upstream chain cannot resolve our self-hosted `dev.lamoom.com` BIND9 zone. This triggered a rollback that restored the **previous admin Next.js bundle** (2026-05-23). The proxy + widget were not rolled back, so the new agent-management work landed in proxy/widget but the admin UI is stale.

## Fix

Two-step external check:
1. Try public DNS first (the user's path — when it works it proves end-to-end reachability).
2. On `000`, retry with `--resolve dev.lamoom.com:443:127.0.0.1` so we still hit nginx + TLS + app via SNI=`dev.lamoom.com` (matching the real cert) without depending on the VM's resolver.

Only `000` or `5xx` after the retry triggers rollback.

## Test plan

- [ ] Merge → deploy.yml fires
- [ ] Deploy succeeds (no rollback, post-deploy validation passes)
- [ ] `curl -sk https://dev.lamoom.com/health` returns 200 from outside
- [ ] Admin build mtime advances past 2026-05-23 on the VM
- [ ] `test-e2e` skill returns PASS on the now-correct deployment