### PR TITLE
fix(mvp): stabilize deploy checks and meta-agent creation flow

### DIFF
--- a/.tasks/228/STATE.md
+++ b/.tasks/228/STATE.md
@@ -1,0 +1,14 @@
+# Task 228 - STATE
+- phase: 1-done
+- issue: #228
+- started: 2026-05-26T23:18:43Z
+- supervisor: github-copilot/gpt-5.3-codex
+- mode: autopilot
+- phase: 2-done
+- phase: 3-done
+- phase: 4-done
+- phase: 4-approved (autopilot)
+- phase: 5-group-A-done
+- phase: 5b-pass
+- phase: 5c-loop-1 (deploy pass, e2e fail on meta-agent 500)
+- phase: 5c-pass

--- a/.tasks/228/STATE.md
+++ b/.tasks/228/STATE.md
@@ -12,3 +12,5 @@
 - phase: 5b-pass
 - phase: 5c-loop-1 (deploy pass, e2e fail on meta-agent 500)
 - phase: 5c-pass
+- phase: 6-ci-green
+- phase: 7-ship-recommended

--- a/.tasks/228/decisions.md
+++ b/.tasks/228/decisions.md
@@ -1,0 +1,41 @@
+# Decision Log — Task 228 (`--autopilot`)
+
+## 2026-05-26 — D1
+- question: Which issue should anchor ownership flow?
+- decision: Create new issue `#228` dedicated to deploy external-check rollback behavior.
+- reasoning: Existing open issues (`#214`, `#224`, `#225`) are broader or different incident scope; ownership flow needs single clear success metric and artifact lineage.
+- alternatives:
+  - Reuse `#214`.
+  - Reuse PR-only context without issue.
+- evidence:
+  - `gh issue view 214` shows legacy 502 incident scope.
+  - `gh issue list` had no exact issue for current rollback-gate behavior.
+
+## 2026-05-26 — D2
+- question: Should deploy fix preserve strict public outage detection while avoiding false rollback?
+- decision: Split checks into rollback-eligible runtime checks and non-rollback public check.
+- reasoning: Rollback should respond to artifact/runtime regressions, not DNS-path failures that do not imply bad deployed build.
+- alternatives:
+  - Keep current all-failure rollback.
+  - Add `--resolve` fallback.
+  - Remove external check.
+- evidence:
+  - `infra/deploy.sh` currently rolls back admin on any post-check failure.
+  - Prior context and PR history indicate `--resolve` fallback can hide real public failures.
+
+## 2026-05-27 — D3
+- question: After deploy-check fix passed, why did real E2E still fail on meta-agent create/describe?
+- decision: Backport missing runtime fixes from `fix/deploy-external-check` into ownership branch:
+  - admin route handler + 300s timeout path,
+  - nginx `/api/agents/create-via-meta` timeout route,
+  - markerless workspace fallback,
+  - validator/python3 alignment + test update,
+  - widget selector compatibility for standalone embed test.
+- reasoning: Production failures were not from deploy-check logic; they were from divergent code paths between main and previously validated branch where end-to-end flow was already fixed.
+- alternatives:
+  - Keep scope strictly deploy script/docs and ignore E2E failures.
+  - Patch only one symptom (e.g., nginx timeout) and retry repeatedly.
+- evidence:
+  - E2E logs showed T5/T6 500 and later T10b selector failures.
+  - `git show` comparison confirmed required files existed in `fix/deploy-external-check` but not on `origin/main`.
+  - Post-backport deploy + E2E produced `14 passed, 0 failed, 1 skipped`.

--- a/.tasks/228/design.md
+++ b/.tasks/228/design.md
@@ -1,0 +1,53 @@
+## Problem / Goal / Success Metric
+
+### Problem
+Deploy can rollback `webagent-admin` even when proxy/admin/openclaw are healthy if VM-side resolver chain cannot resolve `dev.lamoom.com` during final external check. This causes partial rollback and stale admin artifacts.
+
+### Goal
+Keep deploy gate strict for real public outages while preventing false rollback when runtime is healthy and failure is resolver-local.
+
+### Success Metric
+Merged fix is proven in production:
+1. Deploy completes without rollback for healthy runtime.
+2. `https://dev.lamoom.com/` and health endpoints are reachable via public path.
+3. Full MVP flow works post-deploy (meta-agent create -> embed token -> widget chat response).
+
+## Current State
+- `infra/deploy.sh` couples local runtime checks and external public-url check in one function (`run_post_deploy_checks`), and any failure triggers `rollback_admin_service`.
+- External check currently executes from inside remote VM deploy context over SSH, so VM-local resolver anomalies can trip deploy gate even when user path is fine.
+- Rollback logic restores admin artifact/unit only, which can create mixed-version runtime when trigger cause is DNS/network and not admin bundle quality.
+- CI deploy workflow (`.github/workflows/deploy.yml`) runs `bash infra/deploy.sh "$VM_HOST"`, so deploy gate behavior directly controls production rollout outcome.
+
+## Proposed Design
+1. Split post-deploy verification into two classes:
+   - **Runtime integrity checks (remote, rollback-eligible):** local health endpoints, static asset check, OpenClaw health from VM.
+   - **Public availability check (orchestrator-side, non-rollback):** curl `https://${DOMAIN}/` from machine executing `infra/deploy.sh` after remote deploy succeeds.
+2. Keep rollback only for runtime integrity failures (signals likely caused by newly deployed admin/proxy bits).
+3. If public availability check fails, return non-zero to fail deploy, but do not rollback admin artifacts.
+4. Improve operator diagnostics on public check failure so DNS/firewall/TLS issues are actionable.
+
+This preserves hard fail for real outages while removing false rollback path caused by VM-only resolver behavior.
+
+## Alternatives Considered
+1. Keep remote-only check and add `--resolve` fallback.
+   - Rejected: prior outage showed fallback can mask real public DNS breakage and produce false green.
+2. Disable external check entirely.
+   - Rejected: would remove critical signal for real public outages.
+3. Keep rollback on all failures but add DNS heuristics.
+   - Rejected: still couples unrelated failure domain (public DNS) to admin artifact rollback and risks stale bundle restore.
+
+## Risks & Open Questions
+- Risk: deploy can now fail after remote success due orchestrator network path issues.
+  - Mitigation: explicit diagnostic output; rerunnable deploy; no destructive rollback side effect.
+- Risk: operators may expect rollback on every failure.
+  - Mitigation: log clearly that public-check failures are non-rollback by design.
+- Open question: should we add optional second public vantage probe (for local manual deploys)?
+  - Decision: defer; current change addresses known VM-resolver failure mode with minimal blast radius.
+
+## Touched Surface
+- `infra/deploy.sh`
+- `.tasks/228/*` artifacts (design/plan/review/test/verify/state/worklog/decisions)
+
+## Out of Scope
+- Broad DNS infrastructure redesign.
+- Non-deploy admin/proxy feature changes.

--- a/.tasks/228/plan.md
+++ b/.tasks/228/plan.md
@@ -1,0 +1,27 @@
+## Approach Summary
+Decouple deploy verification domains. Keep remote runtime checks as rollback gate, then run public URL verification from deploy orchestrator context as non-rollback gate. This preserves strict outage detection without restoring stale admin artifacts for resolver-local failures.
+
+## Tradeoff: Speed vs Quality
+- chosen: balanced
+- rationale: change is infra-critical and small; need high confidence with real deploy/e2e verification, but no broad refactor.
+
+## Tasks
+| # | Title | Files | Depends on | Parallel group | Suggested model |
+|---|-------|-------|------------|----------------|-----------------|
+| 1 | Split deploy checks and rollback gate | `infra/deploy.sh` | - | A | gpt-5.1-codex |
+| 2 | Update deploy docs for new check semantics | `docs/deployment.md` | - | A | haiku |
+| 3 | Run runtime verification (deploy + E2E) and capture artifacts | `.tasks/228/test-report.md`, `.tasks/228/verify.md` | 1,2 | B | sonnet |
+
+## Parallel Groups
+- **A** (independent): 1, 2
+- **B**: 3 after A
+
+## Done Criteria
+- Task 1: `infra/deploy.sh` runs remote rollback only on runtime-integrity failures; public URL check runs outside remote rollback path; script passes `bash -n infra/deploy.sh`.
+- Task 2: `docs/deployment.md` explicitly documents rollback boundary and public-check location.
+- Task 3: Real deploy run + full E2E test evidence captured with explicit pass/fail and final prod verdict.
+
+## Rollback Plan
+1. Revert `infra/deploy.sh` + docs commit.
+2. Redeploy from known-good commit using `bash infra/deploy.sh`.
+3. Confirm `webagent-admin`, `webagent-proxy`, and `openclaw` health endpoints return expected status.

--- a/.tasks/228/review.md
+++ b/.tasks/228/review.md
@@ -1,2 +1,2 @@
 No findings.
-VERDICT: pass
+FINAL: ship

--- a/.tasks/228/review.md
+++ b/.tasks/228/review.md
@@ -1,0 +1,2 @@
+No findings.
+VERDICT: pass

--- a/.tasks/228/test-plan.md
+++ b/.tasks/228/test-plan.md
@@ -1,0 +1,19 @@
+## Modality
+Infra integration test with real deployment + real protocol E2E script.
+
+## Setup
+1. Ensure branch contains `infra/deploy.sh` + docs update.
+2. Run deployment to target VM: `bash infra/deploy.sh 78.47.152.177`.
+3. Load auth secret from VM `.env` for E2E protocol run.
+
+## Steps
+1. Execute deploy script from local checkout.
+   - expected: deploy completes without triggering rollback block.
+2. Verify public and local health checks.
+   - expected: `https://dev.lamoom.com/` returns non-5xx, `/health` endpoints pass.
+3. Run full E2E protocol test:
+   - `bash .agents/skills/test-lamoom/scripts/test-e2e-full.sh https://dev.lamoom.com <AUTH_SECRET>`
+   - expected: end-to-end flow passes (meta-agent create, embed token, widget chat).
+
+## Pass criterion
+Success metric in `design.md` is met with runtime evidence and `RESULT: pass` in test report.

--- a/.tasks/228/test-report.md
+++ b/.tasks/228/test-report.md
@@ -1,0 +1,163 @@
+## Setup
+
+- Task: 228, Phase 5c
+- Branch workspace: `/home/azureuser/workspace/webagent`
+- Inputs read before execution:
+  - `.tasks/228/design.md`
+  - `.tasks/228/test-plan.md`
+
+## Previous Run (for context)
+
+- Raw log: `/tmp/opencode/task228-phase5c-step1-deploy.log`
+- Result: failed at deploy public check (`https://dev.lamoom.com/`) with self-signed TLS certificate.
+
+## Fresh Run (after `infra/config.env` sourcing fix)
+
+### Step 1 - Deploy with canonical path
+Command:
+
+```bash
+bash infra/deploy.sh 78.47.152.177
+```
+
+Status: **PASS**
+
+Raw log:
+- `/tmp/opencode/task228-phase5c-rerun-step1-deploy.log`
+
+Evidence snippets (exact output):
+
+```text
+✅ Remote deploy finished
+→ Public availability check (https://webagent-dev.duckdns.org/)...
+✓ Public root URL returned 200
+── Deploy complete ──
+```
+
+Additional notable deploy output:
+
+```text
+runtime agent merge skipped: Expecting value: line 2 column 7 (char 32)
+Failed to restart openclaw-gateway.service: Unit openclaw-gateway.service not found.
+```
+
+### Step 2 - Fetch auth secret from VM `.env`
+Status: **PASS**
+
+Method:
+- Read from VM `/opt/webagent/.env`
+- Preference order: `PROXY_INTERNAL_SECRET`, fallback `PROXY_API_TOKEN`
+
+Raw log:
+- `/tmp/opencode/task228-phase5c-rerun-step2-secret.log`
+
+Evidence snippet:
+
+```text
+OK|PROXY_INTERNAL_SECRET|REDACTED|length=64
+```
+
+Secret handling:
+- Secret value was used only as runtime input for Step 3 and is redacted in this report.
+
+### Step 3 - Full E2E protocol
+Command:
+
+```bash
+bash .agents/skills/test-lamoom/scripts/test-e2e-full.sh https://dev.lamoom.com "$AUTH_SECRET"
+```
+
+Status: **FAIL**
+
+Raw log:
+- `/tmp/opencode/task228-phase5c-rerun-step3-e2e.log`
+
+Evidence snippets (exact output):
+
+```text
+═══ Phase 1: Infrastructure Health ═══
+✓ PASS: T1: GET /health → 200, status=ok
+✓ PASS: T2: GET /health/openclaw → 200, status=ok
+✓ PASS: T3: GET /widget.js → 200, 13068 bytes of JS
+```
+
+```text
+═══ Phase 2: Agent Creation via Meta-Agent ═══
+✗ FAIL: T5: Meta-agent describe — expected 200, got 500
+    Body: Internal Server Error
+✗ FAIL: T6: Meta-agent create — expected 200, got 500
+    Body: Internal Server Error
+```
+
+```text
+E2E Results: 8 passed, 2 failed, 5 skipped
+```
+
+## Failures and Likely Root Cause
+
+- Final blocking failure occurred in Step 3 (E2E) during meta-agent describe/create API paths.
+- Exact failure: HTTP 500 `Internal Server Error` on T5 and T6.
+- Likely root cause: runtime issue in the meta-agent creation pipeline (OpenClaw/gateway/proxy integration path) rather than basic service reachability, because:
+  - health endpoints and widget asset checks passed,
+  - initial meta-agent greeting passed,
+  - only deeper describe/create operations failed with server-side 500,
+  - deploy logs still show related runtime warnings (`runtime agent merge skipped ...` and missing `openclaw-gateway.service` unit).
+
+## Final Verdict
+
+RESULT: fail (deploy now succeeds, but full E2E fails: meta-agent describe/create return HTTP 500 Internal Server Error)
+
+---
+
+## Fresh Verification Loop - 2026-05-27
+
+### Step 1 - Deploy with canonical path
+Command:
+
+```bash
+bash infra/deploy.sh 78.47.152.177
+```
+
+Status: **PASS**
+
+Evidence snippets:
+
+```text
+✅ Remote deploy finished
+→ Public availability check (https://webagent-dev.duckdns.org/)...
+✓ Public root URL returned 200
+── Deploy complete ──
+```
+
+### Step 2 - Fetch auth secret from VM `.env`
+Status: **PASS**
+
+Method:
+- Read from `/opt/webagent/.env`
+- Preference order: `PROXY_INTERNAL_SECRET`, fallback `PROXY_API_TOKEN`
+- Value redacted in this report
+
+### Step 3 - Full E2E protocol
+Command:
+
+```bash
+bash .agents/skills/test-lamoom/scripts/test-e2e-full.sh https://dev.lamoom.com "$AUTH_SECRET"
+```
+
+Status: **PASS**
+
+Evidence snippets:
+
+```text
+✓ PASS: T6: Meta-agent create → agent=vibebrowser-app-64e978e1, embedToken=59420f91-926…
+✓ PASS: T10: WS chat → 455-char response from created agent
+✓ PASS: T10b: Standalone widget embed → copy-paste flow works
+```
+
+```text
+E2E Results: 14 passed, 0 failed, 1 skipped
+```
+
+## Final Verdict (Updated)
+
+RESULT: pass

--- a/.tasks/228/verify.md
+++ b/.tasks/228/verify.md
@@ -1,0 +1,24 @@
+## Post-Merge Production Verification Plan
+
+PR for task 228 not merged yet. Post-merge verification will run immediately after merge.
+
+## Target Success Metric Checks
+
+1. Deploy completes with no rollback path triggered for healthy runtime.
+2. Public URL checks pass from real path (`https://webagent-dev.duckdns.org/` and `https://dev.lamoom.com/` as configured flows).
+3. Full MVP E2E path passes (meta-agent create -> embed code -> widget chat).
+
+## Pre-Merge Runtime Evidence (for reference)
+
+- `infra/deploy.sh` run finished with:
+  - `✅ Remote deploy finished`
+  - `✓ Public root URL returned 200`
+- Full E2E protocol run on production endpoint:
+  - `14 passed, 0 failed, 1 skipped`
+
+## Pending
+
+- Await merge to `main`.
+- After merge: rerun production verification and append final verdict.
+
+PROD: pending (awaiting merge)

--- a/.tasks/228/worklog.md
+++ b/.tasks/228/worklog.md
@@ -1,0 +1,5 @@
+- Cycle 1: Claimed issue ownership by creating #228, corrected issue body/labels, captured phase-1/2/3 artifacts, and selected deploy-check split design (runtime rollback checks vs public non-rollback check).
+- Cycle 2: Completed plan group A via subagents: refactored `infra/deploy.sh` to rollback only on remote runtime-integrity failures and moved public URL check to orchestrator context (fail-only, no rollback), then documented boundary in `docs/deployment.md`.
+- Cycle 3: Ran fresh-eye implementation review (Phase 5b); reviewer produced `.tasks/228/review.md` with `VERDICT: pass` and no findings.
+- Cycle 4: Ran real Phase 5c test loop; first rerun fixed deploy gate (`webagent-dev.duckdns.org` 200) but full E2E still failed (`/api/agents/create-via-meta` returns 500 on T5/T6), so task remains in implement loop.
+- Cycle 5: Diagnosed production mismatch (main missing route-handler/timeout + validator updates), backported required commits to ownership branch, applied widget selector compatibility fix, redeployed to VM, and reached full real E2E pass (14 passed, 0 failed, 1 skipped).

--- a/.tasks/228/worklog.md
+++ b/.tasks/228/worklog.md
@@ -3,3 +3,4 @@
 - Cycle 3: Ran fresh-eye implementation review (Phase 5b); reviewer produced `.tasks/228/review.md` with `VERDICT: pass` and no findings.
 - Cycle 4: Ran real Phase 5c test loop; first rerun fixed deploy gate (`webagent-dev.duckdns.org` 200) but full E2E still failed (`/api/agents/create-via-meta` returns 500 on T5/T6), so task remains in implement loop.
 - Cycle 5: Diagnosed production mismatch (main missing route-handler/timeout + validator updates), backported required commits to ownership branch, applied widget selector compatibility fix, redeployed to VM, and reached full real E2E pass (14 passed, 0 failed, 1 skipped).
+- Cycle 6: Opened PR #229, watched CI to green, ran final independent PR review (`FINAL: ship`), and confirmed branch protection exists on `main` before merge ask.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -147,6 +147,13 @@ To retarget the workflow to a different VM, update the `VM_HOST` secret in the r
 DOMAIN=myapp.example.com REPO_URL=git@github.com:OpenCodeEngineer/webagent.git bash /path/to/infra/setup.sh
 ```
 
+### Deploy checks and rollback boundary
+
+- `infra/deploy.sh` runs runtime integrity checks on the VM (local health endpoints, static asset check, OpenClaw health).
+- These VM runtime checks are rollback-eligible: if they fail, admin rollback is attempted on the VM.
+- Public availability is then checked from the deploy orchestrator context (`https://${DOMAIN}/`), not from inside the VM.
+- If the public check fails, the deploy exits non-zero, but it does **not** trigger admin rollback.
+
 ### Service ownership
 
 - OpenClaw gateway unit (`openclaw-gateway.service`) is installed/owned by OpenClaw runtime tooling as a user-level systemd service.

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -4,13 +4,16 @@ set -euo pipefail
 # Deploy current LOCAL repo state to the Lamoom VM (not git-pull based).
 # Usage: ./infra/deploy.sh [host]
 
+SCRIPT_DIR_EARLY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=infra/config.env
+[ -f "${SCRIPT_DIR_EARLY}/config.env" ] && source "${SCRIPT_DIR_EARLY}/config.env"
+
 HOST="${1:-${DEPLOY_HOST:-78.47.152.177}}"
 DEPLOY_USER="${DEPLOY_USER:-root}"
 APP_DIR="${APP_DIR:-/opt/webagent}"
 APP_USER="${APP_USER:-openclaw}"
 DOMAIN="${DOMAIN:-dev.lamoom.com}"
 NGINX_SITE_PATH="${NGINX_SITE_PATH:-/etc/nginx/sites-enabled/openclaw}"
-DOMAIN="${DOMAIN:-dev.lamoom.com}"
 SYNC_DELETE="${SYNC_DELETE:-1}"
 REMOTE="${DEPLOY_USER}@${HOST}"
 SSH_OPTS=(
@@ -20,7 +23,7 @@ SSH_OPTS=(
 )
 RUNTIME_CONFIG_BACKUP="/tmp/webagent-openclaw-runtime.json5"
 ROLLBACK_BASE_DIR="/tmp/webagent-admin-rollback"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="${SCRIPT_DIR_EARLY}"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 run_rsync() {
@@ -302,10 +305,7 @@ rollback_admin_service() {
   systemctl restart webagent-admin
 }
 
-run_post_deploy_checks() {
-  local external_status=""
-  local external_url="https://${DOMAIN}/"
-
+run_runtime_integrity_checks() {
   echo "→ Health checks..."
   curl -sf http://127.0.0.1:3001/health >/dev/null
   curl -sf http://127.0.0.1:3000/ >/dev/null
@@ -326,24 +326,11 @@ run_post_deploy_checks() {
     echo "❌ OpenClaw health failed"
     return 1
   fi
-
-  echo "→ External availability check (${external_url})..."
-  external_status="$(curl -sS -L -o /dev/null -w '%{http_code}' --max-time 20 "${external_url}" || true)"
-  if [[ -z "${external_status}" || "${external_status}" == "000" ]]; then
-    echo "❌ External root URL check failed: no HTTP response"
-    return 1
-  fi
-  if [[ "${external_status}" =~ ^5 ]]; then
-    echo "❌ External root URL returned ${external_status}"
-    return 1
-  fi
-
-  echo "✓ External root URL returned ${external_status}"
   return 0
 }
 
-if ! run_post_deploy_checks; then
-  echo "❌ Post-deploy validation failed"
+if ! run_runtime_integrity_checks; then
+  echo "❌ Runtime integrity checks failed"
   rollback_admin_service || true
 
   if curl -sf http://127.0.0.1:3000/ >/dev/null; then
@@ -357,5 +344,21 @@ fi
 
 echo "✅ Remote deploy finished"
 REMOTE
+
+external_url="https://${DOMAIN}/"
+echo "→ Public availability check (${external_url})..."
+external_status="$(curl -sS -L -o /dev/null -w '%{http_code}' --max-time 20 "${external_url}" || true)"
+
+if [[ -z "${external_status}" || "${external_status}" == "000" ]]; then
+  echo "❌ Public root URL check failed: no HTTP response"
+  exit 1
+fi
+
+if [[ "${external_status}" =~ ^5 ]]; then
+  echo "❌ Public root URL returned ${external_status}"
+  exit 1
+fi
+
+echo "✓ Public root URL returned ${external_status}"
 
 echo "── Deploy complete ──"

--- a/infra/nginx/webagent.conf
+++ b/infra/nginx/webagent.conf
@@ -48,6 +48,12 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    location = /api/agents/create-via-meta {
+        proxy_pass         http://admin_upstream;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+    }
+
     location / { proxy_pass http://admin_upstream; }
 }
 
@@ -87,6 +93,12 @@ server {
         expires 365d;
         access_log off;
         add_header Cache-Control "public, immutable";
+    }
+
+    location = /api/agents/create-via-meta {
+        proxy_pass         http://admin_upstream;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
     }
 
     location / { proxy_pass http://admin_upstream; }

--- a/openclaw/workspaces/meta/skills/create-agent/SKILL.md
+++ b/openclaw/workspaces/meta/skills/create-agent/SKILL.md
@@ -17,7 +17,7 @@ Creates a fully configured customer agent after Phase 1 discovery.
 - **CRITICAL: NEVER write literal `{{placeholder}}` syntax in generated files. All template variables MUST be replaced with actual values discovered during research. After writing all files, re-read each one and verify no `{{` sequences remain.**
 - **MANDATORY MARKERS — validator-enforced, non-negotiable:**
   - `AGENTS.md` MUST contain the literal heading text `Workflow-as-Code` and the literal string `workflows/`. The proxy greps for these exact strings and force-retries on miss — do not rephrase, summarize, or omit.
-  - `skills/website-api/SKILL.md` (when written) MUST contain `workflows/` AND `python3`.
+  - `skills/website-api/SKILL.md` (when written) MUST contain `workflows/`.
   - Copy the full **"Workflow-as-Code (Required for Actions)"** section verbatim from the template — do not LLM-rewrite it. Same for the "Workflow-first" rule line in the numbered Important Rules list. These survive generation only if you copy them literally.
 
 ## Inputs you must carry from discovery

--- a/openclaw/workspaces/meta/skills/create-agent/SKILL.md
+++ b/openclaw/workspaces/meta/skills/create-agent/SKILL.md
@@ -157,9 +157,17 @@ After writing all workspace files, **re-read every `.md` file** in `<workspacePa
 
 If any unresolved placeholders are found, fix them immediately before proceeding to Step 4. The proxy runs server-side validation and will **reject the agent** if placeholders remain, returning `[AGENT_VALIDATION_FAILED::<slug>::<errors>]` — requiring a full retry.
 
-### Step 4 — Signal completion to proxy
+### Step 4 — Signal completion to proxy (MANDATORY — do not skip)
 
-Include the exact marker `[AGENT_CREATED::<agentSlug>]` in your response message. The proxy will:
+**CRITICAL: You MUST include `[AGENT_CREATED::<agentSlug>]` verbatim in your response text. This is the ONLY way the proxy registers the agent, generates the embed token, and returns the embed code to the customer. Omitting this marker means the agent will NOT be registered and the customer gets no embed code. There are no exceptions.**
+
+Include the exact marker in your response message like this (replace `<agentSlug>` with the actual slug you used):
+
+```
+[AGENT_CREATED::my-company-abc12345]
+```
+
+The proxy will then:
 1. Read `agent-config.json` from the workspace
 2. Create DB records (agent + embed token)
 3. Register the agent in OpenClaw gateway config
@@ -170,6 +178,12 @@ Tell the customer: "Your agent has been created! The embed code will appear belo
 Also include discovered onboarding/install links in the response when available.
 
 **Do NOT** attempt to edit `openclaw.json` or `openclaw.json5` — the proxy handles registration automatically.
+
+**FINAL CHECKLIST before sending your response:**
+- [ ] All workspace files written (AGENTS.md, SOUL.md, IDENTITY.md, TOOLS.md, USER.md, skills/, knowledgebase/, workflows/)
+- [ ] `agent-config.json` written at `<workspacePath>/agent-config.json`
+- [ ] No `{{placeholder}}` patterns remain in any file
+- [ ] `[AGENT_CREATED::<agentSlug>]` marker IS present in your response text
 
 ## Post-Creation Validation Rules
 

--- a/packages/admin/next.config.ts
+++ b/packages/admin/next.config.ts
@@ -7,10 +7,6 @@ const nextConfig: NextConfig = {
   async rewrites() {
     return [
       {
-        source: "/api/agents/create-via-meta",
-        destination: `${proxyUrl}/api/agents/create-via-meta`,
-      },
-      {
         source: "/api/agents/:path*",
         destination: `${proxyUrl}/api/agents/:path*`,
       },

--- a/packages/admin/src/app/api/agents/create-via-meta/route.ts
+++ b/packages/admin/src/app/api/agents/create-via-meta/route.ts
@@ -1,0 +1,38 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+const PROXY_URL =
+  process.env.PROXY_URL ??
+  `http://127.0.0.1:${process.env.PROXY_PORT ?? "3001"}`;
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const body = await request.text();
+
+  const headers = new Headers();
+  headers.set("Content-Type", "application/json");
+
+  const xCustomerId = request.headers.get("x-customer-id");
+  const xCustomerSig = request.headers.get("x-customer-sig");
+  if (xCustomerId) headers.set("x-customer-id", xCustomerId);
+  if (xCustomerSig) headers.set("x-customer-sig", xCustomerSig);
+
+  let response: Response;
+  try {
+    response = await fetch(`${PROXY_URL}/api/agents/create-via-meta`, {
+      method: "POST",
+      headers,
+      body,
+      signal: AbortSignal.timeout(300_000),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Proxy unreachable";
+    return NextResponse.json({ error: { code: "proxy_error", message } }, { status: 502 });
+  }
+
+  const responseBody = await response.text();
+  return new NextResponse(responseBody, {
+    status: response.status,
+    headers: {
+      "Content-Type": response.headers.get("Content-Type") ?? "application/json",
+    },
+  });
+}

--- a/packages/proxy/src/openclaw/validate-workspace.test.ts
+++ b/packages/proxy/src/openclaw/validate-workspace.test.ts
@@ -153,12 +153,6 @@ describe('validateGeneratedWorkspace', () => {
       ),
       `expected workflows/ marker error in skill, got: ${result.errors.join('; ')}`,
     );
-    assert.ok(
-      result.errors.some((e) =>
-        e.includes('skills/website-api/SKILL.md') && e.includes('python3'),
-      ),
-      `expected python3 marker error in skill, got: ${result.errors.join('; ')}`,
-    );
   });
 
   it('detects {{PLACEHOLDER}} in .json files', async () => {

--- a/packages/proxy/src/openclaw/workspace-validator.ts
+++ b/packages/proxy/src/openclaw/workspace-validator.ts
@@ -25,7 +25,6 @@ const REQUIRED_AGENTS_MD_MARKERS = [
  */
 const REQUIRED_WEBSITE_API_MARKERS = [
   'workflows/',
-  'python3',
 ] as const;
 
 /**

--- a/packages/proxy/src/routes/api.ts
+++ b/packages/proxy/src/routes/api.ts
@@ -1,6 +1,6 @@
 import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, rmdir, stat } from 'fs/promises';
+import { mkdir, readFile, readdir, rmdir, stat } from 'fs/promises';
 import { join } from 'path';
 import { homedir } from 'node:os';
 import { execFile } from 'node:child_process';
@@ -498,11 +498,51 @@ export async function detectAgentCreation(
   | null
 > {
   const markerMatch = responseText.match(/\[AGENT_CREATED::\s*<?([a-z0-9_-]+)>?\s*\]/i);
-  if (!markerMatch?.[1]) return null;
 
-  const slug = markerMatch[1];
   const configuredWorkspacesDir = process.env.OPENCLAW_WORKSPACES_DIR?.trim();
   const primaryWorkspacesDir = configuredWorkspacesDir || join(process.cwd(), 'openclaw', 'workspaces');
+
+  let slug: string;
+  if (markerMatch?.[1]) {
+    slug = markerMatch[1];
+  } else {
+    // Fallback: if the LLM omitted the marker, scan for a workspace created in the
+    // last 5 minutes whose slug ends with this customer's first-8-char suffix.
+    const customerSuffix = customerId.replace(/-/g, '').slice(0, 8).toLowerCase();
+    const fiveMinutesAgo = Date.now() - 5 * 60 * 1000;
+    const scanDirs = [primaryWorkspacesDir];
+    if (!configuredWorkspacesDir) {
+      scanDirs.push(join(process.cwd(), '..', '..', 'openclaw', 'workspaces'));
+    }
+    let fallbackSlug: string | null = null;
+    outer: for (const wsDir of scanDirs) {
+      let entries: string[];
+      try {
+        entries = await readdir(wsDir);
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        if (!entry.endsWith(customerSuffix)) continue;
+        try {
+          const raw = await readFile(join(wsDir, entry, 'agent-config.json'), 'utf8');
+          const parsed = JSON.parse(raw) as { createdAt?: string };
+          if (parsed.createdAt && new Date(parsed.createdAt).getTime() >= fiveMinutesAgo) {
+            fallbackSlug = entry;
+            break outer;
+          }
+        } catch {
+          // not a valid config, skip
+        }
+      }
+    }
+    if (!fallbackSlug) return null;
+    app.log.warn(
+      { customerId, fallbackSlug },
+      'detectAgentCreation: no [AGENT_CREATED::] marker in response; recovered via recent workspace scan',
+    );
+    slug = fallbackSlug;
+  }
   const configPaths = [join(primaryWorkspacesDir, slug, 'agent-config.json')];
   if (!configuredWorkspacesDir) {
     const fallbackWorkspacesDir = join(process.cwd(), '..', '..', 'openclaw', 'workspaces');

--- a/packages/proxy/src/routes/api.ts
+++ b/packages/proxy/src/routes/api.ts
@@ -514,8 +514,8 @@ export async function detectAgentCreation(
     if (!configuredWorkspacesDir) {
       scanDirs.push(join(process.cwd(), '..', '..', 'openclaw', 'workspaces'));
     }
-    let fallbackSlug: string | null = null;
-    outer: for (const wsDir of scanDirs) {
+    const candidateCreatedAtBySlug = new Map<string, number>();
+    for (const wsDir of scanDirs) {
       let entries: string[];
       try {
         entries = await readdir(wsDir);
@@ -526,19 +526,51 @@ export async function detectAgentCreation(
         if (!entry.endsWith(customerSuffix)) continue;
         try {
           const raw = await readFile(join(wsDir, entry, 'agent-config.json'), 'utf8');
-          const parsed = JSON.parse(raw) as { createdAt?: string };
-          if (parsed.createdAt && new Date(parsed.createdAt).getTime() >= fiveMinutesAgo) {
-            fallbackSlug = entry;
-            break outer;
+          const parsed = JSON.parse(raw) as { createdAt?: string; agentSlug?: string };
+          const createdAtMs = parsed.createdAt ? new Date(parsed.createdAt).getTime() : Number.NaN;
+          if (!Number.isFinite(createdAtMs) || createdAtMs < fiveMinutesAgo) {
+            continue;
+          }
+          if (typeof parsed.agentSlug === 'string' && parsed.agentSlug.trim().length > 0) {
+            if (parsed.agentSlug.trim() !== entry) {
+              continue;
+            }
+          }
+          const existingCreatedAt = candidateCreatedAtBySlug.get(entry);
+          if (existingCreatedAt === undefined || createdAtMs > existingCreatedAt) {
+            candidateCreatedAtBySlug.set(entry, createdAtMs);
           }
         } catch {
           // not a valid config, skip
         }
       }
     }
+
+    let fallbackSlug: string | null = null;
+    let fallbackCreatedAt = Number.NEGATIVE_INFINITY;
+    for (const [candidateSlug, candidateCreatedAt] of candidateCreatedAtBySlug) {
+      if (
+        candidateCreatedAt > fallbackCreatedAt
+        || (
+          candidateCreatedAt === fallbackCreatedAt
+          && fallbackSlug !== null
+          && candidateSlug.localeCompare(fallbackSlug) < 0
+        )
+        || fallbackSlug === null
+      ) {
+        fallbackSlug = candidateSlug;
+        fallbackCreatedAt = candidateCreatedAt;
+      }
+    }
+
     if (!fallbackSlug) return null;
     app.log.warn(
-      { customerId, fallbackSlug },
+      {
+        customerId,
+        fallbackSlug,
+        fallbackCreatedAt: new Date(fallbackCreatedAt).toISOString(),
+        candidateCount: candidateCreatedAtBySlug.size,
+      },
       'detectAgentCreation: no [AGENT_CREATED::] marker in response; recovered via recent workspace scan',
     );
     slug = fallbackSlug;

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -82,6 +82,7 @@ class WebAgentWidget {
     }
 
     this.host = document.createElement('div');
+    this.host.className = 'lamoom-root-host';
     this.host.setAttribute('data-webagent-widget', 'true');
     this.shadowRootNode = this.host.attachShadow({ mode: 'open' });
     this.shadowRootNode.innerHTML = this.template();
@@ -584,10 +585,10 @@ class WebAgentWidget {
         const rendered = renderMarkdownToSafeHtml(message.content);
 
         if (message.role === 'visitor' && message.failed) {
-          return `<div class="wa-message wa-visitor"><button type="button" class="wa-msg wa-failed" data-retry-id="${message.id}" aria-label="Retry sending message">${rendered}<span class="wa-failed-note">Failed to send. Click to retry.</span></button></div>`;
+          return `<div class="wa-message wa-visitor lamoom-message lamoom-user"><button type="button" class="wa-msg wa-failed" data-retry-id="${message.id}" aria-label="Retry sending message">${rendered}<span class="wa-failed-note">Failed to send. Click to retry.</span></button></div>`;
         }
 
-        return `<div class="wa-message ${message.role === 'visitor' ? 'wa-visitor' : 'wa-agent'}"><div class="wa-msg">${rendered}</div></div>`;
+        return `<div class="wa-message ${message.role === 'visitor' ? 'wa-visitor lamoom-user' : 'wa-agent lamoom-assistant'} lamoom-message"><div class="wa-msg">${rendered}</div></div>`;
       })
       .join('');
 
@@ -737,7 +738,6 @@ class WebAgentWidget {
           color: #92400e;
           background: #fef3c7;
         }
-2m+
         .wa-banner[data-kind='error'] {
           color: #991b1b;
           background: #fee2e2;
@@ -1021,7 +1021,7 @@ class WebAgentWidget {
       </style>
 
       <div class="wa-root">
-        <button class="wa-bubble" type="button" aria-label="Toggle chat" aria-expanded="false">
+        <button class="wa-bubble lamoom-bubble" type="button" aria-label="Toggle chat" aria-expanded="false">
           <span aria-hidden="true">💬</span>
           <span class="wa-badge" data-visible="false" aria-label="Unread messages">0</span>
         </button>
@@ -1040,8 +1040,8 @@ class WebAgentWidget {
           </div>
           <form class="wa-form">
             <label for="${inputId}" class="wa-sr-only">Message input</label>
-            <textarea id="${inputId}" class="wa-input" rows="2" aria-label="Type message"></textarea>
-            <button class="wa-send" type="submit" aria-label="Send message">Send</button>
+            <textarea id="${inputId}" class="wa-input lamoom-textarea" rows="2" aria-label="Type message"></textarea>
+            <button class="wa-send lamoom-send" type="submit" aria-label="Send message">Send</button>
           </form>
           <div class="wa-footer">
             <a href="https://github.com/OpenCodeEngineer/webagent" target="_blank" rel="noopener noreferrer">Powered by WebAgent</a>


### PR DESCRIPTION
## Summary
- split deploy verification in `infra/deploy.sh` so runtime-integrity failures trigger rollback, while public URL failures fail deploy without restoring stale admin artifacts
- restored stable create-via-meta path by routing `/api/agents/create-via-meta` through a Next.js route handler with a 300s timeout and nginx timeout support
- hardened markerless agent creation fallback selection and aligned workspace validator/skill expectations; restored widget selector compatibility used by real standalone embed flow

## Closes
Closes #228

## Test plan
- [x] `pnpm --filter @webagent/proxy test`
- [x] `pnpm --filter @webagent/widget build`
- [x] `pnpm --filter @webagent/admin build`
- [x] `bash infra/deploy.sh 78.47.152.177`
- [x] `bash .agents/skills/test-lamoom/scripts/test-e2e-full.sh https://dev.lamoom.com \"$AUTH_SECRET\"` (14 passed, 0 failed, 1 skipped)

## Notes
- design: `.tasks/228/design.md`
- plan: `.tasks/228/plan.md`
- review: `.tasks/228/review.md`
- tests: `.tasks/228/test-report.md`
- verify: `.tasks/228/verify.md`